### PR TITLE
Kalendár: 3 najbližšie dni s udalosťami + emoji picker (issues 439, 440)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1353,3 +1353,30 @@ paths:
   selector components (a parent-scoped class, or `.class[type="..."]`),
   never a bare single class, or it silently inherits the global
   `width:100%`/border/padding/background reset instead of its own CSS.
+- **Pridanie novej VIDITEĽNEJ záložky do `nav.ts` rozbije PEVNÉ počty na
+  TROCH miestach naraz — nielen jednotkový `nav.test.ts`, ale aj E2E
+  `nav.spec.ts`, ktorý má DVE tvrdenia `page.locator(".side-nav .tab")
+  .toHaveCount(N)`** (jedno v rozbalenom menu, druhé v zbalenej lište).
+  Issue 437 (nová záložka „Poznámky"): pridanie do priečinka „Dôležité"
+  posunulo `nav.test.ts`'s `NAV[0].tabs.toHaveLength(2)` → 3 aj
+  `NAV[0].tabs.map(label)` zoznam, A `nav.spec.ts`'s OBA `.toHaveCount(19)`
+  → 20 (+ vhodné pridať `getByRole("button",{name:"<label>"}).toBeVisible()`
+  k výpočtu záložiek). **Pasca overovania: lokálny beh LEN nového spec
+  súboru (`playwright test poznamky.spec.ts`) tieto count-strážcov v
+  `nav.spec.ts` NEODhalí** — prešiel zeleno, no CI (celý balík) zhodil
+  `nav.spec.ts` na `Expected 19, Received 20`. Pri KAŽDEJ novej/odobranej
+  `nav.ts` záložke: `grep -n 'toHaveCount\|toHaveLength\|dvadsať\|devätnásť'
+  apps/web/tests/e2e/nav.spec.ts apps/web/src/nav.test.ts` a spusti lokálne
+  AJ `nav.spec.ts` (nielen svoj nový spec), inak to chytí až CI. (Meno novej
+  záložky navyše kontroluj na substring-kolíziu podľa vzoru issue 240 vyššie.)
+- **Rastrové ikony (PWA `icon-192/512.png`, apod.) sa dajú vygenerovať z
+  brand SVG cez Playwright chromium, keď na boxe NIE JE `rsvg-convert`/
+  ImageMagick `convert`/`sharp`** (issue 437, PWA ikony z favicon značky
+  #430). Vzor: `createRequire(".../apps/web/")` → `require("@playwright/
+  test").chromium` (pnpm store cesta, nie priamy `import`), `page.setContent`
+  s inline SVG (vrátane emoji 🌲 — chromium na `forestshop-dev` má emoji font,
+  vykreslí ho farebne), `page.setViewportSize({width:px,height:px})`,
+  `page.locator("svg").screenshot()`. Over výsledok VIZUÁLNE (Read na PNG) —
+  ak by chýbal emoji font, dostal by si prázdny farebný štvorec, nie strom.
+  Rovnaká chromium závislosť ako e2e (`.claude/rules/local-dev.md`'s
+  libnspr4 knižnice).

--- a/apps/api/src/modules/calendar/constants.ts
+++ b/apps/api/src/modules/calendar/constants.ts
@@ -17,8 +17,10 @@ export const NEXT_EVENT_ERROR_CACHE_TTL_MS = 2 * 60 * 1000;
  * zachytenie ročne sa opakujúcej udalosti (napr. narodeniny), no konečné. */
 export const RECURRENCE_EXPANSION_WINDOW_DAYS = 400;
 
-/** issue 382: majiteľ chce vidieť TRI najbližšie udalosti, nie jednu. */
-export const NEXT_EVENTS_LIMIT = 3;
+/** issue 382 → 439: majiteľ chce vidieť TRI najbližšie DNI, v ktorých je aspoň
+ * jedna udalosť (a v každom také dni VŠETKY jeho udalosti) — nie tri najbližšie
+ * udalosti. Konštanta preto počíta DNI, nie udalosti. */
+export const NEXT_EVENT_DAYS_LIMIT = 3;
 
 /** Strop veľkosti stiahnutého ICS tela — osobný kalendár je rádovo KB až
  * jednotky MB; 10 MB je veľkorysá, no konečná hranica proti

--- a/apps/api/src/modules/calendar/next-event.test.ts
+++ b/apps/api/src/modules/calendar/next-event.test.ts
@@ -211,7 +211,101 @@ describe("resolveNextEvents — viacero VEVENT typov naraz", () => {
   });
 });
 
-// issue 382: majiteľ chce vidieť TRI najbližšie udalosti, nie jednu.
+// issue 439: majiteľ chce 3 najbližšie DNI, v ktorých je nejaká udalosť, a v
+// každom dni VŠETKY jeho udalosti — `limit` (teraz `dayLimit`) počíta DNI, nie
+// udalosti. Dni bez udalosti sa preskakujú a nepočítajú sa do troch.
+describe("resolveNextEvents — zoskupenie po dňoch (issue 439)", () => {
+  function evt(uid: string, summary: string, startLocal: string, endLocal: string): readonly string[] {
+    return [
+      "BEGIN:VEVENT",
+      `UID:${uid}@test`,
+      "DTSTAMP:20260101T000000Z",
+      `SUMMARY:${summary}`,
+      `DTSTART;TZID=Europe/Bratislava:${startLocal}`,
+      `DTEND;TZID=Europe/Bratislava:${endLocal}`,
+      "END:VEVENT",
+    ];
+  }
+
+  it("viac udalostí v JEDEN deň sa vráti VŠETKY (jeden deň = jeden slot), zoradené v rámci dňa", () => {
+    const text = ics([
+      ...evt("a", "Deň1 skoro", "20260810T090000", "20260810T100000"),
+      ...evt("b", "Deň1 neskôr", "20260810T140000", "20260810T150000"),
+      ...evt("c", "Deň2", "20260811T090000", "20260811T100000"),
+    ]);
+    const result = resolveNextEvents(text, NOW, 3);
+    expect(result.map((e) => e.title)).toEqual(["Deň1 skoro", "Deň1 neskôr", "Deň2"]);
+    expect(result.map((e) => e.dateLabel)).toEqual(["pondelok 10. 8.", "pondelok 10. 8.", "utorok 11. 8."]);
+  });
+
+  it("dayLimit počíta DNI, nie udalosti — 4 dni po 1 udalosti, dayLimit 3 → len prvé 3 dni", () => {
+    const text = ics([
+      ...evt("d1", "Deň 9", "20260809T090000", "20260809T100000"),
+      ...evt("d2", "Deň 10", "20260810T090000", "20260810T100000"),
+      ...evt("d3", "Deň 11", "20260811T090000", "20260811T100000"),
+      ...evt("d4", "Deň 12", "20260812T090000", "20260812T100000"),
+    ]);
+    const result = resolveNextEvents(text, NOW, 3);
+    expect(result.map((e) => e.title)).toEqual(["Deň 9", "Deň 10", "Deň 11"]);
+  });
+
+  it("dni bez udalosti sa PRESKAKUJÚ a nepočítajú sa do troch (medzery medzi dňami)", () => {
+    const text = ics([
+      ...evt("g1", "9.8.", "20260809T090000", "20260809T100000"),
+      ...evt("g2", "13.8.", "20260813T090000", "20260813T100000"),
+      ...evt("g3", "20.8.", "20260820T090000", "20260820T100000"),
+    ]);
+    const result = resolveNextEvents(text, NOW, 3);
+    // Prázdne dni (10., 11., 12., 14.–19. 8.) neminú limit — vrátia sa všetky 3.
+    expect(result.map((e) => e.title)).toEqual(["9.8.", "13.8.", "20.8."]);
+    expect(result.map((e) => e.dateLabel)).toEqual(["nedeľa 9. 8.", "štvrtok 13. 8.", "štvrtok 20. 8."]);
+  });
+
+  it("viac dní, každý s viacerými udalosťami — dayLimit oreže na počet DNÍ, vráti všetky udalosti tých dní", () => {
+    const text = ics([
+      ...evt("x1", "D9 a", "20260809T110000", "20260809T120000"),
+      ...evt("x2", "D9 b", "20260809T080000", "20260809T090000"),
+      ...evt("x3", "D11 a", "20260811T090000", "20260811T100000"),
+      ...evt("x4", "D11 b", "20260811T130000", "20260811T140000"),
+      ...evt("x5", "D13 (mimo limitu)", "20260813T090000", "20260813T100000"),
+    ]);
+    const result = resolveNextEvents(text, NOW, 2);
+    // Prvé 2 DNI (9. a 11.), každý so všetkými udalosťami, v rámci dňa zoradené; 13. je mimo.
+    expect(result.map((e) => e.title)).toEqual(["D9 b", "D9 a", "D11 a", "D11 b"]);
+  });
+
+  it("jeden deň s VIAC udalosťami než dayLimit → dayLimit 1 vráti VŠETKY udalosti toho JEDNÉHO dňa (nie len 1)", () => {
+    const text = ics([
+      ...evt("m1", "U1", "20260810T080000", "20260810T090000"),
+      ...evt("m2", "U2", "20260810T100000", "20260810T110000"),
+      ...evt("m3", "U3", "20260810T120000", "20260810T130000"),
+      ...evt("m4", "U4", "20260810T140000", "20260810T150000"),
+    ]);
+    const result = resolveNextEvents(text, NOW, 1);
+    expect(result.map((e) => e.title)).toEqual(["U1", "U2", "U3", "U4"]);
+  });
+
+  it("celodenné (VALUE=DATE) aj časované udalosti v ten istý deň sa zoskupia spolu", () => {
+    const text = ics([
+      "BEGIN:VEVENT",
+      "UID:allday@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Celodenná 10.8.",
+      "DTSTART;VALUE=DATE:20260810",
+      "DTEND;VALUE=DATE:20260811",
+      "END:VEVENT",
+      ...evt("timed", "Časovaná 10.8.", "20260810T150000", "20260810T160000"),
+    ]);
+    const result = resolveNextEvents(text, NOW, 3);
+    // Oba pod 10. 8. — jeden deň, celodenná začína na hranici dňa (skôr), časovaná neskôr.
+    expect(result.map((e) => e.title)).toEqual(["Celodenná 10.8.", "Časovaná 10.8."]);
+    expect(result.every((e) => e.dateLabel === "pondelok 10. 8.")).toBe(true);
+  });
+});
+
+// issue 382: majiteľ chce vidieť TRI najbližšie udalosti, nie jednu. (issue 439
+// zmenilo význam `limit` na POČET DNÍ — tieto fixtúry majú každú udalosť v INÝ
+// deň, takže výsledok ostáva rovnaký a testy platia bezo zmeny.)
 describe("resolveNextEvents — limit (issue 382)", () => {
   function threeFutureEvents(): string {
     return ics([

--- a/apps/api/src/modules/calendar/next-event.ts
+++ b/apps/api/src/modules/calendar/next-event.ts
@@ -60,11 +60,11 @@ function hasNotEnded(candidate: Candidate, now: Date): boolean {
  * udalosť" namiesto toho, aby nahlas zlyhal (dispatch: "Fetch failure /
  * malformed feed → fail loud, never crash, never show raw error").
  *
- * issue 382: majiteľ chce TRI najbližšie udalosti, nie jednu — `limit`
- * rozhoduje koľko sa vráti (zoradené podľa najskoršieho začiatku), NIKDY
- * viac než reálne dostupných kandidátov.
+ * issue 382 → 439: `dayLimit` rozhoduje koľko najbližších DNÍ, v ktorých je
+ * aspoň jedna udalosť, sa vráti — a pre KAŽDÝ taký deň VŠETKY jeho udalosti
+ * (zoradené podľa najskoršieho začiatku). Nie počet udalostí.
  */
-export function resolveNextEvents(icsText: string, now: Date, limit: number): NextCalendarEvent[] {
+export function resolveNextEvents(icsText: string, now: Date, dayLimit: number): NextCalendarEvent[] {
   if (!icsText.includes("BEGIN:VCALENDAR")) {
     throw new Error("Stiahnutý obsah nevyzerá ako platný ICS kalendár (chýba BEGIN:VCALENDAR)");
   }
@@ -90,5 +90,28 @@ export function resolveNextEvents(icsText: string, now: Date, limit: number): Ne
   }
 
   const upcoming = candidates.filter((c) => hasNotEnded(c, now)).sort((a, b) => a.start.getTime() - b.start.getTime());
-  return upcoming.slice(0, limit).map((c) => ({ title: c.title, dateLabel: formatDateLabel(c.start), allDay: c.allDay }));
+
+  // issue 439: `dayLimit` počíta DNI, v ktorých je aspoň jedna udalosť, nie
+  // udalosti. Zoskupenie kľúčom kalendárneho dňa v Europe/Bratislava
+  // (`zonedDateKey`) — rovnaké pásmo ako `formatDateLabel`/`hasNotEnded`, takže
+  // sedí s vypísaným `dateLabel` a je stabilné voči proces-TZ pri celodenných
+  // (`VALUE=DATE`) udalostiach (`.claude/rules/calendar.md`). Iterujeme len cez
+  // udalosti, takže dni bez udalosti do skupiny nikdy nevstúpia — preskočia sa
+  // a NEMINÚ `dayLimit`. `continue` (nie `break`) pri dni nad limitom je
+  // robustné aj voči teoretickému preplietaniu udalostí rôznych dní: ďalšie
+  // udalosti UŽ započítaných dní sa stále pridajú. Prebiehajúca viacdňová
+  // udalosť (začala pred dneškom, ešte neskončila) sa zoskupí pod svoj
+  // ZAČIATOČNÝ deň — konzistentné s doterajším zobrazovaním takej udalosti jej
+  // začiatočným dátumom.
+  const includedDayKeys = new Set<string>();
+  const result: NextCalendarEvent[] = [];
+  for (const candidate of upcoming) {
+    const dayKey = zonedDateKey(candidate.start);
+    if (!includedDayKeys.has(dayKey)) {
+      if (includedDayKeys.size >= dayLimit) continue;
+      includedDayKeys.add(dayKey);
+    }
+    result.push({ title: candidate.title, dateLabel: formatDateLabel(candidate.start), allDay: candidate.allDay });
+  }
+  return result;
 }

--- a/apps/api/src/modules/calendar/service.ts
+++ b/apps/api/src/modules/calendar/service.ts
@@ -9,10 +9,10 @@
 import { log } from "../../logger.js";
 import type { IcsFetcher } from "./fetcher.js";
 import { resolveNextEvents, type NextCalendarEvent } from "./next-event.js";
-import { NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS, NEXT_EVENTS_LIMIT } from "./constants.js";
+import { NEXT_EVENT_DAYS_LIMIT, NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS } from "./constants.js";
 
-// issue 382: pole namiesto singulárnej udalosti — majiteľ chce TRI
-// najbližšie, nie jednu (`NEXT_EVENTS_LIMIT`).
+// issue 382 → 439: pole namiesto singulárnej udalosti — majiteľ chce
+// udalosti z TROCH najbližších dní s udalosťami (`NEXT_EVENT_DAYS_LIMIT`).
 export type NextEventResult = { readonly ok: true; readonly events: readonly NextCalendarEvent[] } | { readonly ok: false };
 
 export interface NextEventService {
@@ -36,7 +36,7 @@ export function createNextEventService(fetchIcs: IcsFetcher): NextEventService {
   async function refresh(now: Date): Promise<CacheEntry> {
     try {
       const icsText = await fetchIcs();
-      const events = resolveNextEvents(icsText, now, NEXT_EVENTS_LIMIT);
+      const events = resolveNextEvents(icsText, now, NEXT_EVENT_DAYS_LIMIT);
       return { result: { ok: true, events }, cachedAtMs: now.getTime(), ttlMs: NEXT_EVENT_OK_CACHE_TTL_MS };
     } catch (error) {
       const rawErrorMessage = error instanceof Error ? error.message : String(error);

--- a/apps/api/tests/emoji-persist.integration.test.ts
+++ b/apps/api/tests/emoji-persist.integration.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 440: emoji sa v appke MUSIA uložiť aj vrátiť identicky (Postgres `text`
+// + node-postgres nesú 4-bajtové UTF-8; žiadna sanitizácia). Šéfovo „nefunguje"
+// bolo o CHÝBAJÚCOM spôsobe vloženia (picker), nie o perzistencii — tento test
+// ZAMKNE perzistenciu, aby ju budúca sanitizácia nemohla ticho pokaziť. Vzorka
+// pokrýva viac-codepointové emoji: ZWJ rodinu, regionálnu vlajku, variation
+// selector.
+const HESLO = "test-heslo-abc";
+const EMOJI = "test 👍🙂 ✅❤️ 🌲 👨‍👩‍👧‍👦 🇸🇰";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function bootAdmin() {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({ email: "sef@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Šéf 🙂", role: "admin" });
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "sef@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie };
+}
+
+describe("emoji perzistencia (issue 440)", () => {
+  it("Poznámka: emoji sa uloží a vráti IDENTICKY (POST /api/notes → GET /api/notes)", async () => {
+    const { app, cookie } = await bootAdmin();
+    const create = await app.request("/api/notes", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ body: EMOJI }),
+    });
+    expect(create.status).toBe(200);
+
+    const list = await app.request("/api/notes", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { body: string }[] };
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0]?.body).toBe(EMOJI);
+  });
+
+  it("Upozornenie: emoji v nadpise aj podrobnostiach sa uloží a vráti IDENTICKY (POST → GET /api/upozornenia)", async () => {
+    const { app, cookie } = await bootAdmin();
+    const create = await app.request("/api/upozornenia", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ title: `Nadpis ${EMOJI}`, details: `Detaily ${EMOJI}` }),
+    });
+    expect(create.status).toBe(200);
+
+    const list = await app.request("/api/upozornenia", { headers: { cookie } });
+    const body = (await list.json()) as { rows: readonly { title: string; details: string }[] };
+    const row = body.rows.find((r) => r.title.startsWith("Nadpis "));
+    expect(row?.title).toBe(`Nadpis ${EMOJI}`);
+    expect(row?.details).toBe(`Detaily ${EMOJI}`);
+  });
+});

