### PR TITLE
Podpora viacerých Google kalendárov na karte Upozornenia (issue 469)

### DIFF
--- a/.claude/rules/calendar.md
+++ b/.claude/rules/calendar.md
@@ -83,6 +83,45 @@ paths:
   tickete v tomto module: rovnaký vzor (funkcia dostane `limit` parameter,
   vráti pole, `.slice(0, limit)` na konci), nie duplicitná druhá funkcia
   vedľa pôvodnej.
+- **Issue 469 (majiteľ chce udalosti zo VŠETKÝCH kalendárov účtu, nie len z
+  jedného): `GOOGLE_CALENDAR_ICS_URL` prijme VIAC adries oddelených čiarkou
+  alebo novým riadkom → `readonly string[] | undefined` (spätne kompatibilné s
+  jednou adresou = 1-prvkové pole).** Zmena je `env.ts` transform (nie
+  `z.string().url()`, ktoré by zoznam odmietlo): `.optional().transform((raw,
+  ctx) => …)` — split na `[,\n]`, trim, vynechať prázdne, validovať KAŽDÚ
+  položku cez `z.string().url().safeParse`, pri neplatnej `ctx.addIssue({code:
+  z.ZodIssueCode.custom, …}) + return z.NEVER`. **Chybová hláška transformu
+  NIKDY neinterpoluje adresu** (tajný token je v ceste — vzor „secret in path"
+  vyššie platí aj tu; test to overuje: `not.toMatch(/basic\.ics/)`). `index.ts`
+  mapuje každú adresu na vlastný `createHttpIcsFetcher(url)` a odovzdá
+  `readonly IcsFetcher[]` do `createNextEventService`. **Kým sa do
+  `docker-compose.prod.yml` premietne, over ako pri každej env premennej
+  (`.claude/rules/deploy.md`) — tu ale `GOOGLE_CALENDAR_ICS_URL` už MÁ riadok v
+  compose (od #309), takže zmena hodnoty na viac-adresovú ide len cez
+  `/srv/forestshop/.env`, žiadny nový compose riadok netreba.**
+  - **Merge-then-group invariant (jadro #469):** `next-event.ts` sa rozdelilo
+    na `collectUpcomingCandidates(icsText, now): Candidate[]` (per kalendár:
+    BEGIN:VCALENDAR check + parse + expand + filter „ešte neskončila", BEZ
+    sortu/grupovania) a `groupByDay(candidates, now, dayLimit)` (sort podľa
+    začiatku + doterajšie zoskupenie po dňoch). `resolveNextEventsFromCalendars
+    (icsTexts[], now, dayLimit)` = `flatMap(collectUpcomingCandidates)` →
+    `groupByDay`. Kandidáti sa teda ZLÚČIA zo všetkých kalendárov, zoradia a AŽ
+    POTOM zoskupia po dňoch — nikdy per-kalendár-then-concat. Keby sa
+    zoskupilo per-kalendár a zreťazilo, deň s udalosťami z dvoch kalendárov by
+    sa do `NEXT_EVENT_DAYS_LIMIT` započítal DVAKRÁT a poradie by nesedelo. Test,
+    ktorý to ROZLIŠUJE: dayLimit 1, kalendár A má 10.+11.8., kalendár B má 11.8.
+    → merge-then-group vráti len 10.8. (`["A 10.8."]`), per-kalendár-concat by
+    dalo `["A 10.8.","B 11.8."]`. `resolveNextEvents(icsText,…)` ostáva ako
+    tenký obal `resolveNextEventsFromCalendars([icsText],…)`, takže všetkých 35
+    pôvodných testov platí bezo zmeny logiky.
+  - **One-fails-all honesty doktrína žije v service, nie vo wiring vrstve:**
+    `createNextEventService` stiahne fetchery cez `Promise.all` — jeden z N
+    zlyhá → celý `refresh` odmietne → `ok:false` (nikdy čiastočný pohľad, ktorý
+    by ticho skryl kalendár — presne problém z #469). Preto pole fetcherov
+    (`readonly IcsFetcher[]`), nie „kombinovaný fetcher `() => Promise<string[]>`"
+    postavený v `index.ts` — druhá voľba by presunula honesty-kritické správanie
+    mimo unit-testovaného service. Cache/TTL/in-flight dedup bez zmeny (drží
+    ZLÚČENÝ výsledok). Web karta (`NextCalendarEventCard.tsx`) sa NEMENÍ.
 - **Issue 439 (majiteľ chce 3 najbližšie DNI s udalosťami, nie 3 udalosti):
   `NEXT_EVENTS_LIMIT` → `NEXT_EVENT_DAYS_LIMIT`, parameter `limit` →
   `dayLimit`. Záverečné `.slice(0, limit)` (prvých N udalostí) sa nahradilo

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { loadEnv } from "./env.js";
+
+// issue 469: `GOOGLE_CALENDAR_ICS_URL` prijme VIAC tajných iCal adries oddelených
+// čiarkou alebo novým riadkom (spätne kompatibilné s jednou adresou). Každá
+// položka sa validuje ako URL; chybová hláška NIKDY neobsahuje samotnú adresu
+// (tajný token je v ceste — `.claude/rules/calendar.md`). Testy používajú
+// výhradne falošné `.invalid` adresy, nikdy skutočnú Google adresu.
+const BASE = { DATABASE_URL: "postgres://u:p@localhost:5432/db" } as NodeJS.ProcessEnv;
+
+describe("loadEnv — GOOGLE_CALENDAR_ICS_URL viac adries (issue 469)", () => {
+  it("nenastavená premenná → undefined (karta sa nezobrazí, fail-graceful)", () => {
+    expect(loadEnv({ ...BASE }).GOOGLE_CALENDAR_ICS_URL).toBeUndefined();
+  });
+
+  it("jedna URL → 1-prvkové pole (spätná kompatibilita)", () => {
+    const env = loadEnv({ ...BASE, GOOGLE_CALENDAR_ICS_URL: "https://cal.example.invalid/private-a/basic.ics" });
+    expect(env.GOOGLE_CALENDAR_ICS_URL).toEqual(["https://cal.example.invalid/private-a/basic.ics"]);
+  });
+
+  it("viac URL oddelených čiarkou → pole všetkých", () => {
+    const env = loadEnv({
+      ...BASE,
+      GOOGLE_CALENDAR_ICS_URL: "https://cal.example.invalid/a/basic.ics,https://cal.example.invalid/b/basic.ics",
+    });
+    expect(env.GOOGLE_CALENDAR_ICS_URL).toEqual([
+      "https://cal.example.invalid/a/basic.ics",
+      "https://cal.example.invalid/b/basic.ics",
+    ]);
+  });
+
+  it("viac URL oddelených novým riadkom (a s okolitými medzerami) → pole orezaných URL", () => {
+    const env = loadEnv({
+      ...BASE,
+      GOOGLE_CALENDAR_ICS_URL: " https://cal.example.invalid/a/basic.ics \n https://cal.example.invalid/b/basic.ics ",
+    });
+    expect(env.GOOGLE_CALENDAR_ICS_URL).toEqual([
+      "https://cal.example.invalid/a/basic.ics",
+      "https://cal.example.invalid/b/basic.ics",
+    ]);
+  });
+
+  it("neplatná položka → loadEnv nahlas zlyhá a chybová hláška NEOBSAHUJE žiadnu adresu", () => {
+    let message = "";
+    try {
+      loadEnv({
+        ...BASE,
+        GOOGLE_CALENDAR_ICS_URL: "https://cal.example.invalid/a/basic.ics,nie-je-url-tajne-xyz",
+      });
+      throw new Error("malo zlyhať, ale nezlyhalo");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toMatch(/GOOGLE_CALENDAR_ICS_URL/);
+    // Tajná adresa (ani jej cesta) sa do hlášky nikdy nevypíše.
+    expect(message).not.toMatch(/nie-je-url-tajne-xyz/);
+    expect(message).not.toMatch(/basic\.ics/);
+  });
+});

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -117,22 +117,28 @@ const envSchema = z.object({
   //
   // issue 469: prijme VIAC adries oddelených čiarkou alebo novým riadkom
   // (spätne kompatibilné s jednou adresou → 1-prvkové pole). Každá položka sa
-  // validuje ako URL; whitespace okolo sa oreže, prázdne položky sa vynechajú.
-  // Chybová hláška pri neplatnej adrese NIKDY neinterpoluje samotnú adresu
-  // (tajný token je v ceste — `.claude/rules/calendar.md`). Výsledný typ je
-  // `readonly string[] | undefined`.
+  // validuje ako URL; whitespace okolo sa oreže, prázdne aj duplicitné položky
+  // sa vynechajú (duplikát by inak stiahol ten istý kalendár dvakrát a
+  // zdvojil udalosti na karte). Chybová hláška pri neplatnej adrese NIKDY
+  // neinterpoluje samotnú adresu (tajný token je v ceste —
+  // `.claude/rules/calendar.md`). Výsledný typ je `string[] | undefined`.
   GOOGLE_CALENDAR_ICS_URL: z
     .string()
     .optional()
     .transform((raw, ctx) => {
       if (raw === undefined) return undefined;
-      const urls = raw
-        .split(/[,\n]/)
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
+      const urlSchema = z.string().url();
+      const urls = [
+        ...new Set(
+          raw
+            .split(/[,\n]/)
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0),
+        ),
+      ];
       if (urls.length === 0) return undefined;
       for (const url of urls) {
-        if (!z.string().url().safeParse(url).success) {
+        if (!urlSchema.safeParse(url).success) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: "GOOGLE_CALENDAR_ICS_URL obsahuje neplatnú URL adresu (tajná adresa sa do hlášky zámerne nevypisuje)",

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -107,14 +107,41 @@ const envSchema = z.object({
   // ostáva konfigurovateľná (rovnaký princíp ako `SHOPTET_ADMIN_BASE_URL`),
   // pre prípad zmeny adresy alebo testovacieho prostredia DPD.
   DPD_PORTAL_BASE_URL: z.string().url().default("https://www.dpdshipper.sk"),
-  // issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho
-  // Google kalendára. Tajná iCal adresa (nie API kľúč/OAuth token — pozri
-  // návrhový komentár na tickete): NESIE tajný token PRIAMO V CESTE (na
+  // issue 309/469: "Eshop → Upozornenia" — najbližšie udalosti z majiteľových
+  // Google kalendárov. Tajné iCal adresy (nie API kľúč/OAuth token — pozri
+  // návrhový komentár na tickete): NESÚ tajný token PRIAMO V CESTE (na
   // rozdiel od SHOPTET_EXPORT_URL, kde je tajomstvom len `hash` query
   // parameter), nikdy do repa/commit správy/logu. Nepovinná: bez nej appka
   // beží ďalej, karta sa na nástenke jednoducho nezobrazí (rovnaký fail-
   // graceful princíp ako SHOPTET_EXPORT_URL).
-  GOOGLE_CALENDAR_ICS_URL: z.string().url().optional(),
+  //
+  // issue 469: prijme VIAC adries oddelených čiarkou alebo novým riadkom
+  // (spätne kompatibilné s jednou adresou → 1-prvkové pole). Každá položka sa
+  // validuje ako URL; whitespace okolo sa oreže, prázdne položky sa vynechajú.
+  // Chybová hláška pri neplatnej adrese NIKDY neinterpoluje samotnú adresu
+  // (tajný token je v ceste — `.claude/rules/calendar.md`). Výsledný typ je
+  // `readonly string[] | undefined`.
+  GOOGLE_CALENDAR_ICS_URL: z
+    .string()
+    .optional()
+    .transform((raw, ctx) => {
+      if (raw === undefined) return undefined;
+      const urls = raw
+        .split(/[,\n]/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (urls.length === 0) return undefined;
+      for (const url of urls) {
+        if (!z.string().url().safeParse(url).success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "GOOGLE_CALENDAR_ICS_URL obsahuje neplatnú URL adresu (tajná adresa sa do hlášky zámerne nevypisuje)",
+          });
+          return z.NEVER;
+        }
+      }
+      return urls;
+    }),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -246,12 +246,14 @@ const dpdDeps = {
   config: dpdUser === undefined || dpdPassword === undefined ? undefined : dpdPortalConfigFromBaseUrl(env.DPD_PORTAL_BASE_URL, dpdUser, dpdPassword),
 };
 
-// issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho Google
-// kalendára. `GOOGLE_CALENDAR_ICS_URL` je nepovinná (env.ts) — bez nej appka
-// beží ďalej, karta na nástenke sa jednoducho nezobrazí (`http/app.ts`'s
-// `nextEvent === undefined` vetva).
-const googleCalendarIcsUrl = env.GOOGLE_CALENDAR_ICS_URL;
-const nextEventService = googleCalendarIcsUrl === undefined ? undefined : createNextEventService(createHttpIcsFetcher(googleCalendarIcsUrl));
+// issue 309/469: "Eshop → Upozornenia" — najbližšie udalosti z majiteľových
+// Google kalendárov. `GOOGLE_CALENDAR_ICS_URL` je nepovinná (env.ts) — bez nej
+// appka beží ďalej, karta na nástenke sa jednoducho nezobrazí (`http/app.ts`'s
+// `nextEvent === undefined` vetva). issue 469: premenná môže obsahovať VIAC
+// adries (env.ts ich už rozdelí na pole) — jeden bounded fetcher per adresa.
+const googleCalendarIcsUrls = env.GOOGLE_CALENDAR_ICS_URL;
+const nextEventService =
+  googleCalendarIcsUrls === undefined ? undefined : createNextEventService(googleCalendarIcsUrls.map((url) => createHttpIcsFetcher(url)));
 
 // issue 319: chýbajúci kľúč tu (na rozdiel od `postaUncollected`/
 // `orderReminder`/`nedostupne`/`orderMerge`/`dpd` nižšie) nechával

--- a/apps/api/src/modules/calendar/next-event.test.ts
+++ b/apps/api/src/modules/calendar/next-event.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveNextEvents } from "./next-event.js";
+import { resolveNextEvents, resolveNextEventsFromCalendars } from "./next-event.js";
 
 // issue 309: čisté testy nad ICS textom — ŽIADNY test v tomto module (ani v
 // tomto súbore) sa NIKDY nepripája na skutočný Google, presne rovnaká
@@ -392,5 +392,70 @@ describe("resolveNextEvents — limit (issue 382)", () => {
   it("`limit: 1` sa správa rovnako ako pôvodná singulárna funkcia (prvý prvok poľa)", () => {
     const result = resolveNextEvents(threeFutureEvents(), NOW, 1);
     expect(result).toEqual([{ title: "Prvá", dateLabel: "nedeľa 9. 8.", allDay: false }]);
+  });
+});
+
+// issue 469: majiteľ chce vidieť udalosti zo VŠETKÝCH kalendárov účtu, nie len z
+// jedného. `resolveNextEventsFromCalendars` zlúči kandidátov z viacerých ICS
+// textov do JEDNÉHO zoznamu, zoradí podľa začiatku a AŽ POTOM zoskupí po dňoch —
+// nikdy per-kalendár-then-concat (to by deň s udalosťami z dvoch kalendárov
+// započítalo do limitu dní dvakrát a poradie by nesedelo).
+describe("resolveNextEventsFromCalendars — zlúčenie viacerých kalendárov (issue 469)", () => {
+  function evt(uid: string, summary: string, startLocal: string, endLocal: string): readonly string[] {
+    return [
+      "BEGIN:VEVENT",
+      `UID:${uid}@test`,
+      "DTSTAMP:20260101T000000Z",
+      `SUMMARY:${summary}`,
+      `DTSTART;TZID=Europe/Bratislava:${startLocal}`,
+      `DTEND;TZID=Europe/Bratislava:${endLocal}`,
+      "END:VEVENT",
+    ];
+  }
+
+  it("udalosti z DVOCH kalendárov sa zlúčia a zoradia podľa začiatku (interleave), nie zreťazené per-kalendár", () => {
+    // Kalendár A má 9. a 12. 8., kalendár B má 10. a 11. 8.
+    const calA = ics([
+      ...evt("a1", "A 9.8.", "20260809T090000", "20260809T100000"),
+      ...evt("a2", "A 12.8.", "20260812T090000", "20260812T100000"),
+    ]);
+    const calB = ics([
+      ...evt("b1", "B 10.8.", "20260810T090000", "20260810T100000"),
+      ...evt("b2", "B 11.8.", "20260811T090000", "20260811T100000"),
+    ]);
+    const result = resolveNextEventsFromCalendars([calA, calB], NOW, 4);
+    // Zlúčené+zoradené: 9, 10, 11, 12. (Per-kalendár-then-concat by dalo 9,12,10,11.)
+    expect(result.map((e) => e.title)).toEqual(["A 9.8.", "B 10.8.", "B 11.8.", "A 12.8."]);
+  });
+
+  it("dayLimit počíta DNI naprieč ZLÚČENÝM zoznamom — deň prvého kalendára minie limit aj pre druhý", () => {
+    // Kalendár A: 10. a 11. 8.  Kalendár B: 11. 8.  dayLimit 1 → len 10. 8. (jeden deň).
+    const calA = ics([
+      ...evt("a1", "A 10.8.", "20260810T090000", "20260810T100000"),
+      ...evt("a2", "A 11.8.", "20260811T090000", "20260811T100000"),
+    ]);
+    const calB = ics([...evt("b1", "B 11.8.", "20260811T110000", "20260811T120000")]);
+    const result = resolveNextEventsFromCalendars([calA, calB], NOW, 1);
+    // merge-then-group (dayLimit 1) → len prvý deň 10. 8. → ["A 10.8."].
+    // per-kalendár-then-concat by dalo ["A 10.8.", "B 11.8."] (každý kalendár svoj prvý deň).
+    expect(result.map((e) => e.title)).toEqual(["A 10.8."]);
+  });
+
+  it("deň s udalosťami z DVOCH kalendárov je JEDEN spoločný slot dňa, zoradený v rámci dňa", () => {
+    const calA = ics([...evt("a1", "A 10.8. ráno", "20260810T080000", "20260810T090000")]);
+    const calB = ics([...evt("b1", "B 10.8. večer", "20260810T180000", "20260810T190000")]);
+    const result = resolveNextEventsFromCalendars([calA, calB], NOW, 3);
+    expect(result.map((e) => e.title)).toEqual(["A 10.8. ráno", "B 10.8. večer"]);
+    expect(result.every((e) => e.dateLabel === "pondelok 10. 8.")).toBe(true);
+  });
+
+  it("jeden kalendár v poli sa správa presne ako resolveNextEvents (spätná kompatibilita)", () => {
+    const cal = ics([...evt("c1", "Jediná", "20260810T090000", "20260810T100000")]);
+    expect(resolveNextEventsFromCalendars([cal], NOW, 3)).toEqual(resolveNextEvents(cal, NOW, 3));
+  });
+
+  it("pokazený feed v KTOROMKOĽVEK kalendári nahlas zlyhá (fail-loud, čiastočný pohľad sa neskrýva)", () => {
+    const good = ics([...evt("g1", "Dobrá", "20260810T090000", "20260810T100000")]);
+    expect(() => resolveNextEventsFromCalendars([good, "toto nie je ICS vôbec"], NOW, 3)).toThrow(/BEGIN:VCALENDAR/);
   });
 });

--- a/apps/api/src/modules/calendar/next-event.test.ts
+++ b/apps/api/src/modules/calendar/next-event.test.ts
@@ -449,9 +449,9 @@ describe("resolveNextEventsFromCalendars — zlúčenie viacerých kalendárov (
     expect(result.every((e) => e.dateLabel === "pondelok 10. 8.")).toBe(true);
   });
 
-  it("jeden kalendár v poli sa správa presne ako resolveNextEvents (spätná kompatibilita)", () => {
+  it("jeden kalendár v poli vráti presne udalosti toho kalendára (spätná kompatibilita)", () => {
     const cal = ics([...evt("c1", "Jediná", "20260810T090000", "20260810T100000")]);
-    expect(resolveNextEventsFromCalendars([cal], NOW, 3)).toEqual(resolveNextEvents(cal, NOW, 3));
+    expect(resolveNextEventsFromCalendars([cal], NOW, 3)).toEqual([{ title: "Jediná", dateLabel: "pondelok 10. 8.", allDay: false }]);
   });
 
   it("pokazený feed v KTOROMKOĽVEK kalendári nahlas zlyhá (fail-loud, čiastočný pohľad sa neskrýva)", () => {

--- a/apps/api/src/modules/calendar/next-event.ts
+++ b/apps/api/src/modules/calendar/next-event.ts
@@ -60,19 +60,23 @@ function hasNotEnded(candidate: Candidate, now: Date): boolean {
 }
 
 /**
+ * Vyzbiera „ešte neskončené" kandidátske udalosti z JEDNÉHO ICS textu (parse +
+ * expanzia opakujúcich sa + filter). Zoradenie ani zoskupenie po dňoch tu NIE
+ * je — to sa robí AŽ nad ZLÚČENÝM zoznamom z viacerých kalendárov
+ * (`resolveNextEventsFromCalendars`), aby deň s udalosťami z dvoch kalendárov
+ * nebol započítaný do limitu dní dvakrát (issue 469).
+ *
  * `ical.sync.parseICS` NIKDY nehodí výnimku, ani na úplne nezmyselný vstup —
  * overené priamo (node-ical 0.27.1, prázdny aj náhodný text obidva vrátia
  * `{}`). Appka preto potrebuje VLASTNÚ minimálnu kontrolu "vyzerá to vôbec
  * ako kalendár" — inak by pokazený/nekalendárový feed (napr. HTML chybová
  * stránka vrátená s HTTP 200) ticho vyzeral ako "žiadna nadchádzajúca
  * udalosť" namiesto toho, aby nahlas zlyhal (dispatch: "Fetch failure /
- * malformed feed → fail loud, never crash, never show raw error").
- *
- * issue 382 → 439: `dayLimit` rozhoduje koľko najbližších DNÍ, v ktorých je
- * aspoň jedna udalosť, sa vráti — a pre KAŽDÝ taký deň VŠETKY jeho udalosti
- * (zoradené podľa najskoršieho začiatku). Nie počet udalostí.
+ * malformed feed → fail loud, never crash, never show raw error"). Pri viac
+ * kalendároch platí per adresu: pokazený feed KTORÉHOKOĽVEK kalendára zhodí
+ * celý výsledok na chybu, nikdy neskryje čiastočný pohľad (issue 469).
  */
-export function resolveNextEvents(icsText: string, now: Date, dayLimit: number): NextCalendarEvent[] {
+function collectUpcomingCandidates(icsText: string, now: Date): Candidate[] {
   if (!icsText.includes("BEGIN:VCALENDAR")) {
     throw new Error("Stiahnutý obsah nevyzerá ako platný ICS kalendár (chýba BEGIN:VCALENDAR)");
   }
@@ -97,27 +101,43 @@ export function resolveNextEvents(icsText: string, now: Date, dayLimit: number):
     }
   }
 
-  const upcoming = candidates.filter((c) => hasNotEnded(c, now)).sort((a, b) => a.start.getTime() - b.start.getTime());
+  return candidates.filter((c) => hasNotEnded(c, now));
+}
 
-  // issue 439: `dayLimit` počíta DNI, v ktorých je aspoň jedna udalosť, nie
-  // udalosti. Zoskupenie kľúčom kalendárneho dňa v Europe/Bratislava
-  // (`zonedDateKey`) — rovnaké pásmo ako `formatDateLabel`/`hasNotEnded`, takže
-  // sedí s vypísaným `dateLabel` a je stabilné voči proces-TZ pri celodenných
-  // (`VALUE=DATE`) udalostiach (`.claude/rules/calendar.md`). Iterujeme len cez
-  // udalosti, takže dni bez udalosti do skupiny nikdy nevstúpia — preskočia sa
-  // a NEMINÚ `dayLimit`. `continue` (nie `break`) pri dni nad limitom je
-  // robustné aj voči teoretickému preplietaniu udalostí rôznych dní: ďalšie
-  // udalosti UŽ započítaných dní sa stále pridajú. Prebiehajúca viacdňová
-  // udalosť (začala pred dneškom, ešte neskončila) sa zoskupí pod svoj
-  // ZAČIATOČNÝ deň — konzistentné s doterajším zobrazovaním takej udalosti jej
-  // začiatočným dátumom.
+/**
+ * Zoradí ZLÚČENÝ zoznam kandidátov (naprieč všetkými kalendármi) podľa začiatku
+ * a zoskupí po kalendárnych dňoch.
+ *
+ * issue 439: `dayLimit` počíta DNI, v ktorých je aspoň jedna udalosť, nie
+ * udalosti. Zoskupenie kľúčom kalendárneho dňa v Europe/Bratislava
+ * (`zonedDateKey`) — rovnaké pásmo ako `formatDateLabel`/`hasNotEnded`, takže
+ * sedí s vypísaným `dateLabel` a je stabilné voči proces-TZ pri celodenných
+ * (`VALUE=DATE`) udalostiach (`.claude/rules/calendar.md`). Iterujeme len cez
+ * udalosti, takže dni bez udalosti do skupiny nikdy nevstúpia — preskočia sa
+ * a NEMINÚ `dayLimit`. `continue` (nie `break`) pri dni nad limitom je
+ * robustné aj voči teoretickému preplietaniu udalostí rôznych dní: ďalšie
+ * udalosti UŽ započítaných dní sa stále pridajú. Prebiehajúca viacdňová
+ * udalosť (začala pred dneškom, ešte neskončila) sa zoskupí pod svoj
+ * ZAČIATOČNÝ deň — konzistentné s doterajším zobrazovaním takej udalosti jej
+ * začiatočným dátumom.
+ *
+ * issue 469: zoradenie aj zoskupenie sa robí AŽ TU, nad zlúčenými kandidátmi zo
+ * VŠETKÝCH kalendárov — nie per-kalendár-then-concat. Keby sa deň zoskupil
+ * osobitne pre každý kalendár a výsledky sa len zreťazili, deň, v ktorom majú
+ * udalosť dva kalendáre, by sa do limitu dní započítal dvakrát a poradie by
+ * nesedelo. `Array.prototype.sort` je stabilný (ES2019+), takže udalosti s
+ * rovnakým začiatkom si držia poradie vloženia (poradie kalendárov).
+ */
+function groupByDay(upcoming: readonly Candidate[], now: Date, dayLimit: number): NextCalendarEvent[] {
+  const sorted = [...upcoming].sort((a, b) => a.start.getTime() - b.start.getTime());
+
   const includedDayKeys = new Set<string>();
   const result: NextCalendarEvent[] = [];
   // issue 442: rok dneška (Europe/Bratislava) sa počíta RAZ pred slučkou —
   // `now` je naprieč všetkými udalosťami nemenné, `formatDateLabel` len
   // porovná rok výskytu proti nemu.
   const nowYear = getZonedDateParts(now).year;
-  for (const candidate of upcoming) {
+  for (const candidate of sorted) {
     const dayKey = zonedDateKey(candidate.start);
     if (!includedDayKeys.has(dayKey)) {
       if (includedDayKeys.size >= dayLimit) continue;
@@ -126,4 +146,29 @@ export function resolveNextEvents(icsText: string, now: Date, dayLimit: number):
     result.push({ title: candidate.title, dateLabel: formatDateLabel(candidate.start, nowYear), allDay: candidate.allDay });
   }
   return result;
+}
+
+/**
+ * Najbližšie udalosti z JEDNÉHO ICS textu — tenký obal nad
+ * `resolveNextEventsFromCalendars([icsText], …)`. Zachovaný ako pôvodné API pre
+ * jedno-kalendárové testy/volania.
+ *
+ * `dayLimit` rozhoduje koľko najbližších DNÍ, v ktorých je aspoň jedna udalosť,
+ * sa vráti — a pre KAŽDÝ taký deň VŠETKY jeho udalosti (zoradené podľa
+ * najskoršieho začiatku). Nie počet udalostí (issue 382 → 439).
+ */
+export function resolveNextEvents(icsText: string, now: Date, dayLimit: number): NextCalendarEvent[] {
+  return resolveNextEventsFromCalendars([icsText], now, dayLimit);
+}
+
+/**
+ * issue 469: najbližšie udalosti zo VIAC kalendárov naraz. Kandidáti sa
+ * vyzbierajú z KAŽDÉHO ICS textu, ZLÚČIA do jedného zoznamu, zoradia podľa
+ * začiatku a AŽ POTOM zoskupia po dňoch (`dayLimit`). Pokazený feed
+ * ktoréhokoľvek kalendára nahlas zlyhá (fail-loud) — čiastočný pohľad, ktorý by
+ * ticho skryl jeden kalendár, je presne problém z tohto ticketu.
+ */
+export function resolveNextEventsFromCalendars(icsTexts: readonly string[], now: Date, dayLimit: number): NextCalendarEvent[] {
+  const candidates = icsTexts.flatMap((icsText) => collectUpcomingCandidates(icsText, now));
+  return groupByDay(candidates, now, dayLimit);
 }

--- a/apps/api/src/modules/calendar/service.test.ts
+++ b/apps/api/src/modules/calendar/service.test.ts
@@ -8,7 +8,7 @@ const NOW = new Date("2026-08-08T10:00:00Z");
 describe("createNextEventService — cache", () => {
   it("druhé volanie v TTL okne NEVOLÁ fetchIcs znova (cache hit)", async () => {
     const fetchIcs = vi.fn().mockResolvedValue(ICS);
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     await service.getNextEvent(NOW);
     await service.getNextEvent(new Date(NOW.getTime() + 1000));
     expect(fetchIcs).toHaveBeenCalledTimes(1);
@@ -16,7 +16,7 @@ describe("createNextEventService — cache", () => {
 
   it("volanie PO uplynutí úspešnej TTL znova zavolá fetchIcs", async () => {
     const fetchIcs = vi.fn().mockResolvedValue(ICS);
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     await service.getNextEvent(NOW);
     await service.getNextEvent(new Date(NOW.getTime() + NEXT_EVENT_OK_CACHE_TTL_MS + 1));
     expect(fetchIcs).toHaveBeenCalledTimes(2);
@@ -24,7 +24,7 @@ describe("createNextEventService — cache", () => {
 
   it("zlyhanie fetchu vráti { ok: false }, NIKDY nehodí výnimku ďalej", async () => {
     const fetchIcs = vi.fn().mockRejectedValue(new Error("simulovaný výpadok"));
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     await expect(service.getNextEvent(NOW)).resolves.toEqual({ ok: false });
   });
 
@@ -58,7 +58,7 @@ describe("createNextEventService — cache", () => {
       "END:VCALENDAR",
     ].join("\r\n");
     const fetchIcs = vi.fn().mockResolvedValue(ics);
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     const result = await service.getNextEvent(NOW);
     expect(result.ok).toBe(true);
     expect(result.ok && result.events.map((e) => e.title)).toEqual(["Prvá", "Druhá", "Tretia"]);
@@ -66,7 +66,7 @@ describe("createNextEventService — cache", () => {
 
   it("zlyhanie sa cachuje LEN na kratšiu error TTL — po jej uplynutí appka skúsi znova", async () => {
     const fetchIcs = vi.fn().mockRejectedValueOnce(new Error("výpadok")).mockResolvedValueOnce(ICS);
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     await service.getNextEvent(NOW);
     // Ešte v error TTL okne — nemá skúšať znova.
     await service.getNextEvent(new Date(NOW.getTime() + NEXT_EVENT_ERROR_CACHE_TTL_MS - 1));
@@ -79,7 +79,7 @@ describe("createNextEventService — cache", () => {
 
   it("úspešné-ale-prázdne (žiadna udalosť) sa cachuje ako úspešný výsledok, nie ako chyba", async () => {
     const fetchIcs = vi.fn().mockResolvedValue(ICS);
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     const result = await service.getNextEvent(NOW);
     expect(result).toEqual({ ok: true, events: [] });
   });
@@ -93,11 +93,55 @@ describe("createNextEventService — cache", () => {
         resolveFetch = resolve;
       }),
     );
-    const service = createNextEventService(fetchIcs);
+    const service = createNextEventService([fetchIcs]);
     const first = service.getNextEvent(NOW);
     const second = service.getNextEvent(NOW);
     resolveFetch(ICS);
     await Promise.all([first, second]);
     expect(fetchIcs).toHaveBeenCalledTimes(1);
+  });
+
+  // issue 469: karta číta VIAC kalendárov — service dostane pole fetcherov,
+  // stiahne ich paralelne a zlúči udalosti do jedného poľa.
+  it("viac kalendárov — udalosti zo VŠETKÝCH sa zlúčia a zoradia podľa začiatku (issue 469)", async () => {
+    const icsA = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VEVENT",
+      "UID:a1@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Kalendár A",
+      "DTSTART;TZID=Europe/Bratislava:20260809T090000",
+      "DTEND;TZID=Europe/Bratislava:20260809T100000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const icsB = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VEVENT",
+      "UID:b1@test",
+      "DTSTAMP:20260101T000000Z",
+      "SUMMARY:Kalendár B",
+      "DTSTART;TZID=Europe/Bratislava:20260810T090000",
+      "DTEND;TZID=Europe/Bratislava:20260810T100000",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const fetchA = vi.fn().mockResolvedValue(icsA);
+    const fetchB = vi.fn().mockResolvedValue(icsB);
+    const service = createNextEventService([fetchA, fetchB]);
+    const result = await service.getNextEvent(NOW);
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.events.map((e) => e.title)).toEqual(["Kalendár A", "Kalendár B"]);
+    expect(fetchA).toHaveBeenCalledTimes(1);
+    expect(fetchB).toHaveBeenCalledTimes(1);
+  });
+
+  it("keď JEDEN z viacerých kalendárov zlyhá, celý výsledok je ok:false — nikdy čiastočný pohľad (issue 469)", async () => {
+    const ok = vi.fn().mockResolvedValue(ICS);
+    const fail = vi.fn().mockRejectedValue(new Error("výpadok jedného kalendára"));
+    const service = createNextEventService([ok, fail]);
+    await expect(service.getNextEvent(NOW)).resolves.toEqual({ ok: false });
   });
 });

--- a/apps/api/src/modules/calendar/service.ts
+++ b/apps/api/src/modules/calendar/service.ts
@@ -8,7 +8,7 @@
 
 import { log } from "../../logger.js";
 import type { IcsFetcher } from "./fetcher.js";
-import { resolveNextEvents, type NextCalendarEvent } from "./next-event.js";
+import { resolveNextEventsFromCalendars, type NextCalendarEvent } from "./next-event.js";
 import { NEXT_EVENT_DAYS_LIMIT, NEXT_EVENT_ERROR_CACHE_TTL_MS, NEXT_EVENT_OK_CACHE_TTL_MS } from "./constants.js";
 
 // issue 382 → 439: pole namiesto singulárnej udalosti — majiteľ chce
@@ -25,7 +25,12 @@ interface CacheEntry {
   readonly ttlMs: number;
 }
 
-export function createNextEventService(fetchIcs: IcsFetcher): NextEventService {
+// issue 469: pole fetcherov (jeden per tajná ICS adresa). Service stiahne
+// VŠETKY paralelne a zlúči udalosti; keď ktorýkoľvek zlyhá, celý výsledok je
+// `ok:false` — nikdy čiastočný pohľad, ktorý by ticho skryl jeden kalendár
+// (presne problém z tohto ticketu). Jedna adresa = 1-prvkové pole (spätná
+// kompatibilita).
+export function createNextEventService(fetchers: readonly IcsFetcher[]): NextEventService {
   let cache: CacheEntry | undefined;
   // Zdieľaný prísľub pre súbežné volania POČAS jedného fetchu — appka má
   // dnes jediného čitateľa, ale je to lacná poistka proti zbytočnému
@@ -35,8 +40,10 @@ export function createNextEventService(fetchIcs: IcsFetcher): NextEventService {
 
   async function refresh(now: Date): Promise<CacheEntry> {
     try {
-      const icsText = await fetchIcs();
-      const events = resolveNextEvents(icsText, now, NEXT_EVENT_DAYS_LIMIT);
+      // `Promise.all` stiahne všetky kalendáre naraz a odmietne (→ catch nižšie
+      // → ok:false), len čo ktorýkoľvek jeden zlyhá — honesty doktrína modulu.
+      const icsTexts = await Promise.all(fetchers.map((fetchIcs) => fetchIcs()));
+      const events = resolveNextEventsFromCalendars(icsTexts, now, NEXT_EVENT_DAYS_LIMIT);
       return { result: { ok: true, events }, cachedAtMs: now.getTime(), ttlMs: NEXT_EVENT_OK_CACHE_TTL_MS };
     } catch (error) {
       const rawErrorMessage = error instanceof Error ? error.message : String(error);

--- a/apps/api/tests/calendar-http.integration.test.ts
+++ b/apps/api/tests/calendar-http.integration.test.ts
@@ -70,7 +70,7 @@ it("bez dodanej nextEvent service vráti configured:false, žiadny fetch sa nevo
 // issue 382: majiteľ chce TRI najbližšie udalosti — trasa vracia pole
 // `events`, nie singulárnu `event` hodnotu.
 it("s nakonfigurovanou service vráti najbližšie udalosti z (falošne) stiahnutého ICS", async () => {
-  const service = createNextEventService(() => Promise.resolve(icsWithEventTomorrow()));
+  const service = createNextEventService([() => Promise.resolve(icsWithEventTomorrow())]);
   const { app, cookie } = await boot(service);
   const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
   expect(res.status).toBe(200);
@@ -83,7 +83,7 @@ it("s nakonfigurovanou service vráti najbližšie udalosti z (falošne) stiahnu
 });
 
 it("keď fetch zlyhá, appka vráti error:true, nikdy surovú chybu ani pád", async () => {
-  const service = createNextEventService(() => Promise.reject(new Error("simulovaný sieťový výpadok")));
+  const service = createNextEventService([() => Promise.reject(new Error("simulovaný sieťový výpadok"))]);
   const { app, cookie } = await boot(service);
   const res = await app.request("/api/upozornenia/next-event", { headers: { cookie } });
   expect(res.status).toBe(200);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.274",
+  "version": "0.3.0-dev.275",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Podpora viacerých Google kalendárov na karte Upozornenia (issue 469)

Karta „najbližšie udalosti" čítala len JEDEN kalendár (`GOOGLE_CALENDAR_ICS_URL`
bola jedna adresa). Štěpánov účet má viac kalendárov (FORESTSHOP, RODINA, ZBOR…)
a udalosti z nich sa vôbec nezobrazovali. Toto PR pridáva podporu viacerých ICS
adries.

### Čo sa zmenilo
- **`env.ts`** — `GOOGLE_CALENDAR_ICS_URL` prijme VIAC adries oddelených čiarkou
  alebo novým riadkom → `string[] | undefined` (spätne kompatibilné s jednou
  adresou = 1-prvkové pole). Každá položka sa validuje ako URL, duplikáty a
  prázdne položky sa vynechajú; chybová hláška NIKDY neinterpoluje adresu (tajný
  token je v ceste).
- **`next-event.ts`** — refaktor na `collectUpcomingCandidates` (per kalendár) +
  `groupByDay` (nad zlúčeným zoznamom); nová `resolveNextEventsFromCalendars`
  zlúči kandidátov zo VŠETKÝCH kalendárov → zoradí → zoskupí po dňoch
  (merge-then-group, nie per-kalendár-then-concat). `resolveNextEvents` ostáva
  tenký obal pre 1 kalendár, takže 35 pôvodných testov platí bezo zmeny logiky.
- **`service.ts`** — `createNextEventService` berie pole fetcherov, stiahne ich
  paralelne (`Promise.all`); keď JEDEN zlyhá, celý výsledok je `ok:false` (žiadny
  čiastočný pohľad). Cache/TTL/in-flight dedup bez zmeny.
- **`index.ts`** — každá adresa → vlastný bounded `createHttpIcsFetcher`.
- **Web karta sa NEMENÍ** — viac kalendárov = viac kandidátov, rovnaký formát
  riadku (zákaz svojvoľných zmien vzhľadu).

### Testy
- RED pred GREEN: env parsing (viac/jedna/neplatná adresa), zlúčenie+zoradenie
  naprieč kalendármi (interleave), merge-then-group vs per-kalendár-concat
  rozlišujúci test, jeden z N zlyhá → error. `gates:local` zelené (api 1010, web
  709 testov), CI zelené (version-check, integration, e2e, check, docker-build).

### Ostáva otvorené (bez zatváracieho kľúčového slova — ticket NEZATVÁRAŤ)
Kódová časť je hotová. Naživo overenie s viacerými kalendármi + zatvorenie
ticketu prídu AŽ po tom, čo Štěpán dodá tajné iCal adresy ostatných kalendárov
(vyžiadané v Discorde) — tie sa pridajú do `/srv/forestshop/.env` a appka sa
reštartne. Preto tu zámerne NIE JE riadok na automatické zatvorenie — issue 469
ostáva otvorená.
