### PR TITLE
Nedostupné tovary: tlačidlo v stave „✓ Odoslané“ červené (.btn.bad) — issue 466

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1488,3 +1488,20 @@ paths:
   tak doložilo, že stavový filter znížil ponuku DPD z 297 na 40 (257
   terminálnych vylúčených) — presne šéfovu výhradu. Len ČÍTANIE, žiadny zápis
   na PROD bez schválenia (`no-destructive-remote-actions.md`).
+- **Appkin JEDINÝ červený BUTTON variant je `.btn.bad` (`app.css:733`,
+  `--fs-danger-bg` pozadie + `--fs-danger` text, pridaný issue 387 E6) — a je
+  DNES v žiadnom `.tsx` NEINŠTANCOVANÝ, lebo jeho pôvodné „✗ Zlé" tlačidlo bolo
+  medzitým odstránené (`PairingReviewCard.tsx` komentár, commit `f45af65`).**
+  Keď šéf inde v appke povie „daj tlačidlo červené" (issue 466 — odoslané
+  tlačidlo v Nedostupných): prepni jeho variant `ghost` → `bad`, NIKDY nezavádzaj
+  novú surovú/priesvitnú farbu (zakázané `--fs-*` token pravidlom vyššie).
+  DVE pasce: (1) `grep .btn.bad apps/web/src` dnes nič nenájde — to NEznamená, že
+  červený button token neexistuje, len že ho nikto práve nepoužíva; je to
+  DEFINOVANÝ variant vedľa `.btn.good`/`.btn.ghost`/`.btn.warn`, plnohodnotne
+  použiteľný. (2) Delete/„✕ zmazať" tlačidlá v appke sú `btn sm ghost` (SIVÉ), NIE
+  červené — takže NIE sú referenciou „červenej, ktorú používame na tlačidlách";
+  tou je práve `.btn.bad`. Varianty sa používajú VÝHRADNE vzájomne (`btn lg bad`,
+  nie `btn lg ghost bad` — stack by nechal ghostov `border-color`). Pozn.: červená
+  inde na tej istej obrazovke znamená CHYBU (BCC/mail varovania, issue 344 preto
+  pre RIADOK zvolil zelenú `--fs-success`) — pri „daj to červené" over, či to šéf
+  myslí naozaj (issue 466: myslel, výslovne zopakoval), a zdôvodnenie napíš na tiket.

--- a/.claude/rules/shoptet-writeback.md
+++ b/.claude/rules/shoptet-writeback.md
@@ -365,3 +365,33 @@ paths:
   `pairing_variant_link` PRIAMO, nie cez `products.internalNote`. Prieskum
   starej appky (`parovanie_produktov` @ f76cafa): mala `internalNote` per
   variant v exporte, takže round-trip tam fungoval — v tejto appke NIE.
+- **KAŽDÁ CSV-emitujúca write-back SELECT cesta MUSÍ filtrovať
+  `isNull(variants.missingSince)` (issue 465).** Katalógový import variant, ktorý
+  zmizol zo Shoptetu, NEMAŽE — len nastaví `variant.missing_since`. Bez tohto
+  filtra sa mŕtvy `code` aj tak pošle do CSV, reálny Shoptet import odmietne CELÚ
+  all-or-nothing dávku (`Zlyhanie variantov: 1` → `failed:1`), `run-writeback.ts`
+  pri `!outcome.ok` neoznačí NIČ ako synced → identická otrávená dávka sa vyberá
+  KAŽDÚ HODINU donekonečna (naživo: 173 zlyhaní za sebou od 13. 8.), pričom jeden
+  mŕtvy kód blokuje aj zdravé súrodenecké overridy v tej istej dávke. Diera bola
+  vo VŠETKÝCH troch cestách: produktová (`select-changes.ts`), split
+  (`select-variant-links.ts`) aj STAVOVÁ (`select-states.ts`, feature 387 E7).
+  Pri KAŽDEJ ďalšej novej write-back SELECT ceste (nový CSV zdroj) pridaj ten
+  filter hneď — je to systémová vlastnosť „Shoptet neprijme zápis pre kód, ktorý
+  už nemá", nie jednorazová oprava.
+- **Marking-set pri missing_since (issue 465, rozšírenie #423 GROUP BY logiky):**
+  produkt so VŠETKÝMI variantmi `missing_since` emituje 0 riadkov, ALE má
+  varianty → v produktovej ceste sa OZNAČÍ synced (nech necyklí donekonečna,
+  presne vzor fully-split dormant override z #423) PLUS `log.warn`
+  (`markedProductKeys`) — nikdy tichý drop, lebo do Shoptetu sa preň reálne nič
+  nezapísalo. Rozlíšenie „všetky missing" (warn+mark) od fully-split-dormant
+  (tichý mark) od „0 variantov vôbec" (skip+warn) robí druhá otázka
+  `liveVariantOverrides` (innerJoin + isNull(missingSince), selectDistinct).
+  Split a stavová cesta majú jednoduchšiu štruktúru — tam all-missing produkt
+  padne do ich existujúcej „bez variantu" vetvy (re-select 0 riadkov / skip +
+  warn, neotrávi nič), self-heal pri návrate variantu.
+- **Test poison dávky proti fixture:** globálny `setOutcome("partial")` NEvie
+  vyjadriť „dávka padne KVÔLI konkrétnemu mŕtvemu kódu". `shoptet-fixture.ts` má
+  `failImportWhenCsvContainsCode(code)` (issue 465) — import vráti `failed:1` LEN
+  keď nahrané CSV obsahuje daný `code`; keď ho oprava odfiltruje, prejde. Tak sa
+  end-to-end testom preukáže, že otrávený produkt neblokuje sync zdravého
+  súrodenca. Helper `insertTestVariantForProduct` má `missingSince?: Date|null`.

--- a/apps/web/src/components/NedostupneSection.test.tsx
+++ b/apps/web/src/components/NedostupneSection.test.tsx
@@ -195,6 +195,36 @@ it.each([
   }
 });
 