--- a/apps/web/src/components/EmojiPickerButton.test.tsx
+++ b/apps/web/src/components/EmojiPickerButton.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef, useState, type JSX } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { EmojiPickerButton, insertEmojiAtSelection } from "./EmojiPickerButton.js";
+
+// issue 440: emoji picker — čistá vkladacia logika + komponent (prepínač +
+// popover). Ukladanie/render emoji funguje (overené integračne inde) — tu ide
+// o samotné vloženie na pozíciu kurzora.
+
+afterEach(cleanup);
+
+describe("insertEmojiAtSelection (čistá logika)", () => {
+  it("vloží emoji na pozíciu kurzora (prázdny výber uprostred)", () => {
+    expect(insertEmojiAtSelection("ahoj", 2, 2, "🙂")).toEqual({ value: "ah🙂oj", cursor: 4 });
+  });
+  it("prepíše výber", () => {
+    expect(insertEmojiAtSelection("ahoj", 1, 3, "👍")).toEqual({ value: "a👍j", cursor: 3 });
+  });
+  it("vloží do prázdneho poľa", () => {
+    expect(insertEmojiAtSelection("", 0, 0, "✅")).toEqual({ value: "✅", cursor: 1 });
+  });
+  it("oreže pozície mimo rozsahu na koniec poľa", () => {
+    expect(insertEmojiAtSelection("abc", 99, 99, "🔥")).toEqual({ value: "abc🔥", cursor: 5 });
+  });
+});
+
+// Kontrolovaný obal, ktorý zrkadlí reálne použitie (Poznámky/Upozornenia).
+function Harness(): JSX.Element {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [value, setValue] = useState("test ");
+  return (
+    <>
+      <textarea ref={ref} value={value} onChange={(e) => { setValue(e.target.value); }} data-testid="ta" />
+      <EmojiPickerButton targetRef={ref} value={value} onChange={setValue} testId="emoji" />
+    </>
+  );
+}
+
+describe("EmojiPickerButton (komponent)", () => {
+  it("prepínač otvorí/zavrie popover", () => {
+    render(<Harness />);
+    expect(screen.queryByTestId("emoji-popover")).toBeNull();
+    fireEvent.click(screen.getByTestId("emoji"));
+    expect(screen.getByTestId("emoji-popover")).toBeDefined();
+    fireEvent.click(screen.getByTestId("emoji"));
+    expect(screen.queryByTestId("emoji-popover")).toBeNull();
+  });
+
+  it("klik na emoji ho vloží na pozíciu kurzora cieľového poľa", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByTestId("emoji"));
+    const ta = screen.getByTestId<HTMLTextAreaElement>("ta");
+    ta.focus();
+    ta.setSelectionRange(5, 5); // za "test "
+    fireEvent.click(screen.getByRole("menuitem", { name: "Vložiť 👍" }));
+    expect(ta.value).toBe("test 👍");
+    // Po vložení sa popover ZAVRIE (inak by prekryl tlačidlo Uložiť pod poľom).
+    expect(screen.queryByTestId("emoji-popover")).toBeNull();
+  });
+
+  it("klik mimo pickeru popover zavrie", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByTestId("emoji"));
+    expect(screen.getByTestId("emoji-popover")).toBeDefined();
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByTestId("emoji-popover")).toBeNull();
+  });
+
+  it("disabled prepínač sa nedá otvoriť", () => {
+    function DisabledHarness(): JSX.Element {
+      const ref = useRef<HTMLTextAreaElement>(null);
+      return <EmojiPickerButton targetRef={ref} value="" onChange={() => {}} testId="emoji" disabled />;
+    }
+    render(<DisabledHarness />);
+    const toggle = screen.getByTestId<HTMLButtonElement>("emoji");
+    expect(toggle.disabled).toBe(true);
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId("emoji-popover")).toBeNull();
+  });
+});

