### PR TITLE
Emoji picker do Úloh na dnes — do textu aj označenie riadku (issue 471)

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -114,6 +114,31 @@ paths:
   poistku: transient CDN/apt hang teraz zlyhá AUTOMATICKY červeno pri 10 min
   namiesto ~19 min visenia (žiadny continue-on-error), takže cancel+rerun postup
   vyššie je stále platný, ale spúšťa sa sám a len pri MISS.
+- **Syntaktická chyba v `src/**/*.test.tsx` (unit test) padne AJ `check` AJ
+  `docker-build`, ale `e2e` NIE — a `pnpm gates:local` ju lokálne prehliadne, ak
+  je oprava len v pracovnom strome a nie zakomitovaná.** Issue 471 (stálo to
+  jeden CI cyklus): slovenská úvodzovka v názve testu (`„…"` s rovnou zatváracou
+  úvodzovkou) predčasne ukončila reťazec → `TS1002`. `check` job beží `pnpm
+  typecheck` (`tsc -b`) a `docker-build` beží `pnpm --filter web build`
+  (`tsc -b && vite build`) — OBA `tsc -b` zbierajú aj `src/**/*.test.tsx` (sú v
+  `apps/web/tsconfig`'s include), takže syntaktická chyba v unit teste zhodí AJ
+  produkčný build, nielen typecheck. `e2e` job (`playwright test`) beží LEN
+  `tests/e2e/**` cez vite/esbuild dev server, ktorý `src` test súbory NIKDY
+  neparsuje → `e2e` prejde ZELENÝ pri rozbitom `src` teste (presne tak to vyzeralo:
+  `e2e`/`version-check` ✓, `check`/`docker-build` ✗). **Druhá polovica pasce:**
+  `pnpm gates:local` (aj `pnpm typecheck`) beží proti PRACOVNÉMU STROMU — ak opravu
+  syntaxe spravíš Editom, ale zabudneš `git add` ten súbor (napr. commituješ skupinu
+  súborov, ktorá ho vynechá), lokálny gate prejde ZELENÝ, kým committed/pushnutá
+  verzia ostane rozbitá a CI padne. **Pred pushom vždy `git status --short`** — a keď
+  commituješ explicitný zoznam súborov (`git add a b c`), over, že medzi nimi je aj
+  súbor, ktorý si práve opravil. Slovenské úvodzovky vo VNÚTRI JS reťazcového
+  literálu (názvy testov) rovno nepoužívaj — buď plain text bez úvodzoviek, alebo
+  správna zatváracia `"` (U+201C), nikdy rovná `"`.
+- **CI logy padnutého jobu sa dajú prečítať EŠTE PRED dokončením celého behu cez
+  REST API** (`gh run view --log`/`--log-failed` odmietne „run still in progress",
+  kým beží iný job): `gh api repos/<owner>/<repo>/actions/jobs/<job_id>/logs
+  --allow-escape-sequences | sed 's/\x1b\[[0-9;]*m//g' | grep -inE "error|fail|TS[0-9]"`.
+  Job ID: `gh run view <run> --json jobs --jq '.jobs[]|select(.conclusion=="failure")|.databaseId'`.
 - **Reálny-Chromium integračné testy majú per-`it` strop `TEST_TIMEOUT_MS =
   120_000` (issue 460), NIE 60 s.** Súbory `shoptet-writeback-run/-playwright/
   -sequence`, `dpd-pickup-playwright`, `dpd-shipment-playwright`,

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -144,7 +144,7 @@ it("riadok: jedným klikom na emoji v pickeri sa emoji uloží (updateDailyTaskE
 });
 
 // issue 471: voľba „bez emoji" v pickeri odstráni emoji riadku (null).
-it("riadok: voľba „bez emoji" odstráni emoji úlohy (updateDailyTaskEmoji null)", async () => {
+it("riadok: voľba bez emoji odstráni emoji úlohy (updateDailyTaskEmoji null)", async () => {
   fetchDailyTasks.mockResolvedValueOnce([ROW_B]).mockResolvedValueOnce([{ ...ROW_B, emoji: null }]);
   updateDailyTaskEmoji.mockResolvedValueOnce(true);
   render(<DailyTasksSection onSessionExpired={vi.fn()} />);
@@ -268,14 +268,22 @@ it("pri 401 POČAS mutácie (nielen počiatočného načítania) tiež zavolá o
   });
 });
 
-// issue 471: otvorenie textového editora (✏️) nesmie ovplyvniť emoji picker
-// riadku — sú to dve nezávislé ovládania (picker je popover, nie inline editor).
-it("otvorenie textového editora nechá riadkový emoji picker prítomný a funkčný", async () => {
+// issue 471: v edit režime sa riadkové akcie (vrátane riadkového PICK pickera)
+// schovajú a namiesto nich je pri textovom poli INSERT picker na vloženie emoji
+// DO textu — nie sú to teda dva pickery naraz, ale prepnutie z označenia riadku
+// na vkladanie do textu.
+it("edit režim ukáže text-insert picker a schová riadkový pick picker", async () => {
   fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
   render(<DailyTasksSection onSessionExpired={vi.fn()} />);
   await screen.findByTestId("uloha-row-task-a");
 
-  // V edit režime je pri textovom poli picker na vloženie emoji DO textu.
+  // Pred úpravou: riadkový pick picker je prítomný, text-insert picker nie.
+  expect(screen.getByTestId("uloha-emoji-task-a")).toBeTruthy();
+  expect(screen.queryByTestId("uloha-edit-emoji-task-a")).toBeNull();
+
   fireEvent.click(screen.getByTestId("uloha-edit-task-a"));
+
+  // V edit režime: text-insert picker je, riadkový pick picker sa schoval.
   expect(screen.getByTestId("uloha-edit-emoji-task-a")).toBeTruthy();
+  expect(screen.queryByTestId("uloha-emoji-task-a")).toBeNull();
 });

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { DailyTasksSection } from "./DailyTasksSection.js";
 
@@ -90,19 +90,71 @@ it("upraví text úlohy cez inline ✏️ toggle", async () => {
   });
 });
 