+// issue 466: tlačidlo v stave „✓ Odoslané" sa vyfarbí existujúcou červenou
+// (`.btn.bad`, appkin jediný červený button variant na tokenoch --fs-danger),
+// NEZÁVISLE pre každé z dvoch tlačidiel podľa jeho VLASTNÉHO sent flagu. Over
+// cez triedu-variant (rovnaká disciplína ako issue 344's row test vyššie —
+// `className` token, nie konkrétny hex/farba). Všetky 4 kombinácie dokazujú
+// nezávislosť oboch tlačidiel; neodoslané tlačidlo si drží pôvodný `ghost`.
+it.each([
+  { nedostupneSent: false, alternativaSent: false },
+  { nedostupneSent: true, alternativaSent: false },
+  { nedostupneSent: false, alternativaSent: true },
+  { nedostupneSent: true, alternativaSent: true },
+])("odoslané tlačidlo je červené (.btn.bad) nezávisle: nedostupneSent=$nedostupneSent, alternativaSent=$alternativaSent", async ({ nedostupneSent, alternativaSent }) => {
+  fetchNedostupneList.mockResolvedValue({
+    groups: [{ ...GROUP, orders: [{ ...GROUP.orders[0], nedostupneSent, alternativaSent }] }],
+    bccMissing: false,
+    mailNotConfigured: false,
+  });
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("nedostupne-group-40237/L");
+
+  const hasVariant = (testId: string, variant: string): boolean => screen.getByTestId(testId).className.split(/\s+/).includes(variant);
+
+  // Každé tlačidlo nesie červený variant PRÁVE keď je jeho vlastný e-mail odoslaný.
+  expect(hasVariant("nedostupne-send-17600001-40237/L", "bad")).toBe(nedostupneSent);
+  expect(hasVariant("nedostupne-alt-send-17600001-40237/L", "bad")).toBe(alternativaSent);
+  // Neodoslané tlačidlo si drží pôvodný ghost štýl — žiadna iná vizuálna zmena.
+  expect(hasVariant("nedostupne-send-17600001-40237/L", "ghost")).toBe(!nedostupneSent);
+  expect(hasVariant("nedostupne-alt-send-17600001-40237/L", "ghost")).toBe(!alternativaSent);
+});
+
 it("klik na 'náhľad' otvorí povinný náhľad PRED odoslaním — Odoslať sa ešte nevolá", async () => {
   fetchNedostupneList.mockResolvedValue(LIST_WITH_GROUP);
   fetchNedostupnePreview.mockResolvedValue({ ok: true, subject: "Informácia o dostupnosti vašej objednávky — Forestshop.sk", html: "<p>Ahoj</p>", text: "Ahoj", recipient: "jan@example.sk", customerName: "Ján Novák", previewToken: "tok-1" });

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -292,8 +292,11 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
                   // issue 344: šéf chce riadok, kde už bol odoslaný AKÝKOĽVEK
                   // z dvoch e-mailov, odlíšiť na prvý pohľad — `handled`
                   // riadi celý riadok (background + ľavý pruh, `app.css`),
-                  // nikdy len tlačidlo. Existujúci text "✓ Odoslané" na
-                  // tlačidle nižšie ostáva nezmenený ako non-color signál.
+                  // nikdy len tlačidlo (zelená `--fs-success`). issue 466: šéf
+                  // navyše chce SAMOTNÉ odoslané tlačidlo červené — každé z
+                  // dvoch tlačidiel nižšie prepne `ghost` → `bad` (appkin
+                  // červený button variant, `--fs-danger`) NEZÁVISLE podľa
+                  // svojho vlastného sent flagu; riadok tým ostáva nedotknutý.
                   const handled = order.nedostupneSent || order.alternativaSent;
                   return (
                     <div
@@ -312,7 +315,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
                         <div className="nedostupne-order-actions">
                           <button
                             type="button"
-                            className="btn lg ghost"
+                            className={`btn lg ${order.nedostupneSent ? "bad" : "ghost"}`}
                             disabled={rowBusy || order.nedostupneSent}
                             onClick={() => {
                               openPreview(order.orderCode, group.variantCode, "nedostupne");
@@ -323,7 +326,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
                           </button>
                           <button
                             type="button"
-                            className="btn lg ghost"
+                            className={`btn lg ${order.alternativaSent ? "bad" : "ghost"}`}
                             disabled={rowBusy || order.alternativaSent}
                             onClick={() => {
                               openPreview(order.orderCode, group.variantCode, "alternativa");

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4290,3 +4290,28 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
 - **#464 (Playwright kontajnerový image namiesto install+cache):** zvážené a **zamietnuté** (architecture-first + investigate-existing-first, na reálnych číslach). Zmeraný cache-HIT hot path (behy `32319785850`, `32318247998`): obnova browser cache = **4–6 s/job** (celý náklad, čo by kontajner odstránil); wall-clock ~9m30s je daný `test:integration` = **~8m55s** (reálny Chromium shoptet-writeback), ktorého sa kontajner nedotkne (~1% zisk).
 - **Prečo NIE:** CI beží 100% na GitHub-hosted `ubuntu-latest` (efemérny, žiadny perzistentný docker layer cache) — kontajner (~1.5–2 GB) by sa sťahoval nanovo na oboch joboch každý beh → nahradí 4–6s obnovu cache väčším pull-om (net pomalšie). + nová ručná väzba image-tag ↔ rozlíšená Playwright verzia (`^1.49.0`→1.62.0, dnes sa kľúč odvodí za behu) + cross-cutting prestavba `services.postgres` siete (`DATABASE_URL`→`postgres:5432`). Freeze trieda už vyriešená #460/#462, posledné 3 behy stabilné 8m55s–9m40s.
 - **Znovu otvoriť LEN ak** CI prejde na self-hosted runner s perzistentným docker layer cache (obráti pull-cost), alebo browser-cache začne opakovane zlyhávať (časté MISS → 10-min install timeouty). Žiadna zmena kódu; `ci.md` doplnené o rozhodovaciu poznámku. Validácia + rozhodnutie durabilne na #464 (2 komentáre). Bez PR/merge/deploy — dev ostáva 0.3.0-dev.272.
+
+## 2026-08-20 — #465 (Spätný zápis odkazov: zmiznuté varianty otravujú dávku)
+
+- Solo bug ticket. STEP 0 overené read-only na prod: `job_run` link.failed:1
+  173 behov za sebou, 2wolfs FOREST 5 živých `62696/*` + 5 missing `15813/*`,
+  LunaVision zaseknutý od 17.8.
+- Version bump `1269463` (0.3.0-dev.272→.273), prvý commit.
+- Design komentár PRED kódom (root cause → missing_since sa nefiltruje →
+  Prístup 1 filter zvolený, Prístup 2 karanténa / Prístup 3 per-riadok parse
+  zamietnuté): issue #465 comment 5357125846.
+- RED→GREEN: link cesta `11b9473`[red]→`5f35bec`[green]
+  (`shoptet-writeback-select` P465/P465ALL, `-select-variant-links` P6,
+  `-run` POISON/HEALTHY); stavová cesta `192d353`[red]→`9668cc1`[green]
+  (`-select-states` P465S — review nález, tá istá missing_since diera v
+  `select-states.ts`, opravená v tom istom PR podľa #311).
+- Kľúčová oprava: `isNull(variants.missingSince)` v `select-changes.ts`,
+  `select-variant-links.ts` aj `select-states.ts`; all-missing produkt sa
+  označí synced + warn (`liveVariantOverrides` selectDistinct). Fixture
+  `failImportWhenCsvContainsCode` imituje reálne Shoptet `failed:1` na kóde.
+- PR #467 dev→main, merge `431207a`, main CI + Deploy zelené, nasadené
+  `0.3.0-dev.273`.
+- Post-deploy akceptácia (prvý beh na novom kóde 15:50:20 UTC): link.status
+  ok, rowCount 6 (z 11), oba overridy synced_at 15:50:20, 0 zaseknutých.
+  Ticket ostáva OTVORENÝ na ručné zatvorenie po review dôkazu (post-deploy
+  akceptačná podmienka).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.273",
+  "version": "0.3.0-dev.274",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Obrazovka Nedostupné tovary: po odoslaní e-mailu sa tlačidlo („✓ Odoslané“) vyfarbí existujúcou červenou (`.btn.bad` token, `--fs-danger`). Každé tlačidlo nezávisle podľa vlastného sent stavu; riadok nedotknutý.

RED `6c49338`, GREEN `8cc6eb1`, playbook `81bb033`.

Ticket issue 466 ostáva otvorený do naživo overenia po nasadení.