--- a/apps/web/src/components/EmojiPickerButton.test.tsx
+++ b/apps/web/src/components/EmojiPickerButton.test.tsx
@@ -52,7 +52,7 @@ describe("EmojiPickerButton (komponent)", () => {
     const ta = screen.getByTestId<HTMLTextAreaElement>("ta");
     ta.focus();
     ta.setSelectionRange(5, 5); // za "test "
-    fireEvent.click(screen.getByRole("menuitem", { name: "Vložiť 👍" }));
+    fireEvent.click(screen.getByRole("button", { name: "Vložiť 👍" }));
     expect(ta.value).toBe("test 👍");
     // Po vložení sa popover ZAVRIE (inak by prekryl tlačidlo Uložiť pod poľom).
     expect(screen.queryByTestId("emoji-popover")).toBeNull();

--- a/apps/web/src/components/EmojiPickerButton.tsx
+++ b/apps/web/src/components/EmojiPickerButton.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useState, type JSX, type RefObject } from "react";
+
+// issue 440: vloženie emoji do textu (Poznámky + Nové upozornenie). Emoji sa v
+// appke ukladajú aj zobrazujú správne (overené naživo proti Postgresu — Postgres
+// `text` + node-postgres nesú 4-bajtové UTF-8, žiadna sanitizácia) — chýbal len
+// SPÔSOB, ako ich na desktope vložiť. Toto je malý znovupoužiteľný prepínač s
+// kurátorovanou sadou bežných emoji, BEZ ťažkej externej knižnice (MVP). Klik na
+// emoji ju vloží na pozíciu kurzora cieľového poľa a vráti fokus + kurzor zaň.
+
+// Kurátorovaná sada bežných emoji pre nástenku obchodu (žiadny externý picker).
+// Grid je 8 stĺpcov (`app.css`), takže násobky 8 vyzerajú vyrovnane.
+const EMOJI: readonly string[] = [
+  "👍", "👎", "🙂", "😀", "😅", "😂", "😉", "😍",
+  "🥰", "😎", "🤔", "😢", "😡", "🎉", "🔥", "⭐",
+  "✅", "❌", "⚠️", "❗", "❓", "💡", "📌", "📅",
+  "⏰", "📦", "🚚", "💰", "🛒", "📞", "📝", "🙏",
+  "👀", "💪", "👌", "✨", "❤️", "🌲", "➡️", "🕒",
+];
+
+/**
+ * Čistá (bez DOM) logika vloženia emoji na pozíciu kurzora — samostatne
+ * testovateľná. Vráti novú CELÚ hodnotu poľa a kam má skončiť kurzor (za
+ * vloženým emoji). Výber (selStart..selEnd) sa prepíše; pozície sa orežú do
+ * platného rozsahu, takže sa dá zavolať aj s "koniec poľa" defaultom, keď pole
+ * nebolo fokusnuté.
+ */
+export function insertEmojiAtSelection(value: string, selStart: number, selEnd: number, emoji: string): { value: string; cursor: number } {
+  const start = Math.max(0, Math.min(selStart, value.length));
+  const end = Math.max(start, Math.min(selEnd, value.length));
+  return { value: value.slice(0, start) + emoji + value.slice(end), cursor: start + emoji.length };
+}
+
+interface Props {
+  readonly targetRef: RefObject<HTMLTextAreaElement | HTMLInputElement | null>;
+  readonly value: string;
+  readonly onChange: (next: string) => void;
+  /** Unikátny testid prefix (viac pickerov na obrazovke, napr. dva vo formulári
+   * upozornenia) — inak by `getByTestId` kolidoval. */
+  readonly testId: string;
+  readonly disabled?: boolean;
+}
+
+export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled = false }: Props): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+
+  // Popover neblokuje zvyšok formulára — zavrie sa na klik mimo a na Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent): void => {
+      const target = e.target;
+      if (rootRef.current !== null && target instanceof Node && !rootRef.current.contains(target)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const insert = (emoji: string): void => {
+    const el = targetRef.current;
+    const selStart = el?.selectionStart ?? value.length;
+    const selEnd = el?.selectionEnd ?? value.length;
+    const { value: next, cursor } = insertEmojiAtSelection(value, selStart, selEnd, emoji);
+    onChange(next);
+    // Popover sa po vložení ZAVRIE — je `position: absolute` a otvára sa NAD
+    // obsahom pod ním (napr. tlačidlo Uložiť leží pod poľom); keby ostal
+    // otvorený, jeho dlaždice by prekryli a "ukradli" klik na Uložiť (nájdené
+    // e2e testom). Ďalšie emoji = znova otvoriť (štandardné správanie ľahkého
+    // pickeru). Kurzor sa nastaví AŽ v `requestAnimationFrame` — kontrolovaná
+    // hodnota sa prekreslí až po commite Reactu, vtedy DOM už nesie novú
+    // hodnotu a `setSelectionRange` sadne správne; fokus sa vráti do poľa, aby
+    // sa dalo písať ďalej.
+    setOpen(false);
+    requestAnimationFrame(() => {
+      const target = targetRef.current;
+      if (target === null) return;
+      target.focus();
+      target.setSelectionRange(cursor, cursor);
+    });
+  };
+
+  return (
+    <span className="emoji-picker" ref={rootRef}>
+      <button
+        type="button"
+        className="emoji-picker-toggle"
+        aria-label="Vložiť emoji"
+        aria-expanded={open}
+        title="Vložiť emoji"
+        disabled={disabled}
+        onClick={() => {
+          setOpen((o) => !o);
+        }}
+        data-testid={testId}
+      >
+        😊
+      </button>
+      {open && (
+        <div className="emoji-picker-popover" role="menu" data-testid={`${testId}-popover`}>
+          {EMOJI.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              className="emoji-picker-option"
+              role="menuitem"
+              aria-label={`Vložiť ${emoji}`}
+              title={emoji}
+              onClick={() => {
+                insert(emoji);
+              }}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/components/EmojiPickerButton.tsx
+++ b/apps/web/src/components/EmojiPickerButton.tsx
@@ -102,13 +102,16 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
         😊
       </button>
       {open && (
-        <div className="emoji-picker-popover" role="menu" data-testid={`${testId}-popover`}>
+        // `role="group"` (nie `menu`) + `aria-label` — čestný ARIA: je to
+        // pomenovaná skupina obyčajných tlačidiel, nie aplikačné menu s
+        // roving-focus/šípkovou navigáciou (tú tento MVP picker neimplementuje;
+        // ovládanie je myš + Tab/Enter na natívnych `<button>`och).
+        <div className="emoji-picker-popover" role="group" aria-label="Emoji na vloženie" data-testid={`${testId}-popover`}>
           {EMOJI.map((emoji) => (
             <button
               key={emoji}
               type="button"
               className="emoji-picker-option"
-              role="menuitem"
               aria-label={`Vložiť ${emoji}`}
               title={emoji}
               onClick={() => {

--- a/apps/web/src/components/NextCalendarEventCard.tsx
+++ b/apps/web/src/components/NextCalendarEventCard.tsx
@@ -41,9 +41,12 @@ export function NextCalendarEventCard(): JSX.Element | null {
       ) : result.events.length === 0 ? (
         <p className="next-calendar-event-row">V kalendári nie je žiadna nadchádzajúca udalosť.</p>
       ) : (
-        // issue 382: až TRI najbližšie udalosti namiesto jednej — každá
-        // vlastný kompaktný riadok (`.next-calendar-event-row`, žiadny
-        // predvolený prehliadačový `<p>` margin), nie samostatné karty.
+        // issue 382 → 439: udalosti z TROCH najbližších dní s udalosťami
+        // (server ich vráti zoskupené po dňoch, `resolveNextEvents`) — každá
+        // vlastný kompaktný riadok `📅 <deň> — <názov>` (`.next-calendar-event-
+        // row`, žiadny predvolený prehliadačový `<p>` margin), nie samostatné
+        // karty. Rovnaký formát riadku ako predtým, len pribudnú riadky (dni) —
+        // žiadna zmena vzhľadu (zadanie 439).
         result.events.map((event, i) => (
           <p className="next-calendar-event-row" key={`${event.dateLabel}-${event.title}-${String(i)}`}>
             📅 <strong>{event.dateLabel}</strong> — {event.title}

--- a/apps/web/src/components/NotesSection.tsx
+++ b/apps/web/src/components/NotesSection.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { createNote, deleteNote, fetchNotes, NotesUnauthorizedError, setNoteResolved, type NoteRow } from "../notesApi.js";
+import { EmojiPickerButton } from "./EmojiPickerButton.js";
 
 // issue 437: "Poznámky" — ZDIEĽANÁ nástenka rýchlych poznámok (mobilný zápis +
 // PWA). Na rozdiel od `DailyTasksSection.tsx` (súkromný per-používateľský
@@ -26,6 +27,8 @@ export function NotesSection({ onSessionExpired }: { readonly onSessionExpired: 
   const [newBody, setNewBody] = useState("");
   const [creating, setCreating] = useState(false);
   const [busyId, setBusyId] = useState("");
+  // issue 440: emoji picker vkladá na pozíciu kurzora tohto poľa.
+  const newBodyRef = useRef<HTMLTextAreaElement>(null);
 
   const load = useCallback(() => {
     fetchNotes()
@@ -117,6 +120,7 @@ export function NotesSection({ onSessionExpired }: { readonly onSessionExpired: 
   const addRow = (
     <div className="poznamky-add">
       <textarea
+        ref={newBodyRef}
         className="poznamka-new-input"
         value={newBody}
         onChange={(e) => {
@@ -128,9 +132,12 @@ export function NotesSection({ onSessionExpired }: { readonly onSessionExpired: 
         rows={3}
         disabled={creating}
       />
-      <button type="button" className="btn good" onClick={addNote} disabled={newBody.trim() === "" || creating} data-testid="poznamka-new-save">
-        Uložiť
-      </button>
+      <div className="poznamka-add-actions">
+        <EmojiPickerButton targetRef={newBodyRef} value={newBody} onChange={setNewBody} testId="poznamka-emoji" disabled={creating} />
+        <button type="button" className="btn good" onClick={addNote} disabled={newBody.trim() === "" || creating} data-testid="poznamka-new-save">
+          Uložiť
+        </button>
+      </div>
     </div>
   );
 

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { UpozorneniaBadgeRefreshContext } from "../upozorneniaBadgeContext.js";
+import { EmojiPickerButton } from "./EmojiPickerButton.js";
 import { NextCalendarEventCard } from "./NextCalendarEventCard.js";
 import { UpozornenieCard } from "./UpozornenieCard.js";
 import { UpozorneniaResolvedList } from "./UpozorneniaResolvedList.js";
@@ -73,6 +74,9 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   // sa inkrementuje na ZAČIATKU každého `load()` volania; oba `.then()` nižšie
   // sa uplatnia len ak je stále najnovšie.
   const loadSeqRef = useRef(0);
+  // issue 440: emoji picker vkladá na pozíciu kurzora príslušného poľa formulára.
+  const draftTitleRef = useRef<HTMLInputElement>(null);
+  const draftDetailsRef = useRef<HTMLTextAreaElement>(null);
 
   const load = useCallback(() => {
     const seq = ++loadSeqRef.current;
@@ -293,6 +297,7 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
           <label>
             Nadpis
             <input
+              ref={draftTitleRef}
               value={draft.title}
               onChange={(e) => {
                 const value = e.target.value;
@@ -301,10 +306,19 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
               aria-label="Nadpis upozornenia"
               data-testid="upozornenie-form-title"
             />
+            <EmojiPickerButton
+              targetRef={draftTitleRef}
+              value={draft.title}
+              onChange={(next) => {
+                setDraft((d) => (d === null ? d : { ...d, title: next }));
+              }}
+              testId="upozornenie-title-emoji"
+            />
           </label>
           <label>
             Podrobnosti
             <textarea
+              ref={draftDetailsRef}
               value={draft.details}
               onChange={(e) => {
                 const value = e.target.value;
@@ -312,6 +326,14 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
               }}
               aria-label="Podrobnosti upozornenia"
               data-testid="upozornenie-form-details"
+            />
+            <EmojiPickerButton
+              targetRef={draftDetailsRef}
+              value={draft.details}
+              onChange={(next) => {
+                setDraft((d) => (d === null ? d : { ...d, details: next }));
+              }}
+              testId="upozornenie-details-emoji"
             />
           </label>
           <label>

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2569,6 +2569,75 @@ a.upozornenie-title:hover {
 .poznamka-new-save {
   align-self: flex-end;
 }
+/* issue 440: spodný riadok pod textovým poľom poznámky — emoji picker vľavo,
+   Uložiť vpravo (zachováva doterajšie "Uložiť vpravo dole"). */
+.poznamka-add-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--fs-space-2);
+}
+
+/* issue 440: vloženie emoji do textu — malý prepínač + popover s kurátorovanou
+   sadou bežných emoji (Poznámky + Nové upozornenie). Bez externej knižnice
+   (MVP). Popover je `position: absolute` s vysokým `z-index`, otvára sa pod
+   prepínačom a prekryje čokoľvek pod ním (dočasný výber). */
+.emoji-picker {
+  position: relative;
+  display: inline-flex;
+}
+/* Vo formulári Upozornenia sedí picker v STĹPCOVOM `<label>` — bez tohto by ho
+   predvolený `align-items: stretch` roztiahol na celú šírku. */
+.upozornenie-form .emoji-picker {
+  align-self: flex-start;
+}
+.emoji-picker-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  cursor: pointer;
+  line-height: 1;
+  padding: var(--fs-space-1) var(--fs-space-2);
+  font-size: var(--fs-text-base);
+}
+.emoji-picker-toggle:hover {
+  background: var(--fs-surface-alt);
+}
+.emoji-picker-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.emoji-picker-popover {
+  position: absolute;
+  top: calc(100% + var(--fs-space-1));
+  left: 0;
+  z-index: 30;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: var(--fs-space-1);
+  width: max-content;
+  max-width: min(20rem, 90vw);
+  padding: var(--fs-space-2);
+  background: var(--fs-surface);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-md);
+  box-shadow: var(--fs-shadow-md);
+}
+.emoji-picker-option {
+  background: none;
+  border: none;
+  cursor: pointer;
+  line-height: 1;
+  padding: var(--fs-space-1);
+  border-radius: var(--fs-radius-sm);
+  font-size: var(--fs-text-md);
+}
+.emoji-picker-option:hover {
+  background: var(--fs-surface-alt);
+}
 .poznamky-list {
   display: flex;
   flex-direction: column;

--- a/apps/web/tests/e2e/poznamky.spec.ts
+++ b/apps/web/tests/e2e/poznamky.spec.ts
@@ -92,7 +92,7 @@ test("emoji picker (desktop + mobil): vloží emoji cez tlačidlo, uloží, vidn
   // Desktop: napísať text, vložiť emoji cez picker na koniec (kurzor), uložiť.
   await vstup.fill("Objednať sáčky ");
   await page.getByTestId("poznamka-emoji").click();
-  await page.getByRole("menuitem", { name: "Vložiť 👍" }).click();
+  await page.getByRole("button", { name: "Vložiť 👍" }).click();
   await expect(vstup).toHaveValue("Objednať sáčky 👍");
   await page.getByTestId("poznamka-new-save").click();
   await expect(page.getByTestId("poznamky-list").getByText("Objednať sáčky 👍")).toBeVisible();
@@ -101,7 +101,7 @@ test("emoji picker (desktop + mobil): vloží emoji cez tlačidlo, uloží, vidn
   await page.setViewportSize({ width: 375, height: 800 });
   await vstup.fill("Zavolať ");
   await page.getByTestId("poznamka-emoji").click();
-  await page.getByRole("menuitem", { name: "Vložiť 🎉" }).click();
+  await page.getByRole("button", { name: "Vložiť 🎉" }).click();
   await expect(vstup).toHaveValue("Zavolať 🎉");
   await page.getByTestId("poznamka-new-save").click();
   await expect(page.getByTestId("poznamky-list").getByText("Zavolať 🎉")).toBeVisible();

--- a/apps/web/tests/e2e/poznamky.spec.ts
+++ b/apps/web/tests/e2e/poznamky.spec.ts
@@ -66,3 +66,53 @@ test("mobil (375px): napísať poznámku, vidieť ju v zozname, vybaviť — zdi
 
   expect(chyby).toEqual([]);
 });
+
+// issue 440: emoji picker — vloženie emoji do textu poznámky cez tlačidlo (na
+// pozíciu kurzora), uloženie, zobrazenie v zozname. Desktop AJ mobilný viewport
+// (zadanie: "desktop aj mobilný viewport pri Poznámkach"). Emoji sa ukladá a
+// zobrazuje správne (perzistenciu zamyká `emoji-persist.integration.test.ts`).
+test("emoji picker (desktop + mobil): vloží emoji cez tlačidlo, uloží, vidno v zozname, konzola čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.setViewportSize({ width: 1280, height: 900 }); // desktop
+  await page.goto("/?tab=poznamky");
+  await page.getByLabel("E-mail").fill(E2E_POZNAMKY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Poznámky" })).toBeVisible();
+
+  const vstup = page.getByTestId("poznamka-new-input");
+
+  // Desktop: napísať text, vložiť emoji cez picker na koniec (kurzor), uložiť.
+  await vstup.fill("Objednať sáčky ");
+  await page.getByTestId("poznamka-emoji").click();
+  await page.getByRole("menuitem", { name: "Vložiť 👍" }).click();
+  await expect(vstup).toHaveValue("Objednať sáčky 👍");
+  await page.getByTestId("poznamka-new-save").click();
+  await expect(page.getByTestId("poznamky-list").getByText("Objednať sáčky 👍")).toBeVisible();
+
+  // Mobil (375px): to isté, iné emoji.
+  await page.setViewportSize({ width: 375, height: 800 });
+  await vstup.fill("Zavolať ");
+  await page.getByTestId("poznamka-emoji").click();
+  await page.getByRole("menuitem", { name: "Vložiť 🎉" }).click();
+  await expect(vstup).toHaveValue("Zavolať 🎉");
+  await page.getByTestId("poznamka-new-save").click();
+  await expect(page.getByTestId("poznamky-list").getByText("Zavolať 🎉")).toBeVisible();
+
+  // Upratanie po teste.
+  const p1 = page.locator(".poznamka-row").filter({ hasText: "Objednať sáčky 👍" });
+  const p2 = page.locator(".poznamka-row").filter({ hasText: "Zavolať 🎉" });
+  await p2.getByRole("button", { name: "Odstrániť poznámku" }).click();
+  await expect(p2).toHaveCount(0);
+  await p1.getByRole("button", { name: "Odstrániť poznámku" }).click();
+  await expect(p1).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -290,7 +290,7 @@ test("emoji picker: vloží emoji do nadpisu aj podrobností upozornenia, ulož�
   const nadpis = page.getByTestId("upozornenie-form-title");
   await nadpis.fill("Urgentné ");
   await page.getByTestId("upozornenie-title-emoji").click();
-  await page.getByRole("menuitem", { name: "Vložiť 🔥" }).click();
+  await page.getByRole("button", { name: "Vložiť 🔥" }).click();
   await expect(nadpis).toHaveValue("Urgentné 🔥");
   // (popover sa po vložení emoji zavrie sám — netreba ho ručne zatvárať)
 
@@ -298,7 +298,7 @@ test("emoji picker: vloží emoji do nadpisu aj podrobností upozornenia, ulož�
   const detaily = page.getByTestId("upozornenie-form-details");
   await detaily.fill("Skontrolovať sklad ");
   await page.getByTestId("upozornenie-details-emoji").click();
-  await page.getByRole("menuitem", { name: "Vložiť ✅" }).click();
+  await page.getByRole("button", { name: "Vložiť ✅" }).click();
   await expect(detaily).toHaveValue("Skontrolovať sklad ✅");
 
   await page.getByTestId("upozornenie-form-save").click();

--- a/apps/web/tests/e2e/upozornenia.spec.ts
+++ b/apps/web/tests/e2e/upozornenia.spec.ts
@@ -262,3 +262,54 @@ test("desktop (1600px): dve karty upozornení sa uložia VEDĽA SEBA, nie pod se
 
   expect(chyby).toEqual([]);
 });
+
+// issue 440: emoji picker vo formulári Nové upozornenie — vloženie emoji do
+// NADPISU aj PODROBNOSTÍ cez tlačidlo, uloženie, zobrazenie na karte. Emoji sa
+// ukladá/zobrazuje správne (perzistenciu zamyká `emoji-persist.integration
+// .test.ts`). Popover jedného poľa sa pred prácou na druhom zavrie (klik na
+// prepínač) — inak by dva otvorené popovery mali dva rovnaké menuitem-y.
+test("emoji picker: vloží emoji do nadpisu aj podrobností upozornenia, uloží, vidno na karte, konzola čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/?tab=upozornenia");
+  await page.getByLabel("E-mail").fill(E2E_UPOZORNENIA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Upozornenia" })).toBeVisible();
+
+  await page.getByTestId("upozornenie-new").click();
+
+  // Nadpis: text + emoji cez picker.
+  const nadpis = page.getByTestId("upozornenie-form-title");
+  await nadpis.fill("Urgentné ");
+  await page.getByTestId("upozornenie-title-emoji").click();
+  await page.getByRole("menuitem", { name: "Vložiť 🔥" }).click();
+  await expect(nadpis).toHaveValue("Urgentné 🔥");
+  // (popover sa po vložení emoji zavrie sám — netreba ho ručne zatvárať)
+
+  // Podrobnosti: text + emoji cez picker.
+  const detaily = page.getByTestId("upozornenie-form-details");
+  await detaily.fill("Skontrolovať sklad ");
+  await page.getByTestId("upozornenie-details-emoji").click();
+  await page.getByRole("menuitem", { name: "Vložiť ✅" }).click();
+  await expect(detaily).toHaveValue("Skontrolovať sklad ✅");
+
+  await page.getByTestId("upozornenie-form-save").click();
+  await expect(page.getByTestId("upozornenie-form")).toBeHidden();
+
+  const card = kartaSNadpisom(page, "Urgentné 🔥");
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("Skontrolovať sklad ✅");
+
+  await card.getByRole("button", { name: "Odstrániť", exact: true }).click(); // upratanie po teste
+  await expect(kartaSNadpisom(page, "Urgentné 🔥")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4214,3 +4214,10 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   marking, round-trip nefunguje) + `.claude/rules/supplier-stock.md` (split čítanie
   pairing_variant_link priamo, restock coalesce + JOIN poradie, 4-miestny
   split-governed predikát).
+
+## issue 437 — Poznámky (zdieľaná mobilná nástenka, PWA)
+- PR #438 → main merge `611d59` ; nasadené v0.3.0-dev.260 na forestshop.newlevel.media.
+- Nový modul `note`: `schema-note.ts` + migrácia `0056_yummy_sue_storm.sql`; `modules/note/{queries,service}.ts` (ZDIEĽANÉ — JOIN na users pre autora, resolve/delete NIE viazané na autora); `http/note-routes.ts` (requireUser, autor zo session). Web `NotesSection.tsx` + `notesApi.ts`, nav „Poznámky" (Dôležité). PWA: `manifest.webmanifest` + `icon-192/512.png` (chromium z favicon SVG) + `index.html` metá, start_url `/?tab=poznamky`.
+- Testy: `note-http.integration.test.ts` (14, RED nepotrebné — feature), `NotesSection.test.tsx` (7), `poznamky.spec.ts` (e2e 375px). `note` do oboch TRUNCATE zoznamov + `E2E_POZNAMKY_EMAIL` (rola sef). Session TTL už 30 dní (nemenené).
+- CI trap: `nav.spec.ts` mal 2× `.side-nav .tab` toHaveCount(19) → 20 (+ `nav.test.ts` folder count 2→3) — lokálny beh len nového spec to nechytil, až CI. Zapísané do `frontend-design.md`.
+- Playbook: `.claude/rules/frontend-design.md` (nová nav záložka rozbije count-strážcov v nav.test.ts+nav.spec.ts; generovanie PWA ikon cez Playwright chromium).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.261",
+  "version": "0.3.0-dev.262",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.260",
+  "version": "0.3.0-dev.261",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Batch dvoch šéfových požiadaviek (Discord, 16. 8. 2026) — v0.3.0-dev.262.

## issue 439 — Kalendár: 3 najbližšie dni s udalosťami
Pruh na Upozorneniach ukazoval len 3 najbližšie UDALOSTI; šéf chce 3 najbližšie
DNI, v ktorých je nejaká udalosť, a v každom dni VŠETKY jeho udalosti.
`resolveNextEvents` teraz zoskupuje udalosti podľa kalendárneho dňa
(Europe/Bratislava, `zonedDateKey`) a oreže na počet DNÍ (`NEXT_EVENT_DAYS_LIMIT
= 3`), nie udalostí; dni bez udalosti sa preskakujú a neminú limit. Návratový
tvar (ploché pole) aj formát riadku karty (`📅 deň — názov`) ostávajú — žiadna
zmena vzhľadu, len pribudnú riadky (dni). Karta bez zmeny logiky.

## issue 440 — Emoji do textu (picker) + overenie ukladania
Vyšetrenie: emoji sa v appke ukladajú aj zobrazujú SPRÁVNE (overené naživo cez
service vrstvu; Postgres `text` + node-postgres nesú 4-bajtové UTF-8, žiadna
sanitizácia). Šéfovo „nefunguje" bolo o CHÝBAJÚCOM spôsobe vloženia. Pridaný
malý znovupoužiteľný `EmojiPickerButton` (bez externej knižnice, kurátorovaná
sada ~40 bežných emoji) + čistý `insertEmojiAtSelection` helper — vkladá na
pozíciu kurzora; popover sa po vložení zavrie (inak by prekryl tlačidlo Uložiť
pod poľom — nájdené e2e testom). Zapojené na textové pole Poznámky a na
Nadpis + Podrobnosti Nového upozornenia.

## Testy
- 439: unit testy zoskupenia po dňoch (viac udalostí/deň, preskočenie prázdnych
  dní, dayLimit počíta dni, celodenné VALUE=DATE cez TZ).
- 440: unit (čistý insert helper + komponent), integračná GARANCIA perzistencie
  (emoji cez `POST /api/notes` a `POST /api/upozornenia` sa vráti identicky —
  ZWJ rodina, vlajka, variation selector), Playwright e2e (vloženie cez picker
  → Uložiť → v zozname; Poznámky desktop aj 375px mobil; Upozornenia nadpis +
  podrobnosti). Konzola 0 chýb / 0 varovaní.

issue 439, issue 440 (tickety sa zavrú ručne po živom overení na produkcii —
appka nezatvára cez merge kľúčové slová podľa konvencie repa).