-it("pridá emoji cez inline 😊 toggle", async () => {
-  fetchDailyTasks.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([{ ...ROW_A, emoji: "🚚" }]);
+// issue 471: emoji do TEXTU novej úlohy cez zdieľaný EmojiPickerButton (insert
+// na pozíciu kurzora — presne ako Poznámky/440).
+it("nový vstup: emoji z pickera sa vloží do textu novej úlohy", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("ulohy-empty");
+
+  const input = screen.getByTestId<HTMLInputElement>("uloha-new-input");
+  fireEvent.change(input, { target: { value: "poslať" } });
+  fireEvent.click(screen.getByTestId("uloha-new-emoji"));
+  fireEvent.click(within(screen.getByTestId("uloha-new-emoji-popover")).getByRole("button", { name: "Vložiť 🚀" }));
+
+  await waitFor(() => {
+    expect(input.value).toContain("🚀");
+  });
+});
+
+// issue 471: emoji do TEXTU aj v inline edit režime.
+it("edit editor: emoji z pickera sa vloží do upravovaného textu", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-a");
+
+  fireEvent.click(screen.getByTestId("uloha-edit-task-a"));
+  const editInput = screen.getByTestId<HTMLInputElement>("uloha-edit-input-task-a");
+  fireEvent.change(editInput, { target: { value: "poslať DPD" } });
+  fireEvent.click(screen.getByTestId("uloha-edit-emoji-task-a"));
+  fireEvent.click(within(screen.getByTestId("uloha-edit-emoji-task-a-popover")).getByRole("button", { name: "Vložiť 🚚" }));
+
+  await waitFor(() => {
+    expect(editInput.value).toContain("🚚");
+  });
+});
+
+// issue 471: označenie CELÉHO riadku emojkou — klik na 😊 otvorí picker,
+// JEDNÝM klikom na emoji sa emoji rovno uloží (žiadne textové pole + Uložiť).
+it("riadok: jedným klikom na emoji v pickeri sa emoji uloží (updateDailyTaskEmoji)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_A]).mockResolvedValueOnce([{ ...ROW_A, emoji: "🚀" }]);
   updateDailyTaskEmoji.mockResolvedValueOnce(true);
   render(<DailyTasksSection onSessionExpired={vi.fn()} />);
   await screen.findByTestId("uloha-row-task-a");
 
   fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  const emojiInput = screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a");
-  fireEvent.change(emojiInput, { target: { value: "🚚" } });
-  fireEvent.click(screen.getByTestId("uloha-emoji-save-task-a"));
+  fireEvent.click(within(screen.getByTestId("uloha-emoji-task-a-popover")).getByRole("button", { name: "Vložiť 🚀" }));
 
   await waitFor(() => {
-    expect(updateDailyTaskEmoji).toHaveBeenCalledWith("task-a", "🚚");
+    expect(updateDailyTaskEmoji).toHaveBeenCalledWith("task-a", "🚀");
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("uloha-emoji-cell-task-a").textContent).toBe("🚀");
+  });
+});
+
+// issue 471: voľba „bez emoji" v pickeri odstráni emoji riadku (null).
+it("riadok: voľba „bez emoji" odstráni emoji úlohy (updateDailyTaskEmoji null)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_B]).mockResolvedValueOnce([{ ...ROW_B, emoji: null }]);
+  updateDailyTaskEmoji.mockResolvedValueOnce(true);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("uloha-row-task-b");
+
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-b"));
+  fireEvent.click(screen.getByTestId("uloha-emoji-task-b-clear"));
+
+  await waitFor(() => {
+    expect(updateDailyTaskEmoji).toHaveBeenCalledWith("task-b", null);
   });
 });
 
@@ -216,90 +268,14 @@ it("pri 401 POČAS mutácie (nielen počiatočného načítania) tiež zavolá o
   });
 });
 
