### PR TITLE
issues 446, 447, 448 — badge aktívne nenapárované, pilulky Beží, override odkazy v zbere

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1408,3 +1408,23 @@ paths:
   4-bajtové UTF-8; zamknuté `emoji-persist.integration.test.ts`
   POST→GET round-tripom vrátane ZWJ rodiny/vlajky/variation selectora) —
   „emoji nefunguje" bol vždy len chýbajúci VSTUP, nikdy perzistencia.
+- **Nav count BADGE (`nav-badge-<id>`, vzor Upozornenia/#147) naviazaný na
+  DB dopyt sa v e2e NIKDY neasertuje presným číslom — zdieľaná e2e DB
+  (`scripts/e2e-setup.ts`) seeduje VEĽA objednávok, ktoré kritériu
+  vyhovujú, nielen fixtúry danej funkcie.** Issue 445 (DPD badge = počet
+  „na objednanie DPD"): `toHaveText("2")` (počítal som s dvomi DPD
+  fixtúrami 9012/9013) padlo na CI s `Received "14"` — e2e-setup má ~14
+  otvorených objednávok bez `package_number`, ktoré všetky kvalifikujú.
+  Lokálny beh len nového spec súboru to nechytil rovnako ako pri
+  `toHaveCount` (issue 437) — chytila to až CI. Fix: over len, že odznak
+  SVIETI a nesie kladné celé číslo (`toHaveText(/^[1-9]\d*$/)`) — presnú
+  sémantiku počtu pokrýva API integration test s RIADENÝMI dátami, nie
+  e2e proti zdieľanej seed DB. Platí pre KAŽDÝ budúci count badge.
+- **PROD DB sa dá čítať PRIAMO na `forestshop-dev` cez `docker exec` — užitočné
+  na živý „pred/po" dôkaz pri overovaní (nielen cez UI).** `docker exec
+  forestshop-postgres-1 psql -U forestshop -d forestshop -c "..."` (kontajner
+  s POMLČKOU `forestshop-postgres-1` = PROD, bez host portu; s PODTRŽNÍKOM
+  `forestshop_app-postgres-1` = lokálna dev DB na 5433, `.env`). Issue 445
+  tak doložilo, že stavový filter znížil ponuku DPD z 297 na 40 (257
+  terminálnych vylúčených) — presne šéfovu výhradu. Len ČÍTANIE, žiadny zápis
+  na PROD bez schválenia (`no-destructive-remote-actions.md`).

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -203,6 +203,23 @@ paths:
   tiché. Ďalší podobný nález (iný vlastný/interný odkaz omylom vytiahnutý
   z voľného textu): rovnaký vzor — vylúčiť PRI ZBERE podľa hosta, vyčistiť
   staré riadky, ukázať počet, nikdy len ticho prestať zapisovať nové.
+- **Zdroje populácie zberu (`collectSupplierLinks`, `run.ts`) — od issue 448
+  EFEKTÍVNE odkazy, nie surový `internalNote`:** populácia = `resolveEffectiveSupplierLink`
+  (`modules/orders/effective-supplier-link.ts` — override `product_supplier_link_override`
+  ∪ URL vytiahnutá z `products.internalNote`) ∪ split `pairing_variant_link`
+  (`pairing_decision.status='split'`, issue 423). Pred issue 448 čítal
+  `collectSupplierLinks` LEN surový `internalNote` (`.where(isNotNull(internalNote))`)
+  a bol JEDINÝ z čítacích ciest, čo `resolveEffectiveSupplierLink` NEVOLAL —
+  potvrdený odkaz z Párovania zapísaný do override tabuľky (`product_supplier_link_override`)
+  bol pre nočný zber neviditeľný až do Shoptet writebacku + ďalšieho catalog syncu
+  (betalov: 35 produktov s poznámkou „betalov", ale len 11 s URL v poznámke;
+  zvyšných 24 čaká na napárovanie, po ktorom sa override odkaz teraz zoberie
+  OKAMŽITE). `.where(isNotNull(internalNote))` filter je odstránený — produkt
+  s override ale bez poznámky by sa inak minul. `hostOf` normalizácia +
+  vylúčenie vlastného e-shopu (issue 227) platia rovnako na efektívny odkaz.
+  Efektívna linka je čistá JS funkcia (regex + coalesce), preto „načítaj do JS"
+  vzor (rovnako ako `computeCatalogCoverage`/`determineReviewPopulationKeys`),
+  nie SQL JOIN, ktorý by zaviedol druhú rozíditeľnú definíciu.
 - **Ten istý Shoptet FRONTEND ŠABLÓNOVÝ prvok (`<span class="availability-
   label" ... data-testid="labelAvailability">`) sa opakuje NAPRIEČ VIACERÝMI
   nezávislými doménami (issue 227: `virginiashop.sk`, `tenolix.cz`,

--- a/apps/api/src/modules/pairing-review/queries.ts
+++ b/apps/api/src/modules/pairing-review/queries.ts
@@ -141,6 +141,13 @@ export interface PairingReviewSearchResult {
    * fronty — `computeCatalogCoverage`. */
   readonly catalogLinked: number;
   readonly catalogActive: number;
+  /** issue 446 — badge záložky Párovanie: AKTÍVNE nenapárované produkty
+   * (≥1 sellable variant AND bez efektívneho odkazu AND bez terminálneho
+   * rozhodnutia unavailable/discontinued/split). Podmnožina `catalogActive −
+   * catalogLinked`, počítaná v tom istom prechode ako `catalogLinked`
+   * (`computeCatalogCoverage`), aby si badge a hlavný ukazovateľ obrazovky
+   * nemohli rozísť. NEZÁVISLÉ od `filter` (rovnako ako catalog* polia). */
+  readonly activeUnpaired: number;
   readonly items: readonly PairingReviewItem[];
 }
 
@@ -233,10 +240,12 @@ async function determineReviewPopulationKeys(db: Database): Promise<string[]> {
 // fronty — aktívny olinkovaný produkt MIMO populácie (má linku, nebol
 // gatherovaný ani rozhodnutý) sa v pokrytí správne objaví, hoci `linkedTotal`
 // (odvodený z fronty) ho minie.
-async function computeCatalogCoverage(db: Database): Promise<{ readonly catalogActive: number; readonly catalogLinked: number }> {
+async function computeCatalogCoverage(
+  db: Database,
+): Promise<{ readonly catalogActive: number; readonly catalogLinked: number; readonly activeUnpaired: number }> {
   const sellableRows = await db.selectDistinct({ productKey: variants.productKey }).from(variants).where(eq(variants.state, "sellable"));
   const activeKeys = sellableRows.map((r) => r.productKey);
-  if (activeKeys.length === 0) return { catalogActive: 0, catalogLinked: 0 };
+  if (activeKeys.length === 0) return { catalogActive: 0, catalogLinked: 0, activeUnpaired: 0 };
 
   const productRows = await db.select({ key: products.key, internalNote: products.internalNote }).from(products).where(inArray(products.key, activeKeys));
   const internalNoteByKey = new Map(productRows.map((r) => [r.key, r.internalNote]));
@@ -247,12 +256,35 @@ async function computeCatalogCoverage(db: Database): Promise<{ readonly catalogA
     .where(inArray(productSupplierLinkOverrides.productKey, activeKeys));
   const overrideByProduct = new Map(overrideRows.map((r) => [r.productKey, r.url]));
 
+  // issue 446 — badge záložky Párovanie = AKTÍVNE nenapárované produkty
+  // (≥1 sellable variant AND bez efektívneho odkazu AND bez TERMINÁLNEHO
+  // rozhodnutia). Terminálne rozhodnutie (unavailable/discontinued/split — tá
+  // istá množina ako `isUnreviewed` nižšie) znamená "už zrevidované, netreba
+  // naň upozorňovať". `good`/`manual` VŽDY produkujú efektívnu linku, takže sú
+  // vylúčené už podmienkou `effective.url !== null`. Počíta sa v tom istom
+  // prechode ako `catalogLinked`, aby si badge a hlavný ukazovateľ obrazovky
+  // (catalogActive − catalogLinked) nemohli rozísť.
+  const terminalDecisionRows = await db
+    .select({ productKey: pairingDecisions.productKey, status: pairingDecisions.status })
+    .from(pairingDecisions)
+    .where(inArray(pairingDecisions.productKey, activeKeys));
+  const terminalDecided = new Set(
+    terminalDecisionRows
+      .filter((r) => r.status === "unavailable" || r.status === "discontinued" || r.status === "split")
+      .map((r) => r.productKey),
+  );
+
   let catalogLinked = 0;
+  let activeUnpaired = 0;
   for (const key of activeKeys) {
     const effective = resolveEffectiveSupplierLink(internalNoteByKey.get(key) ?? null, overrideByProduct.get(key) ?? null);
-    if (effective.url !== null) catalogLinked += 1;
+    if (effective.url !== null) {
+      catalogLinked += 1;
+      continue;
+    }
+    if (!terminalDecided.has(key)) activeUnpaired += 1;
   }
-  return { catalogActive: activeKeys.length, catalogLinked };
+  return { catalogActive: activeKeys.length, catalogLinked, activeUnpaired };
 }
 
 // issue 399 — zdieľané budovanie karty(-diet) pre KONKRÉTNU množinu
@@ -489,9 +521,9 @@ export async function getPairingReviewItem(db: Database, productKey: string): Pr
 export async function listPairingReview(db: Database, input: PairingReviewSearchInput): Promise<PairingReviewSearchResult> {
   // issue 432 — katalógové pokrytie sa počíta NEZÁVISLE od populácie fronty
   // (aj keď je fronta prázdna — napr. všetko olinkované — pokrytie ostáva správne).
-  const { catalogActive, catalogLinked } = await computeCatalogCoverage(db);
+  const { catalogActive, catalogLinked, activeUnpaired } = await computeCatalogCoverage(db);
   const productKeys = await determineReviewPopulationKeys(db);
-  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked, catalogActive, items: [] };
+  if (productKeys.length === 0) return { total: 0, gatheredTotal: 0, linkedTotal: 0, catalogLinked, catalogActive, activeUnpaired, items: [] };
 
   const allItems = await buildPairingReviewItems(db, productKeys);
 
@@ -559,7 +591,7 @@ export async function listPairingReview(db: Database, input: PairingReviewSearch
   const start = (input.page - 1) * input.pageSize;
   const items = filtered.slice(start, start + input.pageSize);
 
-  return { total, gatheredTotal, linkedTotal, catalogLinked, catalogActive, items };
+  return { total, gatheredTotal, linkedTotal, catalogLinked, catalogActive, activeUnpaired, items };
 }
 
 export interface PairingReviewCandidate {

--- a/apps/api/src/modules/supplier-stock/run.ts
+++ b/apps/api/src/modules/supplier-stock/run.ts
@@ -6,8 +6,9 @@
 
 import { and, eq, isNotNull, like, notInArray, or } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { pairingDecisions, pairingVariantLinks, products, supplierStock, variants } from "../../db/schema.js";
+import { pairingDecisions, pairingVariantLinks, productSupplierLinkOverrides, products, supplierStock, variants } from "../../db/schema.js";
 import { extractSupplierLink } from "../catalog/supplier-link.js";
+import { resolveEffectiveSupplierLink } from "../orders/effective-supplier-link.js";
 import { MAX_AGE_HOURS, OWN_SHOP_HOST, PER_HOST_DELAY_MS, SUPPLIER_STOCK_RUN_LOCK_KEY } from "./constants.js";
 import type { PageFetcher } from "./page-fetcher.js";
 import {
@@ -73,13 +74,24 @@ function isOwnShopHost(host: string): boolean {
  * e-shopu ako pri produktových linkách, aby sa kľúč na `supplier_stock`
  * nemohol rozísť s `restock/queries.ts`. */
 export async function collectSupplierLinks(db: Database): Promise<readonly string[]> {
-  const rows = await db
-    .select({ internalNote: products.internalNote })
-    .from(products)
-    .where(isNotNull(products.internalNote));
+  // issue 448: EFEKTÍVNY odkaz = override ∪ internalNote (`resolveEffectiveSupplierLink`,
+  // TÁ ISTÁ čítacia logika ako ostatné čítacie cesty — orders, nedostupne,
+  // pairing-review, product-links, coverage…). Potvrdený odkaz z Párovania
+  // zapísaný do `product_supplier_link_override` tak tečie do nočného zberu
+  // OKAMŽITE, bez čakania na Shoptet writeback + ďalší catalog sync. Čítame
+  // VŠETKY produkty (bez `.where(isNotNull(internalNote))`) — produkt s override
+  // ale bez poznámky by sa inak minul. Efektívna linka je čistá JS funkcia
+  // (regex + coalesce), nedá sa vyjadriť ako SQL predikát bez duplicity —
+  // rovnaký "načítaj do JS" vzor ako `computeCatalogCoverage`/
+  // `determineReviewPopulationKeys` (`pairing-review/queries.ts`).
+  const rows = await db.select({ key: products.key, internalNote: products.internalNote }).from(products);
+  const overrideRows = await db
+    .select({ productKey: productSupplierLinkOverrides.productKey, url: productSupplierLinkOverrides.url })
+    .from(productSupplierLinkOverrides);
+  const overrideByProduct = new Map(overrideRows.map((r) => [r.productKey, r.url]));
   const links = new Set<string>();
   for (const row of rows) {
-    const url = extractSupplierLink(row.internalNote).url;
+    const url = resolveEffectiveSupplierLink(row.internalNote, overrideByProduct.get(row.key) ?? null).url;
     const host = url === null ? "" : hostOf(url);
     if (url !== null && host !== "" && !isOwnShopHost(host)) links.add(url);
   }

--- a/apps/api/tests/pairing-review-catalog-coverage-http.integration.test.ts
+++ b/apps/api/tests/pairing-review-catalog-coverage-http.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it } from "vitest";
-import { productSupplierLinkOverrides, users } from "../src/db/schema.js";
+import { pairingDecisions, productSupplierLinkOverrides, users } from "../src/db/schema.js";
 import { createApp } from "../src/http/app.js";
 import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
 import { hashPassword } from "../src/modules/auth/passwords.js";
@@ -51,6 +51,9 @@ interface Telo {
   readonly linkedTotal: number;
   readonly catalogLinked: number;
   readonly catalogActive: number;
+  // issue 446 — badge záložky Párovanie = aktívne (≥1 sellable) produkty bez
+  // efektívneho odkazu a bez terminálneho rozhodnutia.
+  readonly activeUnpaired: number;
 }
 
 async function fetchCoverage(app: Awaited<ReturnType<typeof boot>>["app"], cookie: string): Promise<Telo> {
@@ -108,4 +111,49 @@ it("issue 432: aktívny olinkovaný produkt MIMO recenznej fronty sa ráta do po
   // Katalógové pokrytie ho VŠAK zaráta (aktívny + olinkovaný).
   expect(telo.catalogActive).toBe(1);
   expect(telo.catalogLinked).toBe(1);
+});
+
+// issue 446 — badge záložky Párovanie počíta AKTÍVNE nenapárované produkty
+// (≥1 sellable variant AND bez efektívneho odkazu AND bez terminálneho
+// rozhodnutia), nie celú no-link populáciu (~2302 vrátane ~2000 nepredajných).
+// `activeUnpaired` je tretie číslo z `computeCatalogCoverage`, vracia sa v tej
+// istej odpovedi ako `catalogActive`/`catalogLinked`.
+it("issue 446: activeUnpaired ráta LEN aktívne bez odkazu a bez terminálneho rozhodnutia", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  const snapshotId = await insertTestSnapshot(db);
+  const [u] = await db.select({ id: users.id }).from(users).limit(1);
+  if (u === undefined) throw new Error("testovací používateľ chýba");
+
+  // (A) aktívny (sellable) bez odkazu, bez rozhodnutia → SA počíta do badge.
+  await seedProduct(db, snapshotId, "AU-ACTIVE", { name: "Aktívny bez odkazu" });
+
+  // (B) nepredajný (discontinued variant) bez odkazu → NEpočíta sa (nie je
+  // aktívny) — presne tých ~2000 položiek, čo nafukovali starý badge na 2302.
+  await seedProduct(db, snapshotId, "AU-DISCONTINUED", {
+    name: "Ukončený bez odkazu",
+    variants: [{ code: "AU-DISCONTINUED/1", state: "discontinued" }],
+  });
+
+  // (C) aktívny bez odkazu, ALE terminálne rozhodnutý (unavailable) → NEpočíta
+  // sa (už zrevidovaný, netreba naň ďalej upozorňovať).
+  await seedProduct(db, snapshotId, "AU-UNAVAIL", { name: "Aktívny, u dodávateľa nedostupný" });
+  await db.insert(pairingDecisions).values({
+    productKey: "AU-UNAVAIL",
+    status: "unavailable",
+    url: null,
+    decidedBy: u.id,
+    decidedAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  // (D) aktívny s efektívnou linkou → NEpočíta sa (má odkaz).
+  await seedProduct(db, snapshotId, "AU-LINKED", { name: "Aktívny s linkou", internalNote: "https://dodavatel.example.com/au" });
+
+  const telo = await fetchCoverage(app, cookie);
+
+  // Menovateľ = aktívne produkty (≥1 sellable): AU-ACTIVE, AU-UNAVAIL, AU-LINKED
+  // — nie AU-DISCONTINUED.
+  expect(telo.catalogActive).toBe(3);
+  // Badge = LEN AU-ACTIVE (bez odkazu, bez terminálneho rozhodnutia).
+  expect(telo.activeUnpaired).toBe(1);
 });

--- a/apps/api/tests/supplier-stock-override-links.integration.test.ts
+++ b/apps/api/tests/supplier-stock-override-links.integration.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "../src/db/client.js";
+import { productSupplierLinkOverrides } from "../src/db/schema.js";
+import { collectSupplierLinks } from "../src/modules/supplier-stock/run.js";
+import { withCleanDb } from "./helpers/db.js";
+import { insertTestVariantForProduct } from "./helpers/orders.js";
+
+// issue 448: `collectSupplierLinks` musí čítať EFEKTÍVNY odkaz
+// (`product_supplier_link_override` ∪ `internalNote` cez
+// `resolveEffectiveSupplierLink`), nie len surový `internalNote` — inak
+// potvrdený odkaz z Párovania zapísaný do override tabuľky ostane pre nočný
+// zber neviditeľný až do Shoptet round-tripu + ďalšieho catalog syncu.
+
+describe("collectSupplierLinks — override odkazy (issue 448)", () => {
+  let db: Database;
+  let close: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ db, close } = await withCleanDb());
+  });
+  afterEach(async () => {
+    await close();
+  });
+
+  it("includes a link that exists ONLY in product_supplier_link_override (internalNote has no URL)", async () => {
+    // presne betalov prípad: poznámka = LEN meno dodávateľa, žiadny URL,
+    // ale v Párovaní potvrdený odkaz je zapísaný do override tabuľky.
+    await insertTestVariantForProduct(db, "BETA", "BETA/1", { internalNote: "betalov" });
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "BETA", url: "https://betalov.sk/produkt-x", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual(["https://betalov.sk/produkt-x"]);
+  });
+
+  it("still EXCLUDES a name-only note when there is no override and no URL anywhere", async () => {
+    await insertTestVariantForProduct(db, "NOURL", "NOURL/1", { internalNote: "betalov" });
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual([]);
+  });
+
+  it("prefers the override URL over the internalNote URL, and uses internalNote when no override", async () => {
+    await insertTestVariantForProduct(db, "NOTE", "NOTE/1", { internalNote: "https://dodavatel.example/z-poznamky" });
+    await insertTestVariantForProduct(db, "OVR", "OVR/1", { internalNote: "https://dodavatel.example/stara" });
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "OVR", url: "https://dodavatel.example/nova-override", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual(["https://dodavatel.example/nova-override", "https://dodavatel.example/z-poznamky"]);
+  });
+
+  it("excludes an override that points to OUR OWN e-shop (issue 227 discipline)", async () => {
+    await insertTestVariantForProduct(db, "OWN", "OWN/1", { internalNote: null });
+    await db
+      .insert(productSupplierLinkOverrides)
+      .values({ productKey: "OWN", url: "https://www.forestshop.sk/produkt-x", updatedAt: new Date("2026-01-02T00:00:00Z") });
+
+    const links = await collectSupplierLinks(db);
+    expect(links).toEqual([]);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { fetchMe, postLogout, type Me } from "./api.js";
 import { applyThemeColors } from "./applyThemeColors.js";
+import { buildAutomationStatus, STATIC_AUTOMATION_STATUS } from "./automationStatus.js";
 import { ChangePasswordForm } from "./components/ChangePasswordForm.js";
 import { Footer } from "./components/Footer.js";
 import { LoginForm } from "./components/LoginForm.js";
@@ -16,6 +17,7 @@ import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
 import { fetchPairingReviewUnreviewedCount } from "./pairingReviewApi.js";
 import { PairingReviewBadgeRefreshContext } from "./pairingReviewBadgeContext.js";
 import { fetchPostaUncollectedStatus } from "./postaUncollectedApi.js";
+import { fetchRestockStatus } from "./restockApi.js";
 import { fetchThemeColors } from "./themeColorsApi.js";
 import { fetchUpozorneniaCount } from "./upozorneniaApi.js";
 import { UpozorneniaBadgeRefreshContext } from "./upozorneniaBadgeContext.js";
@@ -220,17 +222,21 @@ export function App(): JSX.Element {
   useEffect(() => {
     if (me === null) return;
     let cancelled = false;
-    Promise.all([fetchPostaUncollectedStatus(), fetchOrderReminderStatus()])
-      .then(([posta, reminder]) => {
+    // issue 447 — pilulka „Beží"/„Zastavené" pri VŠETKÝCH automatizáciách:
+    // togglované (posta/order-reminder/restock) podľa `enabled`, always-on
+    // joby (supplier-stock/sync) staticky „on" cez `buildAutomationStatus`.
+    Promise.all([fetchPostaUncollectedStatus(), fetchOrderReminderStatus(), fetchRestockStatus()])
+      .then(([posta, reminder, restock]) => {
         if (cancelled) return;
-        setAutomationStatus({
-          "posta-uncollected": posta.enabled ? "on" : "off",
-          "order-reminder": reminder.enabled ? "on" : "off",
-        });
+        setAutomationStatus(
+          buildAutomationStatus({ postaUncollected: posta.enabled, orderReminder: reminder.enabled, restock: restock.enabled }),
+        );
       })
       .catch(() => {
-        // Sieťový výpadok — odznak v menu nie je kritický, ticho ponechá
-        // predošlý (alebo žiadny) stav namiesto nespracovanej výnimky.
+        // Sieťový výpadok — togglované automatizácie necháme bez pilulky
+        // (nezavádzať falošné „Zastavené"), ale always-on statické (supplier-
+        // stock/sync) ukáž aj tak. Odznak v menu nie je kritický.
+        if (!cancelled) setAutomationStatus(STATIC_AUTOMATION_STATUS);
       });
     return () => {
       cancelled = true;

--- a/apps/web/src/automationStatus.test.ts
+++ b/apps/web/src/automationStatus.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildAutomationStatus, STATIC_AUTOMATION_STATUS } from "./automationStatus.js";
+
+// issue 447 — pilulka „Beží"/„Zastavené" musí byť pri VŠETKÝCH automatizáciách,
+// nielen posta/order-reminder. Togglované automatizácie odrážajú `enabled`,
+// always-on joby (supplier-stock/sync) sú staticky „on".
+
+describe("buildAutomationStatus (issue 447)", () => {
+  it("always-on joby (supplier-stock, sync) sú vždy 'on'", () => {
+    expect(STATIC_AUTOMATION_STATUS["supplier-stock"]).toBe("on");
+    expect(STATIC_AUTOMATION_STATUS["sync"]).toBe("on");
+  });
+
+  it("togglované automatizácie odrážajú enabled flag (restock doplnený, issue 447)", () => {
+    const s = buildAutomationStatus({ postaUncollected: true, orderReminder: false, restock: true });
+    expect(s["posta-uncollected"]).toBe("on");
+    expect(s["order-reminder"]).toBe("off");
+    expect(s["restock"]).toBe("on");
+  });
+
+  it("vypnutý restock ukáže 'off' (Zastavené), zapnutý 'on' (Beží)", () => {
+    expect(buildAutomationStatus({ postaUncollected: false, orderReminder: false, restock: false })["restock"]).toBe("off");
+    expect(buildAutomationStatus({ postaUncollected: false, orderReminder: false, restock: true })["restock"]).toBe("on");
+  });
+
+  it("always-on joby ostávajú 'on' bez ohľadu na togglované vstupy", () => {
+    const s = buildAutomationStatus({ postaUncollected: false, orderReminder: false, restock: false });
+    expect(s["supplier-stock"]).toBe("on");
+    expect(s["sync"]).toBe("on");
+  });
+
+  it("mapuje presne 5 automatizácií (2 statické + 3 togglované)", () => {
+    const s = buildAutomationStatus({ postaUncollected: true, orderReminder: true, restock: true });
+    expect(Object.keys(s).sort()).toEqual(["order-reminder", "posta-uncollected", "restock", "supplier-stock", "sync"]);
+  });
+});

--- a/apps/web/src/automationStatus.ts
+++ b/apps/web/src/automationStatus.ts
@@ -1,0 +1,34 @@
+// issue 447 — mapovanie stavu automatizácií pre pilulky „Beží"/„Zastavené"
+// v ľavom menu (`Sidebar.tsx` renderuje pilulku pre KAŽDÝ `badgeStatus[tab.id]`).
+// Vyčlenené z `App.tsx`'s efektu ako ČISTÁ funkcia, aby sa mapovanie dalo
+// otestovať bez Reactu. Pilulka = „automatizácia je ZAPNUTÁ" (Štart/Stop
+// prepínač), NIE živé vykonávanie jobu — job beží pár minút v noci, živý stav
+// ostáva lokálnym ⏳ na obrazovke jobu (design komentár na issue 447).
+
+export type AutomationStatus = "on" | "off";
+
+// always-on plánované joby BEZ Štart/Stop prepínača (`supplier-stock` =
+// „Dodávateľský sklad", `sync` = „Sync zo Shoptetu" — joby `catalog-import` +
+// `orders-import`). Nemajú koncept „vypnuté", takže pilulka „Beží" trvalo;
+// odvodené staticky, žiadne API netreba. Tab id-čka zodpovedajú `nav.ts`.
+export const STATIC_AUTOMATION_STATUS: Readonly<Record<string, AutomationStatus>> = {
+  "supplier-stock": "on",
+  sync: "on",
+};
+
+// Togglované automatizácie (majú DB `enabled` flag / Štart/Stop): „Beží" keď
+// zapnuté, „Zastavené" keď vypnuté. `restock` = „Vypredané → Skladom" (issue
+// 447 — doteraz chýbalo), `posta-uncollected` = „Nevyzdvihnuté zásielky",
+// `order-reminder` = „Pripomienky objednávok" (pôvodný rozsah, issue 185).
+export function buildAutomationStatus(inputs: {
+  readonly postaUncollected: boolean;
+  readonly orderReminder: boolean;
+  readonly restock: boolean;
+}): Record<string, AutomationStatus> {
+  return {
+    ...STATIC_AUTOMATION_STATUS,
+    "posta-uncollected": inputs.postaUncollected ? "on" : "off",
+    "order-reminder": inputs.orderReminder ? "on" : "off",
+    restock: inputs.restock ? "on" : "off",
+  };
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -227,9 +227,21 @@ export function Sidebar({
                           // "Zastavené") ako `.pill` vnútri
                           // PostaUncollectedSection/OrderReminderSection —
                           // žiadny nový vzor navyše, len znovupoužitá trieda.
+                          // issue 447: `aria-hidden` (rovnaký vzor ako
+                          // `folder-badge`/`ticon` vyššie, `.claude/rules/
+                          // frontend-design.md` issue 343) — text pilulky by
+                          // sa inak zlial do PRÍSTUPNÉHO NÁZVU tlačidla
+                          // ("Vypredané → Skladom Beží"), čím by `getByRole
+                          // ("button", {name, exact:true})` prestal sedieť. Do
+                          // #447 to nevadilo (pilulku mali len posta/order-
+                          // reminder, klikané substringom); nové always-on tab-y
+                          // (restock/sync/supplier-stock) sú v e2e klikané
+                          // `exact:true`. Pilulka ostáva vizuálne + `nav-status-`
+                          // testid nedotknutý (aria-hidden neovplyvňuje text/testid).
                           <span
                             className={"pill tab-status" + (status === "off" ? " off" : "")}
                             data-testid={`nav-status-${tab.id}`}
+                            aria-hidden="true"
                           >
                             {status === "on" ? "Beží" : "Zastavené"}
                           </span>

--- a/apps/web/src/pairingReviewApi.ts
+++ b/apps/web/src/pairingReviewApi.ts
@@ -70,6 +70,9 @@ const searchSchema = z.object({
   // linkou), na rozdiel od `gatheredTotal`/`linkedTotal` (veľkosť recenznej fronty).
   catalogLinked: z.number(),
   catalogActive: z.number(),
+  // issue 446 — badge záložky Párovanie: AKTÍVNE nenapárované produkty (≥1
+  // sellable variant, bez efektívneho odkazu, bez terminálneho rozhodnutia).
+  activeUnpaired: z.number(),
   items: z.array(itemSchema),
 });
 export type PairingReviewSearchResult = z.infer<typeof searchSchema>;
@@ -107,21 +110,24 @@ export async function searchPairingReview(input: { readonly filter: PairingRevie
   return searchSchema.parse(await readJson(response, "Zoznam párovania sa nepodarilo načítať"));
 }
 
-const countSchema = z.object({ total: z.number() });
+// issue 446 — badge číta `activeUnpaired` (AKTÍVNE nenapárované produkty),
+// NIE `total` (veľkosť recenznej fronty ~2302 vrátane ~2000 dávno
+// nepredávaných katalógových položiek). `activeUnpaired` sa v odpovedi
+// vracia nezávisle od `filter`/`pageSize` (`computeCatalogCoverage`).
+const countSchema = z.object({ activeUnpaired: z.number() });
 
 // Badge v ľavom menu (`App.tsx`, rovnaký priamy vzor ako `restockLinksMissingCount`,
 // issue 331) — musí byť známy hneď po prihlásení. Znovupoužíva TEN ISTÝ
-// `GET /api/pairing-review` s `filter=unreviewed&pageSize=1` (lacný dopyt,
-// `total` sa v `listPairingReview` počíta nad CELOU odfiltrovanou množinou
-// nezávisle od `pageSize`). Chyba (401/sieť) sa nikdy nehádže — odznak
-// zostane na poslednej známej hodnote.
+// `GET /api/pairing-review` s `pageSize=1` (lacný dopyt, `activeUnpaired` sa
+// počíta nezávisle od `pageSize` aj `filter`). Chyba (401/sieť) sa nikdy
+// nehádže — odznak zostane na poslednej známej hodnote.
 export async function fetchPairingReviewUnreviewedCount(): Promise<number> {
   const query = new URLSearchParams({ filter: "unreviewed", page: "1", pageSize: "1" });
   const response = await fetch(`/api/pairing-review?${query.toString()}`);
   if (response.status === 401) return 0;
   if (!response.ok) return 0;
   const parsed = countSchema.safeParse(await response.json());
-  return parsed.success ? parsed.data.total : 0;
+  return parsed.success ? parsed.data.activeUnpaired : 0;
 }
 
 const candidateSchema = z.object({

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -160,6 +160,17 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
   await expect(page.getByRole("heading", { name: "Pripomienky objednávok" })).toBeVisible();
   await expect(page.getByTestId("nav-status-order-reminder")).toHaveText(/^(Zastavené|Beží)$/);
 
+  // issue 447: pilulka „Beží"/„Zastavené" musí byť pri VŠETKÝCH
+  // automatizáciách. `restock` („Vypredané → Skladom") je togglovaná rovnako
+  // ako posta/order-reminder (Štart/Stop) — rovnaká shared-state disciplína
+  // (regex, nie presná hodnota, `restock.spec.ts` si ju môže dočasne prepnúť).
+  await expect(page.getByTestId("nav-status-restock")).toHaveText(/^(Zastavené|Beží)$/);
+  // Always-on plánované joby `sync` („Sync zo Shoptetu") a `supplier-stock`
+  // („Dodávateľský sklad") nemajú Štart/Stop prepínač — pilulka je preto VŽDY
+  // „Beží", nikdy „Zastavené" (žiadny súbežný spec ju nevie prepnúť).
+  await expect(page.getByTestId("nav-status-sync")).toHaveText("Beží");
+  await expect(page.getByTestId("nav-status-supplier-stock")).toHaveText("Beží");
+
   await page.getByRole("button", { name: "Nedostupné tovary" }).click();
   await expect(page.getByRole("heading", { name: "Nedostupné tovary" })).toBeVisible();
   // "Nedostupné tovary" nemá koncept zapnuté/vypnuté vôbec (je len na

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.265",
+  "version": "0.3.0-dev.266",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Batch troch bundle-safe úloh (issues 446, 447, 448). Jedna dev vetva, jeden CI cyklus.

Tickety sa zavrú RUČNE až po nasadení a živom overení (majú post-deploy akceptačné podmienky), preto tu ZÁMERNE nie je `Closes` — pozri projektové CLAUDE.md.

## issue 446 — Párovanie: badge ráta aktívne nenapárované (~447), nie celú frontu (2302)
Badge záložky Párovanie čítal `total` (veľkosť recenznej fronty ~2302 vrátane ~2000 dávno nepredávaných). Nové: `computeCatalogCoverage()` vracia tretie číslo `activeUnpaired` = aktívne (≥1 sellable variant) produkty bez efektívneho odkazu a bez terminálneho rozhodnutia (unavailable/discontinued/split); badge číta jeho. Zoznam/filtre/obrazovka nedotknuté.

## issue 447 — Automatizácie: pilulka „Beží" pri Vypredané → Skladom, Sync a Dodávateľskom sklade
`restock` fetchuje `enabled` (Beží/Zastavené); `supplier-stock` + `sync` sú always-on plánované joby → staticky „Beží". Vyčlenené do čistej `buildAutomationStatus()`. `aria-hidden` na pilulke, aby text nezanášal prístupný názov tab tlačidla (issue 343 vzor).

## issue 448 — Dodávateľský sklad: zber číta efektívne odkazy (override ∪ internalNote)
`collectSupplierLinks` volá `resolveEffectiveSupplierLink` ako ostatné čítacie cesty — potvrdený odkaz z Párovania (`product_supplier_link_override`) tečie do nočného zberu okamžite, bez čakania na Shoptet round-trip.

## Testy
- #446: integračný test `activeUnpaired` (discontinued/terminal vylúčené) — RED→GREEN.
- #448: regression test override-only odkaz zahrnutý — RED→GREEN; name-only/own-shop guardy; split-links regression zelený.
- #447: unit `buildAutomationStatus`; e2e pilulky „Beží" na štyroch tab-och; aria-hidden regresia pokrytá restock exact-name e2e (lokálne 5/5 zelené).
- Lokálne: typecheck 0, lint clean, api unit 998, web unit 692. CI f00c54b: všetko zelené.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