-// Issue 381 (majiteľ: "to emoji čo si môžeš priradiť na úlohy na dnes tam
-// chcem mať ale sa správa hrozne") — naživo reprodukované na produkcii
-// (komentár na ticket-e): rozpísaný emoji draft sa ticho stratí pri
-// prepnutí na iný riadok, chýba Zrušiť, textový aj emoji editor sa dajú
-// mať otvorené súčasne na tom istom riadku.
-
-it("draft rozpísaného emoji PREŽIJE prepnutie na iný riadok a späť (bez uloženia)", async () => {
-  fetchDailyTasks.mockResolvedValue([ROW_B, ROW_A]);
-  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
-  await screen.findByTestId("uloha-row-task-a");
-
-  // Otvor emoji editor riadku A, rozpíš draft, NEULOŽ.
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  fireEvent.change(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a"), { target: { value: "🎯" } });
-
-  // Appka dovolí len JEDEN otvorený naraz — otvorenie iného riadku ticho
-  // "zavrie" prvý.
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-b"));
-  expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
-
-  // Zavri riadok B (Zrušiť, bez uloženia) a znova otvor riadok A — draft
-  // 🎯 musí byť STÁLE tam, appka ho nesmie zahodiť len preto, že si sa
-  // pozrel na iný riadok.
-  fireEvent.click(screen.getByTestId("uloha-emoji-cancel-task-b"));
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  expect(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a").value).toBe("🎯");
-});
-
-it("Zrušiť v emoji editore ho zavrie BEZ uloženia a zahodí draft (ďalšie otvorenie ukáže znova serverovú hodnotu)", async () => {
+// issue 471: otvorenie textového editora (✏️) nesmie ovplyvniť emoji picker
+// riadku — sú to dve nezávislé ovládania (picker je popover, nie inline editor).
+it("otvorenie textového editora nechá riadkový emoji picker prítomný a funkčný", async () => {
   fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
   render(<DailyTasksSection onSessionExpired={vi.fn()} />);
   await screen.findByTestId("uloha-row-task-a");
 
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  fireEvent.change(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a"), { target: { value: "🚚" } });
-  fireEvent.click(screen.getByTestId("uloha-emoji-cancel-task-a"));
-
-  expect(updateDailyTaskEmoji).not.toHaveBeenCalled();
-  expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
-
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  expect(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a").value).toBe("");
-});
-
-it("otvorenie textového editora zavrie emoji editor TOHO ISTÉHO riadku (nikdy oba naraz)", async () => {
-  fetchDailyTasks.mockResolvedValueOnce([ROW_A]);
-  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
-  await screen.findByTestId("uloha-row-task-a");
-
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  expect(screen.getByTestId("uloha-emoji-input-task-a")).toBeTruthy();
-
+  // V edit režime je pri textovom poli picker na vloženie emoji DO textu.
   fireEvent.click(screen.getByTestId("uloha-edit-task-a"));
-  expect(screen.queryByTestId("uloha-emoji-input-task-a")).toBeNull();
-  expect(screen.getByTestId("uloha-edit-input-task-a")).toBeTruthy();
-});
-
-// Nezávislý review dispatch (issue 381 PR) našiel doplnkový race: Zrušiť
-// nebolo chránené proti bežiacemu uloženiu TOHO ISTÉHO riadku — kliknutie
-// Zrušiť počas čakajúcej odpovede, znovu-otvorenie a nový rozpis by stále
-// mohli byť zahodené, keď PÔVODNÁ (už zrušená) odpoveď dorazí neskôr.
-it("Zrušiť je disabled, kým čaká uloženie TOHO ISTÉHO riadku (nedá sa obísť rozbehnuté uloženie)", async () => {
-  fetchDailyTasks.mockResolvedValue([ROW_A]);
-  let resolveSave: (v: boolean) => void = () => {};
-  updateDailyTaskEmoji.mockImplementationOnce(
-    () =>
-      new Promise<boolean>((resolve) => {
-        resolveSave = resolve;
-      }),
-  );
-  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
-  await screen.findByTestId("uloha-row-task-a");
-
-  fireEvent.click(screen.getByTestId("uloha-emoji-task-a"));
-  fireEvent.change(screen.getByTestId<HTMLInputElement>("uloha-emoji-input-task-a"), { target: { value: "🚚" } });
-  fireEvent.click(screen.getByTestId("uloha-emoji-save-task-a"));
-
-  // Odpoveď ešte NEDORAZILA — Zrušiť musí byť disabled, presne ako Uložiť.
-  expect(screen.getByTestId<HTMLButtonElement>("uloha-emoji-cancel-task-a").disabled).toBe(true);
-  fireEvent.click(screen.getByTestId("uloha-emoji-cancel-task-a"));
-  expect(screen.getByTestId("uloha-emoji-input-task-a")).toBeTruthy();
-
-  resolveSave(true);
-  await waitFor(() => {
-    expect(updateDailyTaskEmoji).toHaveBeenCalledWith("task-a", "🚚");
-  });
+  expect(screen.getByTestId("uloha-edit-emoji-task-a")).toBeTruthy();
 });

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -376,6 +376,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                         showClear
                         align="right"
                         label={`Pridať/zmeniť emoji úlohy ${row.text}`}
+                        title="Pridať/zmeniť emoji"
                         testId={`uloha-emoji-${row.id}`}
                         disabled={busy}
                       />

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -9,6 +9,7 @@ import {
   updateDailyTaskText,
   type DailyTaskRow,
 } from "../dailyTasksApi.js";
+import { EmojiPickerButton } from "./EmojiPickerButton.js";
 
 // issue 342: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané do
 // Discord kanála #úlohy-na-dnes. Na rozdiel od zvyšku appky (viď
@@ -32,24 +33,17 @@ import {
 //    ustálený vzor ako `.ord-supplier-link-edit`, issue 162) zníži ju na
 //    ~338px bez zmeny riadkovej výšky.
 // 2) Prepínač "vybavené" je teraz skutočný `<input type="checkbox">`
-//    namiesto `<button>`u s Unicode ☐/☑ — jediné miesto v appke, kde hlavný
-//    ovládací prvok obrazovky bol len text namiesto skutočného UI prvku
-//    (OrderLineRow.tsx/UpozorneniaSection.tsx/DpdSection.tsx majú všade
-//    skutočný checkbox — CSS špecificitu proti globálnemu resetu, pozri
-//    app.css, si však rieši výslovne len OrderLineRow.tsx's
-//    `.order-group input[type="checkbox"]`, viď fix nižšie).
-// 3) `.uloha-row`'s `align-items` je `flex-start` namiesto `center` — pri
-//    zalomení textu na užšom okne (viac riadkov) drží checkbox/ikony pri
-//    PRVOM riadku textu namiesto stredu celého zalomeného bloku.
+//    namiesto `<button>`u s Unicode ☐/☑.
+// 3) `.uloha-row`'s `align-items` je `flex-start` namiesto `center`.
 
-// Issue 381: odstráni draft PRE JEDEN riadok z `emojiDraft` bez `delete`
-// operátora (`@typescript-eslint/no-dynamic-delete` zakazuje `delete
-// next[dynamickýKľúč]`) — filtrovanie cez `Object.entries` je funkčne
-// rovnaké, len lint-safe.
-function forgetEmojiDraft(draft: Record<string, string>, id: string): Record<string, string> {
-  if (!(id in draft)) return draft;
-  return Object.fromEntries(Object.entries(draft).filter(([key]) => key !== id));
-}
+// issue 471: emoji picker (zdieľaný `EmojiPickerButton`, issue 440) je zapojený
+// na DVE miesta:
+//  - INSERT do TEXTU úlohy (nový vstup aj inline edit) — vloženie na kurzor,
+//    presne ako Poznámky/Upozornenia.
+//  - PICK na označenie CELÉHO riadku — klik na 😊 otvorí picker a JEDNÝM klikom
+//    sa emoji rovno uloží (`PATCH …/emoji`); voľba „bez emoji" ho odstráni.
+//    Nahradilo pôvodný medzikrok s textovým poľom + Uložiť (issue 342/381),
+//    ktorý Štěpán opísal ako nepoužiteľný.
 
 export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpired: () => void }): JSX.Element {
   const [rows, setRows] = useState<readonly DailyTaskRow[] | null>(null);
@@ -59,20 +53,22 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
   const [creating, setCreating] = useState(false);
   const [editingTextId, setEditingTextId] = useState<string | null>(null);
   const [textDraft, setTextDraft] = useState<Record<string, string>>({});
-  const [editingEmojiId, setEditingEmojiId] = useState<string | null>(null);
-  const [emojiDraft, setEmojiDraft] = useState<Record<string, string>>({});
+
+  // issue 471: emoji picker vkladá na pozíciu kurzora týchto polí. Nový vstup má
+  // vlastný ref; inline edit má JEDEN zdieľaný ref — appka dovolí najviac jeden
+  // riadok v editácii textu naraz, takže je namountované vždy najviac jedno pole.
+  const newTextRef = useRef<HTMLInputElement>(null);
+  const editTextRef = useRef<HTMLInputElement>(null);
 
   // Code review (rovnaký nález ako issue 251's `SupplierLinksSection.tsx`/
-  // `PairingSection.tsx`): `saveText`/`saveEmoji`'s `.then()` musí vedieť,
-  // KTORÝ riadok je PRÁVE editovaný V OKAMIHU, keď odpoveď doletí — nie ten,
-  // čo bol editovaný v momente kliknutia na Uložiť. Bez tohto by uloženie
-  // riadku A (ešte čakajúce na odpoveď) mohlo zavrieť editor riadku B,
-  // otvorený medzitým. "Latest ref" vzor — synchrónne priamo v tele
-  // komponentu, nie cez `useEffect`.
+  // `PairingSection.tsx`): `saveText`'s `.then()` musí vedieť, KTORÝ riadok je
+  // PRÁVE editovaný V OKAMIHU, keď odpoveď doletí — nie ten, čo bol editovaný
+  // v momente kliknutia na Uložiť. Bez tohto by uloženie riadku A (ešte
+  // čakajúce na odpoveď) mohlo zavrieť editor riadku B, otvorený medzitým.
+  // "Latest ref" vzor — synchrónne priamo v tele komponentu, nie cez
+  // `useEffect`.
   const editingTextIdRef = useRef(editingTextId);
   editingTextIdRef.current = editingTextId;
-  const editingEmojiIdRef = useRef(editingEmojiId);
-  editingEmojiIdRef.current = editingEmojiId;
 
   const load = useCallback(() => {
     fetchDailyTasks()
@@ -169,20 +165,15 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
     [textDraft, load, handleActionError],
   );
 
-  const saveEmoji = useCallback(
-    (id: string) => {
-      const emoji = (emojiDraft[id] ?? "").trim();
+  // issue 471: jednoklikové označenie riadku — picker zavolá toto priamo s
+  // vybraným emoji (alebo `null` pri voľbe „bez emoji"). Žiadny draft ani
+  // medzikrokové textové pole; picker si popover zatvorí sám.
+  const saveRowEmoji = useCallback(
+    (id: string, emoji: string | null) => {
       setBusyId(id);
       setError("");
-      updateDailyTaskEmoji(id, emoji === "" ? null : emoji)
+      updateDailyTaskEmoji(id, emoji)
         .then(() => {
-          // Rovnaký dôvod ako `saveText` vyššie — nezavrieť CUDZÍ, medzitým
-          // otvorený emoji editor.
-          if (editingEmojiIdRef.current === id) setEditingEmojiId(null);
-          // Issue 381: draft je teraz uložený, zahoď ho — ĎALŠIE otvorenie
-          // musí znova nasadiť čerstvú serverovú hodnotu, nie tento (už
-          // uložený, prípadne časom zastaraný) záznam.
-          setEmojiDraft((d) => forgetEmojiDraft(d, id));
           load();
         })
         .catch((err: unknown) => {
@@ -192,41 +183,12 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
           setBusyId("");
         });
     },
-    [emojiDraft, load, handleActionError],
+    [load, handleActionError],
   );
-
-  // Issue 381: majiteľ nahlásil, že priraďovanie emoji "sa správa hrozne" —
-  // naživo overené (komentár na ticket-e): (1) rozpísaný draft sa ticho
-  // stratí pri prepnutí na iný riadok, (2) chýba Zrušiť, (3) textový aj
-  // emoji editor sa dajú mať otvorené súčasne na tom istom riadku. Tri
-  // opravy nižšie, minimálne, správanie funkcie samotnej nemenia.
-
-  // Draft sa nasadí len keď PRE TENTO riadok ešte neexistuje (prvé
-  // otvorenie od posledného uloženia/zrušenia) — nie bezpodmienečne pri
-  // KAŽDOM kliknutí. Vďaka tomu draft prežije prepnutie na iný riadok a
-  // späť namiesto toho, aby ho každé ďalšie otvorenie ticho prepísalo
-  // serverovou hodnotou.
-  const openEmojiEditor = useCallback((row: DailyTaskRow) => {
-    setEmojiDraft((d) => (row.id in d ? d : { ...d, [row.id]: row.emoji ?? "" }));
-    // Textový a emoji editor sa nesmú dať mať otvorené súčasne na tom
-    // istom riadku (viedlo to k dvom identickým 💾 tlačidlám vedľa seba).
-    setEditingTextId((current) => (current === row.id ? null : current));
-    setEditingEmojiId(row.id);
-  }, []);
 
   const openTextEditor = useCallback((row: DailyTaskRow) => {
     setTextDraft((d) => ({ ...d, [row.id]: row.text }));
-    setEditingEmojiId((current) => (current === row.id ? null : current));
     setEditingTextId(row.id);
-  }, []);
-
-  // Explicitné Zrušiť pre emoji editor (textový editor už jedno má) —
-  // predtým bol jediný spôsob odchodu Uložiť, aj s prázdnou/nechcenou
-  // hodnotou. Draft sa zahodí, aby ďalšie otvorenie ukázalo znova
-  // serverovú hodnotu, nie tento zrušený pokus.
-  const cancelEmojiEdit = useCallback((id: string) => {
-    setEditingEmojiId((current) => (current === id ? null : current));
-    setEmojiDraft((d) => forgetEmojiDraft(d, id));
   }, []);
 
   const removeTask = useCallback(
@@ -252,6 +214,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
   const addRow = (
     <div className="ulohy-add-row">
       <input
+        ref={newTextRef}
         value={newText}
         onChange={(e) => {
           setNewText(e.target.value);
@@ -267,6 +230,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
         data-testid="uloha-new-input"
         disabled={creating}
       />
+      <EmojiPickerButton targetRef={newTextRef} value={newText} onChange={setNewText} testId="uloha-new-emoji" disabled={creating} />
       <button type="button" className="btn good sm" onClick={addTask} disabled={newText.trim() === "" || creating} data-testid="uloha-new-add">
         + Pridať
       </button>
@@ -325,8 +289,8 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                     data-testid={`uloha-done-${row.id}`}
                   />
 
-                  {row.emoji !== null && editingEmojiId !== row.id && (
-                    <span className="uloha-emoji" aria-hidden="true">
+                  {row.emoji !== null && (
+                    <span className="uloha-emoji" data-testid={`uloha-emoji-cell-${row.id}`} aria-hidden="true">
                       {row.emoji}
                     </span>
                   )}
@@ -334,6 +298,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                   {editingTextId === row.id ? (
                     <>
                       <input
+                        ref={editTextRef}
                         className="uloha-edit-input"
                         value={textDraft[row.id] ?? row.text}
                         onChange={(e) => {
@@ -343,6 +308,16 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                         aria-label="Upraviť text úlohy"
                         data-testid={`uloha-edit-input-${row.id}`}
                         autoFocus
+                      />
+                      {/* issue 471: emoji DO textu aj v edit režime (insert na kurzor). */}
+                      <EmojiPickerButton
+                        targetRef={editTextRef}
+                        value={textDraft[row.id] ?? row.text}
+                        onChange={(v) => {
+                          setTextDraft((d) => ({ ...d, [row.id]: v }));
+                        }}
+                        testId={`uloha-edit-emoji-${row.id}`}
+                        disabled={busy}
                       />
                       <button
                         type="button"
@@ -375,55 +350,6 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                     </span>
                   )}
 
-                  {editingEmojiId === row.id && (
-                    <>
-                      <input
-                        className="uloha-emoji-input-field"
-                        value={emojiDraft[row.id] ?? row.emoji ?? ""}
-                        onChange={(e) => {
-                          const value = e.target.value;
-                          setEmojiDraft((d) => ({ ...d, [row.id]: value }));
-                        }}
-                        aria-label="Emoji úlohy"
-                        placeholder="😊"
-                        data-testid={`uloha-emoji-input-${row.id}`}
-                        autoFocus
-                      />
-                      <button
-                        type="button"
-                        className="uloha-icon-btn"
-                        disabled={busy}
-                        onClick={() => {
-                          saveEmoji(row.id);
-                        }}
-                        title="Uložiť emoji"
-                        aria-label="Uložiť emoji"
-                        data-testid={`uloha-emoji-save-${row.id}`}
-                      >
-                        💾
-                      </button>
-                      {/* Review dispatch (issue 381): bez `disabled={busy}` by Zrušiť
-                          počas ROZBEHNUTÉHO uloženia TOHO ISTÉHO riadku otvorilo
-                          okno na race — zrušenie + nový rozpis medzitým a
-                          následné doručenie PÔVODNEJ (už "zrušenej") odpovede
-                          by ten nový rozpis ticho zahodilo cez `saveEmoji`'s
-                          `forgetEmojiDraft`. Rovnaký `busy` guard ako má Save. */}
-                      <button
-                        type="button"
-                        className="uloha-icon-btn"
-                        disabled={busy}
-                        onClick={() => {
-                          cancelEmojiEdit(row.id);
-                        }}
-                        title="Zrušiť"
-                        aria-label="Zrušiť úpravu emoji"
-                        data-testid={`uloha-emoji-cancel-${row.id}`}
-                      >
-                        ✕
-                      </button>
-                    </>
-                  )}
-
                   {editingTextId !== row.id && (
                     <div className="uloha-actions">
                       <button
@@ -438,20 +364,21 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                       >
                         ✏️
                       </button>
-                      {editingEmojiId !== row.id && (
-                        <button
-                          type="button"
-                          className="uloha-icon-btn"
-                          onClick={() => {
-                            openEmojiEditor(row);
-                          }}
-                          title="Pridať/zmeniť emoji"
-                          aria-label={`Pridať/zmeniť emoji úlohy ${row.text}`}
-                          data-testid={`uloha-emoji-${row.id}`}
-                        >
-                          😊
-                        </button>
-                      )}
+                      {/* issue 471: 😊 otvorí picker, JEDNÝM klikom uloží emoji k úlohe
+                          (`saveRowEmoji`); voľba „bez emoji" ho odstráni. `align="right"`
+                          ukotví popover k pravému okraju (picker je pri pravom okraji
+                          panela). Vzhľad prepínača je CSS-scopnutý na `.uloha-icon-btn`
+                          (`app.css`), takže hustota riadku ostáva rovnaká (issue 471). */}
+                      <EmojiPickerButton
+                        onPick={(emoji) => {
+                          saveRowEmoji(row.id, emoji);
+                        }}
+                        showClear
+                        align="right"
+                        label={`Pridať/zmeniť emoji úlohy ${row.text}`}
+                        testId={`uloha-emoji-${row.id}`}
+                        disabled={busy}
+                      />
                       <button
                         type="button"
                         className="uloha-icon-btn"

--- a/apps/web/src/components/EmojiPickerButton.test.tsx
+++ b/apps/web/src/components/EmojiPickerButton.test.tsx
@@ -144,7 +144,7 @@ describe("EmojiPickerButton — pick režim (issue 471)", () => {
     expect(screen.queryByTestId("pick-popover")).toBeNull();
   });
 
-  it("voľba „bez emoji" zavolá onPick(null) a zavrie popover", () => {
+  it("voľba bez emoji zavolá onPick(null) a zavrie popover", () => {
     const picked: (string | null)[] = [];
     render(
       <EmojiPickerButton
@@ -166,7 +166,7 @@ describe("EmojiPickerButton — pick režim (issue 471)", () => {
     expect(screen.getByRole("button", { name: "Pridať/zmeniť emoji" })).toBeDefined();
   });
 
-  it("bez showClear sa voľba „bez emoji" nezobrazí", () => {
+  it("bez showClear sa voľba bez emoji nezobrazí", () => {
     render(<EmojiPickerButton testId="pick" onPick={() => {}} />);
     fireEvent.click(screen.getByTestId("pick"));
     expect(screen.queryByTestId("pick-clear")).toBeNull();

--- a/apps/web/src/components/EmojiPickerButton.test.tsx
+++ b/apps/web/src/components/EmojiPickerButton.test.tsx
@@ -119,6 +119,68 @@ describe("EmojiPickerButton — vloženie použije živú DOM hodnotu, nie zaost
   });
 });
 
+// issue 471: „pick" režim — klik na emoji rovno zavolá `onPick(emoji)` (bez
+// vkladania do poľa), voľba „bez emoji" zavolá `onPick(null)`. Ten istý zdieľaný
+// popover + zoznam ako insert režim (Úlohy na dnes ho použijú na jednoklikové
+// označenie celého riadku).
+describe("EmojiPickerButton — pick režim (issue 471)", () => {
+  it("klik na emoji zavolá onPick(emoji) a zavrie popover", () => {
+    const picked: (string | null)[] = [];
+    render(
+      <EmojiPickerButton
+        testId="pick"
+        onPick={(e) => {
+          picked.push(e);
+        }}
+        showClear
+        label="Pridať/zmeniť emoji"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("pick"));
+    expect(screen.getByTestId("pick-popover")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Vložiť 🚀" }));
+    expect(picked).toEqual(["🚀"]);
+    // Po výbere sa popover ZAVRIE — jeden klik = hotovo.
+    expect(screen.queryByTestId("pick-popover")).toBeNull();
+  });
+
+  it("voľba „bez emoji" zavolá onPick(null) a zavrie popover", () => {
+    const picked: (string | null)[] = [];
+    render(
+      <EmojiPickerButton
+        testId="pick"
+        onPick={(e) => {
+          picked.push(e);
+        }}
+        showClear
+      />,
+    );
+    fireEvent.click(screen.getByTestId("pick"));
+    fireEvent.click(screen.getByTestId("pick-clear"));
+    expect(picked).toEqual([null]);
+    expect(screen.queryByTestId("pick-popover")).toBeNull();
+  });
+
+  it("prepínač nesie zadaný label (aria-label + title)", () => {
+    render(<EmojiPickerButton testId="pick" onPick={() => {}} label="Pridať/zmeniť emoji" />);
+    expect(screen.getByRole("button", { name: "Pridať/zmeniť emoji" })).toBeDefined();
+  });
+
+  it("bez showClear sa voľba „bez emoji" nezobrazí", () => {
+    render(<EmojiPickerButton testId="pick" onPick={() => {}} />);
+    fireEvent.click(screen.getByTestId("pick"));
+    expect(screen.queryByTestId("pick-clear")).toBeNull();
+  });
+
+  it("zdieľaný zoznam obsahuje rozšírené emoji Štěpánovej sady (issue 471)", () => {
+    render(<EmojiPickerButton testId="pick" onPick={() => {}} />);
+    fireEvent.click(screen.getByTestId("pick"));
+    for (const e of ["👏", "🚀", "🥳", "📣", "🤯", "😭", "😆", "🤷", "😳", "😜", "🤨"]) {
+      expect(screen.getByRole("button", { name: `Vložiť ${e}` })).toBeDefined();
+    }
+  });
+});
+
 // issue 455 (hlbšia príčina flaku upozornenia.spec.ts:271): obnova fokusu +
 // caretu po vložení emoji beží v `requestAnimationFrame`. rAF vystrelí AŽ keď
 // kompozítor vyrobí snímku — na zaťaženom (CI) stroji to môže zaostať o stovky

--- a/apps/web/src/components/EmojiPickerButton.tsx
+++ b/apps/web/src/components/EmojiPickerButton.tsx
@@ -47,9 +47,13 @@ interface CommonProps {
    * kolidoval). */
   readonly testId: string;
   readonly disabled?: boolean;
-  /** Popis prepínača (aria-label + title). Predvolene „Vložiť emoji"; riadkové
-   * označenie úlohy použije napr. „Pridať/zmeniť emoji". */
+  /** Prístupný názov prepínača (aria-label). Predvolene „Vložiť emoji"; riadkové
+   * označenie úlohy použije napr. „Pridať/zmeniť emoji úlohy <text>" (rozlíši
+   * riadky pre čítačku obrazovky). */
   readonly label?: string;
+  /** Hover tooltip prepínača (`title`). Predvolene = `label`; použi krátky
+   * tooltip, keď je `label` dlhý a s tooltipom by rušil. */
+  readonly title?: string;
 }
 
 /** Predvolený INSERT režim — vloženie na pozíciu kurzora cieľového poľa. */
@@ -79,6 +83,7 @@ type Props = InsertProps | PickProps;
 
 export function EmojiPickerButton(props: Props): JSX.Element {
   const { testId, disabled = false, label = "Vložiť emoji" } = props;
+  const tooltip = props.title ?? label;
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLSpanElement>(null);
   // rAF na obnovu fokusu po vložení — držaný v refe, nech ho vieme zrušiť pri
@@ -182,7 +187,7 @@ export function EmojiPickerButton(props: Props): JSX.Element {
         className="emoji-picker-toggle"
         aria-label={label}
         aria-expanded={open}
-        title={label}
+        title={tooltip}
         disabled={disabled}
         onClick={() => {
           setOpen((o) => !o);

--- a/apps/web/src/components/EmojiPickerButton.tsx
+++ b/apps/web/src/components/EmojiPickerButton.tsx
@@ -4,17 +4,29 @@ import { useEffect, useRef, useState, type JSX, type RefObject } from "react";
 // appke ukladajú aj zobrazujú správne (overené naživo proti Postgresu — Postgres
 // `text` + node-postgres nesú 4-bajtové UTF-8, žiadna sanitizácia) — chýbal len
 // SPÔSOB, ako ich na desktope vložiť. Toto je malý znovupoužiteľný prepínač s
-// kurátorovanou sadou bežných emoji, BEZ ťažkej externej knižnice (MVP). Klik na
-// emoji ju vloží na pozíciu kurzora cieľového poľa a vráti fokus + kurzor zaň.
+// kurátorovanou sadou bežných emoji, BEZ ťažkej externej knižnice (MVP).
+//
+// issue 471: DVA režimy nad TÝM ISTÝM popoverom a zoznamom.
+//  - INSERT (predvolený, Poznámky/Upozornenia/text úlohy): klik vloží emoji na
+//    pozíciu kurzora cieľového poľa a vráti fokus + kurzor zaň.
+//  - PICK (`onPick`, označenie CELEJ úlohy jedným klikom): klik na emoji rovno
+//    zavolá `onPick(emoji)` a popover sa zavrie; voľba „bez emoji" volá
+//    `onPick(null)`.
 
 // Kurátorovaná sada bežných emoji pre nástenku obchodu (žiadny externý picker).
-// Grid je 8 stĺpcov (`app.css`), takže násobky 8 vyzerajú vyrovnane.
+// JEDEN zdieľaný zoznam pre všetky použitia (Poznámky, Upozornenia, Úlohy).
+// Grid je 8 stĺpcov (`app.css`). issue 471 rozšíril pôvodných 40 (issue 440) o
+// 11 emoji z Štěpánovej „Frequently Used" sady — APPEND na koniec, aby sa
+// zaužívané pozície prvých 40 nemenili (strop ~60–70 dodržaný).
 const EMOJI: readonly string[] = [
   "👍", "👎", "🙂", "😀", "😅", "😂", "😉", "😍",
   "🥰", "😎", "🤔", "😢", "😡", "🎉", "🔥", "⭐",
   "✅", "❌", "⚠️", "❗", "❓", "💡", "📌", "📅",
   "⏰", "📦", "🚚", "💰", "🛒", "📞", "📝", "🙏",
   "👀", "💪", "👌", "✨", "❤️", "🌲", "➡️", "🕒",
+  // issue 471 — Štěpánova reálne používaná sada:
+  "👏", "🚀", "🥳", "📣", "🤯", "😭", "😆", "🤷",
+  "😳", "😜", "🤨",
 ];
 
 /**
@@ -30,22 +42,49 @@ export function insertEmojiAtSelection(value: string, selStart: number, selEnd: 
   return { value: value.slice(0, start) + emoji + value.slice(end), cursor: start + emoji.length };
 }
 
-interface Props {
+interface CommonProps {
+  /** Unikátny testid prefix (viac pickerov na obrazovke — inak by `getByTestId`
+   * kolidoval). */
+  readonly testId: string;
+  readonly disabled?: boolean;
+  /** Popis prepínača (aria-label + title). Predvolene „Vložiť emoji"; riadkové
+   * označenie úlohy použije napr. „Pridať/zmeniť emoji". */
+  readonly label?: string;
+}
+
+/** Predvolený INSERT režim — vloženie na pozíciu kurzora cieľového poľa. */
+interface InsertProps extends CommonProps {
   readonly targetRef: RefObject<HTMLTextAreaElement | HTMLInputElement | null>;
   readonly value: string;
   readonly onChange: (next: string) => void;
-  /** Unikátny testid prefix (viac pickerov na obrazovke, napr. dva vo formulári
-   * upozornenia) — inak by `getByTestId` kolidoval. */
-  readonly testId: string;
-  readonly disabled?: boolean;
+  readonly onPick?: undefined;
+  readonly showClear?: undefined;
+  readonly align?: undefined;
 }
 
-export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled = false }: Props): JSX.Element {
+/** PICK režim — klik na emoji rovno zavolá `onPick` (bez cieľového poľa). */
+interface PickProps extends CommonProps {
+  readonly onPick: (emoji: string | null) => void;
+  /** Zobraziť voľbu „bez emoji" (→ `onPick(null)`). */
+  readonly showClear?: boolean;
+  /** „right" ukotví popover k PRAVÉMU okraju prepínača — pre picker pri pravom
+   * okraji riadku (inak by sa `left:0` popover roztiahol mimo panela). */
+  readonly align?: "left" | "right";
+  readonly targetRef?: undefined;
+  readonly value?: undefined;
+  readonly onChange?: undefined;
+}
+
+type Props = InsertProps | PickProps;
+
+export function EmojiPickerButton(props: Props): JSX.Element {
+  const { testId, disabled = false, label = "Vložiť emoji" } = props;
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLSpanElement>(null);
   // rAF na obnovu fokusu po vložení — držaný v refe, nech ho vieme zrušiť pri
   // ďalšom inserte aj pri odmountovaní (issue 455: oneskorený rAF nesmie
-  // ukradnúť fokus tam, kam sa používateľ medzičasom presunul).
+  // ukradnúť fokus tam, kam sa používateľ medzičasom presunul). Používa sa len
+  // v INSERT režime.
   const rafRef = useRef<number | null>(null);
 
   // Zruš čakajúci rAF na obnovu fokusu pri odmountovaní (napr. zatvorení
@@ -72,8 +111,11 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
     };
   }, [open]);
 
+  // INSERT režim — vloženie na pozíciu kurzora. V PICK režime sa nikdy nevolá
+  // (skorý return zároveň zúži `props` na `InsertProps`).
   const insert = (emoji: string): void => {
-    const el = targetRef.current;
+    if (props.onPick !== undefined) return;
+    const el = props.targetRef.current;
     // Bázová hodnota = ŽIVÁ DOM hodnota poľa (`el.value`), nie React `value`
     // prop. Prop je snímka z posledného renderu a vie zaostať za tým, čo
     // používateľ reálne napísal, keď React ešte neskomitoval onChange poľa
@@ -82,11 +124,11 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
     // prop prepísal napísaný text — DOM hodnota je vždy aktuálna). Výber sa
     // číta z TOHO ISTÉHO elementu, takže hodnota + caret sú jedna konzistentná
     // snímka. Na prop spadneme len keď element neexistuje.
-    const base = el !== null ? el.value : value;
+    const base = el !== null ? el.value : props.value;
     const selStart = el?.selectionStart ?? base.length;
     const selEnd = el?.selectionEnd ?? base.length;
     const { value: next, cursor } = insertEmojiAtSelection(base, selStart, selEnd, emoji);
-    onChange(next);
+    props.onChange(next);
     // Popover sa po vložení ZAVRIE — je `position: absolute` a otvára sa NAD
     // obsahom pod ním (napr. tlačidlo Uložiť leží pod poľom); keby ostal
     // otvorený, jeho dlaždice by prekryli a "ukradli" klik na Uložiť (nájdené
@@ -100,16 +142,13 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
     // keď sa používateľ — alebo Playwright `.fill()` iného poľa, čo je dvojkroková
     // focus→insertText operácia — medzičasom presunul inam. Bezpodmienečný
     // `target.focus()` by vtedy skočil späť na naše pole a text by sa napísal do
-    // zlého poľa (issue 455: hlbšia príčina flaku upozornenia.spec.ts:271 — rAF
-    // z insertu nadpisu vystrelil počas `.fill()` podrobností a ukradol fokus).
-    // Fokus vráť LEN keď je stále „náš" — aktívny prvok je pole samo, náš
-    // popover/root, `<body>` alebo `null`. Po `setOpen(false)` sa kliknuté emoji
-    // tlačidlo odmountuje a fokus padne na `<body>`, takže bežná cesta (hneď po
-    // vložení) sa aj tak refokusne. Predošlý čakajúci rAF zrušíme.
+    // zlého poľa (issue 455). Fokus vráť LEN keď je stále „náš" — aktívny prvok
+    // je pole samo, náš popover/root, `<body>` alebo `null`. Predošlý čakajúci
+    // rAF zrušíme.
     if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
-      const target = targetRef.current;
+      const target = props.targetRef.current;
       if (target === null) return;
       const active = document.activeElement;
       const ours =
@@ -123,14 +162,27 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
     });
   };
 
+  const choose = (emoji: string): void => {
+    if (props.onPick !== undefined) {
+      // PICK režim: jeden klik = hotovo, popover sa zavrie.
+      setOpen(false);
+      props.onPick(emoji);
+      return;
+    }
+    insert(emoji);
+  };
+
+  const alignRight = props.onPick !== undefined && props.align === "right";
+  const showClear = props.onPick !== undefined && props.showClear === true;
+
   return (
     <span className="emoji-picker" ref={rootRef}>
       <button
         type="button"
         className="emoji-picker-toggle"
-        aria-label="Vložiť emoji"
+        aria-label={label}
         aria-expanded={open}
-        title="Vložiť emoji"
+        title={label}
         disabled={disabled}
         onClick={() => {
           setOpen((o) => !o);
@@ -144,7 +196,29 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
         // pomenovaná skupina obyčajných tlačidiel, nie aplikačné menu s
         // roving-focus/šípkovou navigáciou (tú tento MVP picker neimplementuje;
         // ovládanie je myš + Tab/Enter na natívnych `<button>`och).
-        <div className="emoji-picker-popover" role="group" aria-label="Emoji na vloženie" data-testid={`${testId}-popover`}>
+        <div
+          className={"emoji-picker-popover" + (alignRight ? " align-right" : "")}
+          role="group"
+          aria-label="Emoji na vloženie"
+          data-testid={`${testId}-popover`}
+        >
+          {showClear && (
+            <button
+              type="button"
+              className="emoji-picker-clear"
+              aria-label="Bez emoji"
+              title="Odstrániť emoji"
+              data-testid={`${testId}-clear`}
+              onClick={() => {
+                // `props` je tu už zúžené na PickProps (cez alias `showClear`),
+                // takže `onPick` je vždy definované.
+                setOpen(false);
+                props.onPick(null);
+              }}
+            >
+              bez emoji
+            </button>
+          )}
           {EMOJI.map((emoji) => (
             <button
               key={emoji}
@@ -153,7 +227,7 @@ export function EmojiPickerButton({ targetRef, value, onChange, testId, disabled
               aria-label={`Vložiť ${emoji}`}
               title={emoji}
               onClick={() => {
-                insert(emoji);
+                choose(emoji);
               }}
             >
               {emoji}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2504,10 +2504,20 @@ a.upozornenie-title:hover {
   width: auto;
   padding: var(--fs-space-1) var(--fs-space-2);
 }
-.uloha-emoji-input-field {
-  flex: 0 0 auto;
-  width: 4rem;
-  padding: var(--fs-space-1) var(--fs-space-2);
+/* issue 471: riadkové 😊 je teraz `EmojiPickerButton` v PICK režime. Aby sa
+   hustota/vzhľad riadku NEZMENIL (zákaz svojvoľných zmien vzhľadu), jeho
+   prepínač sa scopne na vzhľad `.uloha-icon-btn` (bez rámika/pozadia, rovnaký
+   padding a `--fs-text-sm`). Špecificita `.uloha-actions .emoji-picker-toggle`
+   = (0,0,2,0) porazí základný `.emoji-picker-toggle` (0,0,1,0) bezpodmienečne. */
+.uloha-actions .emoji-picker-toggle {
+  background: none;
+  border: none;
+  padding: var(--fs-space-1);
+  font-size: var(--fs-text-sm);
+  border-radius: var(--fs-radius-sm);
+}
+.uloha-actions .emoji-picker-toggle:hover {
+  background: var(--fs-surface-alt);
 }
 .uloha-actions {
   display: flex;
@@ -2626,6 +2636,14 @@ a.upozornenie-title:hover {
   border-radius: var(--fs-radius-md);
   box-shadow: var(--fs-shadow-md);
 }
+/* issue 471: pri pickeri na PRAVOM okraji riadku (`.uloha-actions`) sa popover
+   ukotví k pravému okraju prepínača (`align="right"` → `.align-right`), inak by
+   sa `left:0` popover roztiahol mimo panela. Špecificita (0,0,2,0) porazí
+   základný `.emoji-picker-popover` (0,0,1,0). */
+.emoji-picker-popover.align-right {
+  left: auto;
+  right: 0;
+}
 .emoji-picker-option {
   background: none;
   border: none;
@@ -2636,6 +2654,25 @@ a.upozornenie-title:hover {
   font-size: var(--fs-text-md);
 }
 .emoji-picker-option:hover {
+  background: var(--fs-surface-alt);
+}
+/* issue 471: voľba „bez emoji" (PICK režim, `showClear`) — celá šírka mriežky,
+   oddelená spodnou čiarou od dlaždíc emoji. */
+.emoji-picker-clear {
+  grid-column: 1 / -1;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--fs-border-soft);
+  cursor: pointer;
+  text-align: left;
+  line-height: 1.2;
+  padding: var(--fs-space-1) var(--fs-space-2);
+  margin-bottom: var(--fs-space-1);
+  border-radius: var(--fs-radius-sm);
+  font-size: var(--fs-text-sm);
+  color: var(--fs-ink-muted);
+}
+.emoji-picker-clear:hover {
   background: var(--fs-surface-alt);
 }
 .poznamky-list {

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -3,13 +3,14 @@ import { expect, test } from "@playwright/test";
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const E2E_ULOHY_EMAIL = "e2e-ulohy@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
 
-// issue 342: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané do
-// Discordu. Reálny prehliadač cez celý cyklus: napísať + Enter (žiadny
-// formulár), upraviť text, pridať emoji, označiť vybavené (ostáva v
-// zozname, len stlmené), odstrániť. Konzola musí zostať čistá
+// issue 342 + 471: "Dôležité → Úlohy na dnes". Reálny prehliadač cez celý cyklus:
+// napísať + Enter (žiadny formulár), vložiť emoji DO textu cez picker (nová úloha
+// aj inline edit), označiť CELÚ úlohu emojkou JEDNÝM klikom v pickeri (bez
+// textového poľa + Uložiť), zmeniť/odstrániť emoji, upraviť text, vybaviť
+// (ostáva v zozname, len stlmené), odstrániť. Konzola musí zostať čistá
 // (`.claude/rules/testing.md`). Účet má rolu "citanie" — server (a teda aj
 // appka) nemá pre tento súkromný zoznam žiadne role-podmienené obmedzenie.
-test("napísať jedno za druhým, upraviť, pridať emoji, vybaviť (ostáva vidno), odstrániť — konzola je čistá", async ({ page }) => {
+test("emoji picker do textu úlohy + jednoklikové označenie riadku, upraviť, vybaviť, odstrániť — konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {
     if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
@@ -25,11 +26,14 @@ test("napísať jedno za druhým, upraviť, pridať emoji, vybaviť (ostáva vid
   await expect(page.getByRole("heading", { name: "Úlohy na dnes" })).toBeVisible();
   await expect(page.getByTestId("ulohy-empty")).toBeVisible();
 
-  // "Písať jedno za druhým" — napísať + Enter, žiadny formulár/dialóg.
+  // --- Nová úloha S EMOJI V TEXTE cez picker (vloženie na kurzor) ---
   const novyVstup = page.getByTestId("uloha-new-input");
-  await novyVstup.fill("Nemáme sáčky");
+  await novyVstup.fill("Nemáme sáčky ");
+  await page.getByTestId("uloha-new-emoji").click();
+  await page.locator(".emoji-picker-popover").getByRole("button", { name: "Vložiť 👍" }).click();
+  await expect(novyVstup).toHaveValue("Nemáme sáčky 👍");
   await novyVstup.press("Enter");
-  await expect(page.getByTestId("ulohy-list").getByText("Nemáme sáčky")).toBeVisible();
+  await expect(page.getByTestId("ulohy-list").getByText("Nemáme sáčky 👍")).toBeVisible();
   await expect(novyVstup).toHaveValue("");
 
   await novyVstup.fill("Záhorecký volať");
@@ -40,34 +44,50 @@ test("napísať jedno za druhým, upraviť, pridať emoji, vybaviť (ostáva vid
   const riadky = page.locator(".uloha-row");
   await expect(riadky).toHaveCount(2);
   await expect(riadky.nth(0)).toContainText("Záhorecký volať");
-  await expect(riadky.nth(1)).toContainText("Nemáme sáčky");
+  await expect(riadky.nth(1)).toContainText("Nemáme sáčky 👍");
 
   // Nájsť konkrétny riadok podľa aktuálneho textu (rovnaký vzor ako
   // `upozornenia.spec.ts`'s `kartaSNadpisom`, len cez `.uloha-row`).
   const sackyRiadok = page.locator(".uloha-row").filter({ hasText: "Nemáme sáčky" });
 
-  // Upraviť text inline. Kým je riadok v editačnom móde, jeho pôvodný text
-  // už NIE JE textovým uzlom v DOM-e (je len hodnotou <input>u), takže
-  // `sackyRiadok`'s `hasText` filter by sa prestal zhodovať s KAŽDÝM ĎALŠÍM
-  // (lazy) vyhodnotením — vstup/tlačidlo sa preto vyhľadáva GLOBÁLNE cez ich
-  // pevný (nie per-riadok interpolovaný) `aria-label`, bezpečné, lebo appka
-  // dovolí najviac JEDEN riadok v editácii textu naraz.
+  // --- Upraviť text inline + vložiť emoji DO textu cez edit picker ---
+  // Kým je riadok v editačnom móde, jeho pôvodný text už NIE JE textovým
+  // uzlom v DOM-e (je len hodnotou <input>u), takže `sackyRiadok`'s `hasText`
+  // filter by sa prestal zhodovať — vstup/tlačidlá sa preto vyhľadávajú
+  // GLOBÁLNE cez ich pevný `aria-label`/testid (appka dovolí najviac JEDEN
+  // riadok v editácii textu naraz).
   await sackyRiadok.getByRole("button", { name: "Upraviť text" }).click();
   const editInput = page.locator("input.uloha-edit-input");
-  await editInput.fill("Nemáme sáčky — objednať zajtra");
+  await editInput.fill("Nemáme sáčky — objednať ");
+  // Edit picker (label "Vložiť emoji") je vnútri edit riadku — vyhľadá sa
+  // scopnuto na riadok obsahujúci edit input, aby nekolidoval s picker-om nad
+  // zoznamom (nový-vstup picker má rovnaký label, ale NIE JE v `.uloha-row`).
+  const editRiadok = page.locator(".uloha-row").filter({ has: page.locator("input.uloha-edit-input") });
+  await editRiadok.getByRole("button", { name: "Vložiť emoji" }).click();
+  await page.locator(".emoji-picker-popover").getByRole("button", { name: "Vložiť 🚚" }).click();
+  await expect(editInput).toHaveValue("Nemáme sáčky — objednať 🚚");
   await page.getByRole("button", { name: "Uložiť text" }).click();
-  const upravenyRiadok = page.locator(".uloha-row").filter({ hasText: "Nemáme sáčky — objednať zajtra" });
+  const upravenyRiadok = page.locator(".uloha-row").filter({ hasText: "Nemáme sáčky — objednať 🚚" });
   await expect(upravenyRiadok).toBeVisible();
 
-  // Pridať emoji (samostatná akcia od úpravy textu).
+  // --- Označiť CELÝ riadok emojkou JEDNÝM klikom v pickeri (žiadne textové pole) ---
   await upravenyRiadok.getByRole("button", { name: "Pridať/zmeniť emoji" }).click();
-  await upravenyRiadok.locator('input[placeholder="😊"]').fill("🛍️");
-  await upravenyRiadok.getByRole("button", { name: "Uložiť emoji" }).click();
-  await expect(upravenyRiadok.locator(".uloha-emoji")).toHaveText("🛍️");
+  await page.locator(".emoji-picker-popover").getByRole("button", { name: "Vložiť 🚀" }).click();
+  // Emoji sa uloží na server (PATCH) a po refetchi sa zobrazí pri riadku.
+  await expect(upravenyRiadok.locator(".uloha-emoji")).toHaveText("🚀");
+
+  // --- Zmeniť emoji riadku na iné (opäť jeden klik) ---
+  await upravenyRiadok.getByRole("button", { name: "Pridať/zmeniť emoji" }).click();
+  await page.locator(".emoji-picker-popover").getByRole("button", { name: "Vložiť 🔥" }).click();
+  await expect(upravenyRiadok.locator(".uloha-emoji")).toHaveText("🔥");
+
+  // --- Odstrániť emoji riadku cez voľbu „bez emoji" ---
+  await upravenyRiadok.getByRole("button", { name: "Pridať/zmeniť emoji" }).click();
+  await page.locator(".emoji-picker-popover").getByRole("button", { name: "Bez emoji" }).click();
+  await expect(upravenyRiadok.locator(".uloha-emoji")).toHaveCount(0);
 
   // Označiť ako vybavené — úloha OSTÁVA v zozname (nezmizne), len stlmená.
-  // issue 403: skutočný `<input type="checkbox">` namiesto `<button>`u —
-  // rola je teraz "checkbox", nie "button" (meno ostáva rovnaké).
+  // issue 403: skutočný `<input type="checkbox">` — rola je "checkbox".
   await upravenyRiadok.getByRole("checkbox", { name: "Označiť ako vybavené" }).click();
   await expect(upravenyRiadok).toHaveClass(/done/);
   await expect(riadky).toHaveCount(2); // stále obe, žiadna nezmizla

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.275",
+  "version": "0.3.0-dev.276",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Emoji picker do Úloh na dnes (issue 471)

Štěpán chcel emoji ako v Discorde — do textu úlohy aj na označenie celej úlohy;
pôvodné riešenie (textové pole na emoji) bolo v praxi nepoužiteľné.

**Čo sa mení (len obrazovka Úlohy na dnes + zdieľaný picker):**
- Emoji DO TEXTU úlohy cez zdieľaný `EmojiPickerButton` (z ticketu 440) — v novom
  vstupe aj v inline editore textu (vloženie na pozíciu kurzora, presne ako
  Poznámky/Upozornenia).
- Označenie CELÉHO riadku: klik na 😊 otvorí ten istý picker a JEDNÝM klikom sa
  emoji rovno uloží (`PATCH /api/daily-tasks/:id/emoji`); voľba „bez emoji" ho
  odstráni. Zaniklo medzikrokové textové pole + Uložiť (ticket 342/381).
- Zdieľaný kurátorovaný zoznam rozšírený 40 → 51 o Štěpánovu reálne používanú
  sadu (👏 🚀 🥳 📣 🤯 😭 😆 🤷 😳 😜 🤨) — jeden zoznam pre Poznámky/Upozornenia/
  Úlohy, žiadna externá knižnica, žiadne CDN.
- Vzhľad/hustota riadkov sa NEMENÍ; API/DB bez zmeny.

**Implementácia:** `EmojiPickerButton` dostal discriminated-union props
(InsertProps | PickProps) — insert režim (targetRef/value/onChange) ostáva pre
existujúce volania nezmenený, nový pick režim má `onPick(emoji|null)` +
`showClear` + `align="right"` + `label`/`title`.

**TDD:** RED (512fbff) → GREEN (c7adab3) → review polish (1fd847d, 0 🔴 0 🟡, oba
🔵 opravené v tej istej vetve). Lokálne zelené: `pnpm gates:local`
(typecheck + lint + 714 web + 1010 api unit testy); e2e prerobené na picker flow
beží v CI.

Ticket 471 ostáva otvorený a zatvorí sa RUČNE až po naživo overení po nasadení
(bez zatváracieho kľúčového slova, per repo pravidlo).
