### PR TITLE
Menu: súčtové odznaky pre Úlohy na dnes a Objednávky predajňa (issue 473)

### DIFF
--- a/apps/api/src/http/daily-tasks-routes.ts
+++ b/apps/api/src/http/daily-tasks-routes.ts
@@ -3,7 +3,7 @@ import type { Hono } from "hono";
 import { z } from "zod";
 import type { Database } from "../db/client.js";
 import { createDailyTask, deleteDailyTask, setDailyTaskDone, updateDailyTaskEmoji, updateDailyTaskText } from "../modules/daily-tasks/service.js";
-import { listDailyTasks } from "../modules/daily-tasks/queries.js";
+import { countOpenDailyTasks, listDailyTasks } from "../modules/daily-tasks/queries.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { requireUser, type AppBindings } from "./middleware.js";
 
@@ -28,6 +28,17 @@ export function registerDailyTasksRoutes(app: Hono<AppBindings>, db: Database): 
     const user = c.get("user");
     const rows = await listDailyTasks(db, user.userId);
     return c.json({ rows });
+  });
+
+  // issue 473: odznak počtu v ľavom menu — počet MOJICH otvorených (bez fajky)
+  // úloh. Literal-path súrodenec MUSÍ byť pred `/:id` trasami rovnakej metódy
+  // (`.claude/rules/http-routes.md` — poradie literal-vs-`:param`); dnes žiadna
+  // GET `/:id` trasa neexistuje, ale poradie sa drží ako zvyk (rovnako ako
+  // `upozornenia-routes.ts`'s `/count`).
+  app.get("/api/daily-tasks/count", requireUser(db), async (c) => {
+    const user = c.get("user");
+    const count = await countOpenDailyTasks(db, user.userId);
+    return c.json({ count });
   });
 
   app.post("/api/daily-tasks", requireSameOrigin(), requireUser(db), zValidator("json", createBody), async (c) => {

--- a/apps/api/src/http/floor-notes-routes.ts
+++ b/apps/api/src/http/floor-notes-routes.ts
@@ -13,7 +13,7 @@ import {
   updateFloorNoteProductQuantity,
   updateFloorNoteText,
 } from "../modules/floor-notes/service.js";
-import { listFloorNotes } from "../modules/floor-notes/queries.js";
+import { countUnresolvedFloorNotes, listFloorNotes } from "../modules/floor-notes/queries.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -39,6 +39,16 @@ export function registerFloorNotesRoutes(app: Hono<AppBindings>, db: Database): 
   app.get("/api/floor-notes", requireUser(db), async (c) => {
     const rows = await listFloorNotes(db);
     return c.json({ rows });
+  });
+
+  // issue 473: odznak počtu v ľavom menu — počet nevybavených (`resolved=false`)
+  // zápisov, globálne. Literal-path súrodenec MUSÍ byť pred `/:id` trasami
+  // (`.claude/rules/http-routes.md` — poradie literal-vs-`:param`); dnes žiadna
+  // GET `/:id` trasa neexistuje, ale poradie sa drží ako zvyk (rovnako ako
+  // `upozornenia-routes.ts`'s `/count`).
+  app.get("/api/floor-notes/count", requireUser(db), async (c) => {
+    const count = await countUnresolvedFloorNotes(db);
+    return c.json({ count });
   });
 
   app.post("/api/floor-notes", requireSameOrigin(), requireUser(db), requireRole("admin", "manazer"), zValidator("json", createBody), async (c) => {

--- a/apps/api/src/modules/daily-tasks/queries.ts
+++ b/apps/api/src/modules/daily-tasks/queries.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { dailyTask } from "../../db/schema.js";
 
@@ -27,4 +27,18 @@ export async function listDailyTasks(db: Database, userId: string): Promise<read
     .from(dailyTask)
     .where(eq(dailyTask.userId, userId))
     .orderBy(desc(dailyTask.createdAt));
+}
+
+// issue 473: odznak počtu v ľavom menu — počet OTVORENÝCH (bez fajky) úloh
+// PRIHLÁSENÉHO používateľa. `COUNT(*) WHERE ...` priamo v SQL (rovnaký vzor ako
+// `countActionableUpozornenia`, nie natiahnutie všetkých riadkov a `.length` v
+// JS). Úlohy sú SÚKROMNÉ — `user_id` filter na KAŽDOM dopyte, presne ako
+// `listDailyTasks` vyššie (viď design komentár na issue 342/473), takže odznak
+// nikdy nezapočíta cudzie úlohy. `done_at IS NULL` = ešte nevybavená.
+export async function countOpenDailyTasks(db: Database, userId: string): Promise<number> {
+  const [row] = await db
+    .select({ total: count() })
+    .from(dailyTask)
+    .where(and(eq(dailyTask.userId, userId), isNull(dailyTask.doneAt)));
+  return row?.total ?? 0;
 }

--- a/apps/api/src/modules/floor-notes/queries.ts
+++ b/apps/api/src/modules/floor-notes/queries.ts
@@ -1,4 +1,4 @@
-import { asc, desc, eq } from "drizzle-orm";
+import { asc, count, desc, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { floorNoteProducts, floorNotes, shopProductUrl, variants } from "../../db/schema.js";
 
@@ -83,4 +83,18 @@ export async function listFloorNotes(db: Database): Promise<readonly FloorNoteRo
     updatedAt: n.updatedAt.toISOString(),
     products: byNote.get(n.id) ?? [],
   }));
+}
+
+// issue 473: odznak počtu v ľavom menu — počet NEVYBAVENÝCH (`resolved = false`)
+// zápisov. GLOBÁLNY (zdieľaný zoznam, žiadny `user_id` filter na čítaní, presne
+// ako `listFloorNotes` vyššie). `COUNT(*) WHERE ...` priamo v SQL (rovnaký vzor
+// ako `countActionableUpozornenia`). Značky `ordered`/`called` sú NEZÁVISLÉ a do
+// počtu NEVSTUPUJÚ — jediné, čo znamená "vybavené", je `resolved` (design
+// komentár na issue 410/473).
+export async function countUnresolvedFloorNotes(db: Database): Promise<number> {
+  const [row] = await db
+    .select({ total: count() })
+    .from(floorNotes)
+    .where(eq(floorNotes.resolved, false));
+  return row?.total ?? 0;
 }

--- a/apps/api/tests/daily-tasks-http.integration.test.ts
+++ b/apps/api/tests/daily-tasks-http.integration.test.ts
@@ -46,6 +46,20 @@ async function secondLogin(app: ReturnType<typeof createApp>, db: Awaited<Return
   return { cookie };
 }
 
+async function createTask(app: ReturnType<typeof createApp>, cookie: string, text: string): Promise<string> {
+  const res = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text }) });
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function readCount(app: ReturnType<typeof createApp>, cookie: string): Promise<number> {
+  const res = await app.request("/api/daily-tasks/count", { headers: { cookie } });
+  return ((await res.json()) as { count: number }).count;
+}
+
+async function setDone(app: ReturnType<typeof createApp>, cookie: string, id: string, done: boolean): Promise<void> {
+  await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ done }) });
+}
+
 describe("GET /api/daily-tasks", () => {
   it("bez prihlásenia vráti 401", async () => {
     const { app } = await bootUser("sef@forestshop.sk", "admin");
@@ -238,5 +252,55 @@ describe("DELETE /api/daily-tasks/:id", () => {
 
     const list = await app.request("/api/daily-tasks", { headers: { cookie } });
     expect(((await list.json()) as { rows: readonly { id: string }[] }).rows.map((r) => r.id)).toEqual([id]);
+  });
+});
+
+// issue 473: odznak počtu v ľavom menu — počet MOJICH otvorených (bez fajky) úloh.
+describe("GET /api/daily-tasks/count", () => {
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks/count");
+    expect(res.status).toBe(401);
+  });
+
+  it("čerstvý používateľ má count 0", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const res = await app.request("/api/daily-tasks/count", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { count: number }).toEqual({ count: 0 });
+  });
+
+  it("počíta LEN otvorené úlohy — vybavená (s fajkou) sa neráta", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const a = await createTask(app, cookie, "A");
+    await createTask(app, cookie, "B");
+    await createTask(app, cookie, "C");
+    await setDone(app, cookie, a, true);
+
+    expect(await readCount(app, cookie)).toBe(2);
+  });
+
+  it("odfajknutie a späť mení count OBOMA smermi (POST /:id/done je toggle)", async () => {
+    const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
+    const id = await createTask(app, cookie, "úloha");
+    expect(await readCount(app, cookie)).toBe(1);
+
+    await setDone(app, cookie, id, true);
+    expect(await readCount(app, cookie)).toBe(0);
+
+    await setDone(app, cookie, id, false);
+    expect(await readCount(app, cookie)).toBe(1);
+  });
+
+  it("count je PER-POUŽÍVATEĽ — cudzie otvorené úlohy sa nerátajú", async () => {
+    const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
+    await createTask(app, cookie, "šéfova 1");
+    await createTask(app, cookie, "šéfova 2");
+
+    const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    // druhý používateľ vidí LEN svoje (0), nie šéfove dve
+    expect(await readCount(app, other.cookie)).toBe(0);
+    // vlastník vidí svoje dve
+    expect(await readCount(app, cookie)).toBe(2);
   });
 });

--- a/apps/api/tests/daily-tasks-http.integration.test.ts
+++ b/apps/api/tests/daily-tasks-http.integration.test.ts
@@ -280,7 +280,7 @@ describe("GET /api/daily-tasks/count", () => {
     expect(await readCount(app, cookie)).toBe(2);
   });
 
-  it("odfajknutie a späť mení count OBOMA smermi (POST /:id/done je toggle)", async () => {
+  it("odfajknutie a späť mení count OBOMA smermi (POST /:id/done nastaví done explicitne v oboch smeroch)", async () => {
     const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
     const id = await createTask(app, cookie, "úloha");
     expect(await readCount(app, cookie)).toBe(1);

--- a/apps/api/tests/floor-notes-http.integration.test.ts
+++ b/apps/api/tests/floor-notes-http.integration.test.ts
@@ -60,6 +60,15 @@ async function createNote(app: ReturnType<typeof createApp>, cookie: string, tex
   return body.id;
 }
 
+async function setMarker(app: ReturnType<typeof createApp>, cookie: string, id: string, marker: "resolved" | "ordered" | "called", value: boolean): Promise<void> {
+  await app.request(`/api/floor-notes/${id}/${marker}`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ value }) });
+}
+
+async function readCount(app: ReturnType<typeof createApp>, cookie: string): Promise<number> {
+  const res = await app.request("/api/floor-notes/count", { headers: { cookie } });
+  return ((await res.json()) as { count: number }).count;
+}
+
 describe("GET /api/floor-notes", () => {
   it("bez prihlásenia vráti 401", async () => {
     const { app } = await bootUser("manazer@forestshop.sk", "manazer");
@@ -225,4 +234,60 @@ describe("DELETE /api/floor-notes/:id", () => {
   // `onDelete: "cascade"` (`schema-floor-notes.ts`) — dôkaz je v
   // `floor-notes-products-http.integration.test.ts`, tematicky patrí tam
   // (ten súbor produkty aj vkladá).
+});
+
+// issue 473: odznak počtu v ľavom menu — počet nevybavených (`resolved=false`)
+// zápisov, globálne. Značky 🛒 objednané / 📞 zavolané do počtu NEVSTUPUJÚ.
+describe("GET /api/floor-notes/count", () => {
+  it("bez prihlásenia vráti 401", async () => {
+    const { app } = await bootUser("manazer@forestshop.sk", "manazer");
+    const res = await app.request("/api/floor-notes/count");
+    expect(res.status).toBe(401);
+  });
+
+  it("čerstvá appka má count 0", async () => {
+    const { app, cookie } = await bootUser("manazer@forestshop.sk", "manazer");
+    const res = await app.request("/api/floor-notes/count", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { count: number }).toEqual({ count: 0 });
+  });
+
+  it("počíta LEN nevybavené (resolved=false) zápisy — vybavený sa neráta", async () => {
+    const { app, cookie } = await bootUser("manazer@forestshop.sk", "manazer");
+    const a = await createNote(app, cookie, "A");
+    await createNote(app, cookie, "B");
+    await createNote(app, cookie, "C");
+    await setMarker(app, cookie, a, "resolved", true);
+
+    expect(await readCount(app, cookie)).toBe(2);
+  });
+
+  it("prepnutie ✅ vybavené a späť mení count OBOMA smermi", async () => {
+    const { app, cookie } = await bootUser("manazer@forestshop.sk", "manazer");
+    const id = await createNote(app, cookie, "zápis");
+    expect(await readCount(app, cookie)).toBe(1);
+
+    await setMarker(app, cookie, id, "resolved", true);
+    expect(await readCount(app, cookie)).toBe(0);
+
+    await setMarker(app, cookie, id, "resolved", false);
+    expect(await readCount(app, cookie)).toBe(1);
+  });
+
+  it("značky 🛒 objednané / 📞 zavolané NEMENIA count (do počtu vstupuje len ✅ vybavené)", async () => {
+    const { app, cookie } = await bootUser("manazer@forestshop.sk", "manazer");
+    const id = await createNote(app, cookie, "zápis");
+    await setMarker(app, cookie, id, "ordered", true);
+    await setMarker(app, cookie, id, "called", true);
+
+    expect(await readCount(app, cookie)).toBe(1);
+  });
+
+  it("count je GLOBÁLNY (zdieľaný) — zápis jedného vidí v počte aj druhý používateľ", async () => {
+    const { app, cookie, db } = await bootUser("manazer@forestshop.sk", "manazer");
+    await createNote(app, cookie, "spoločný zápis");
+
+    const other = await secondLogin(app, db, "kolega@forestshop.sk", "manazer");
+    expect(await readCount(app, other.cookie)).toBe(1);
+  });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,8 +7,12 @@ import { Footer } from "./components/Footer.js";
 import { LoginForm } from "./components/LoginForm.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { Topbar } from "./components/Topbar.js";
+import { fetchOpenDailyTasksCount } from "./dailyTasksApi.js";
+import { DailyTasksBadgeRefreshContext } from "./dailyTasksBadgeContext.js";
 import { fetchDpdShippableCount } from "./dpdApi.js";
 import { DpdBadgeRefreshContext } from "./dpdBadgeContext.js";
+import { fetchUnresolvedFloorNotesCount } from "./floorNotesApi.js";
+import { FloorNotesBadgeRefreshContext } from "./floorNotesBadgeContext.js";
 import { DEFAULT_TAB_ID, NAV, findTab, isVisibleTabId } from "./nav.js";
 import { fetchOrderFlagCounts } from "./orderFlagsApi.js";
 import { OrderFlagsBadgeRefreshContext } from "./orderFlagsBadgeContext.js";
@@ -177,10 +181,74 @@ export function App(): JSX.Element {
     };
   }, [me, activeTabId, orderFlagsRefreshNonce]);
 
+  // issue 473: odznak "Úlohy na dnes" — presná kópia `upozorneniaCount` vzoru
+  // vyššie (App.tsx vlastní count, fetchuje ho pri prihlásení/zmene záložky/
+  // refresh-nonce, žiaden polling). Číslo je PER-POUŽÍVATEĽ (úlohy sú súkromné),
+  // musí byť známe HNEĎ po prihlásení, nie až po prvom otvorení záložky.
+  // `DailyTasksSection` po každej úspešnej count-meniacej mutácii (pridať/
+  // zmazať/odfajknúť) zavolá `refresh()` cez `DailyTasksBadgeRefreshContext`.
+  const [dailyTasksCount, setDailyTasksCount] = useState<number | null>(null);
+  const [dailyTasksRefreshNonce, setDailyTasksRefreshNonce] = useState(0);
+  const dailyTasksBadgeRefresh = useCallback(() => {
+    setDailyTasksRefreshNonce((n) => n + 1);
+  }, []);
+  const dailyTasksBadgeContextValue = useMemo(() => ({ refresh: dailyTasksBadgeRefresh }), [dailyTasksBadgeRefresh]);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchOpenDailyTasksCount()
+      .then((count) => {
+        if (!cancelled) setDailyTasksCount(count);
+      })
+      .catch(() => {
+        // `fetchOpenDailyTasksCount` už interne zachytáva všetky chyby a vždy
+        // vráti 0 (`dailyTasksApi.ts`) — tento catch je len poistka pre eslint
+        // `no-floating-promises`, nikdy by sa reálne nemal spustiť.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId, dailyTasksRefreshNonce]);
+
+  // issue 473: odznak "Objednávky predajňa" — rovnaký PRIAMY vzor ako
+  // `dailyTasksCount` vyššie, ibaže tento počet je GLOBÁLNY (zdieľaný zoznam,
+  // žiadny user filter). `FloorNotesSection` po každej count-meniacej mutácii
+  // (pridať/zmazať/prepnúť ✅ vybavené) zavolá `refresh()` cez
+  // `FloorNotesBadgeRefreshContext` — značky 🛒/📞 count nemenia, tie refresh
+  // nevolajú.
+  const [floorNotesCount, setFloorNotesCount] = useState<number | null>(null);
+  const [floorNotesRefreshNonce, setFloorNotesRefreshNonce] = useState(0);
+  const floorNotesBadgeRefresh = useCallback(() => {
+    setFloorNotesRefreshNonce((n) => n + 1);
+  }, []);
+  const floorNotesBadgeContextValue = useMemo(() => ({ refresh: floorNotesBadgeRefresh }), [floorNotesBadgeRefresh]);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchUnresolvedFloorNotesCount()
+      .then((count) => {
+        if (!cancelled) setFloorNotesCount(count);
+      })
+      .catch(() => {
+        // `fetchUnresolvedFloorNotesCount` už interne zachytáva všetky chyby a
+        // vždy vráti 0 (`floorNotesApi.ts`) — poistka pre eslint
+        // `no-floating-promises`, nikdy by sa reálne nemal spustiť.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId, floorNotesRefreshNonce]);
+
   const badgeCounts = useMemo<Readonly<Record<string, number>>>(() => {
     const counts: Record<string, number> = {};
     if (ordersRemainingCount !== null) counts["orders"] = ordersRemainingCount;
     if (upozorneniaCount !== null) counts["upozornenia"] = upozorneniaCount;
+    // issue 473: odznaky sa ukazujú AJ pri nule (rovnako ako "upozornenia"/
+    // "dpd" — appka tým hovorí "toto číslo poznám, je 0"), presne ako žiada
+    // zadanie ("presne ako pri Upozornenia"). Kľúče `ulohy`/`floor-orders`
+    // zodpovedajú `nav.ts`'s `tab.id` — `Sidebar` ich vykreslí genericky.
+    if (dailyTasksCount !== null) counts["ulohy"] = dailyTasksCount;
+    if (floorNotesCount !== null) counts["floor-orders"] = floorNotesCount;
     // issue 445: odznak sa ukazuje AJ pri nule (rovnako ako "upozornenia"/
     // "pairing-review" — appka tým hovorí "toto číslo poznám, je 0"), aby
     // šéf hneď videl "dnes netreba objednať žiadnu DPD prepravu".
@@ -206,7 +274,7 @@ export function App(): JSX.Element {
     // istý tvar bugu ako `UpozorneniaSection.tsx`'s `withBusy`), takže lint
     // to nezachytí a stará hodnota (chýbajúce odznaky hneď po prihlásení,
     // kým sa nespustí NEJAKÝ INÝ trigger) prežije bez varovania.
-  }, [ordersRemainingCount, upozorneniaCount, dpdCount, pairingReviewUnreviewedCount, orderFlagCounts]);
+  }, [ordersRemainingCount, upozorneniaCount, dpdCount, pairingReviewUnreviewedCount, orderFlagCounts, dailyTasksCount, floorNotesCount]);
 
   // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
   // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU
@@ -334,34 +402,38 @@ export function App(): JSX.Element {
         <DpdBadgeRefreshContext.Provider value={dpdBadgeContextValue}>
           <PairingReviewBadgeRefreshContext.Provider value={pairingReviewBadgeContextValue}>
             <OrderFlagsBadgeRefreshContext.Provider value={orderFlagsBadgeContextValue}>
-              <div className="app-shell">
-                <Sidebar
-                  folders={NAV}
-                  activeTabId={activeTabId}
-                  onSelectTab={selectTab}
-                  badgeCounts={badgeCounts}
-                  badgeStatus={automationStatus}
-                />
-                <div className="main">
-                  <Topbar
-                    title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
-                    greeting={`Prihlásený: ${me.displayName} (${me.role})`}
-                    role={me.role}
-                    onSessionExpired={reload}
-                    onLogout={logout}
-                    passwordPanelOpen={passwordPanelOpen}
-                    onTogglePasswordPanel={() => {
-                      setPasswordPanelOpen((open) => !open);
-                    }}
-                  >
-                    <ChangePasswordForm email={me.email} onSessionExpired={reload} />
-                  </Topbar>
-                  <main className={tab?.wide === true ? "main-wide" : undefined}>
-                    {logoutError !== "" && <p role="alert">{logoutError}</p>}
-                    {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
-                  </main>
-                </div>
-              </div>
+              <DailyTasksBadgeRefreshContext.Provider value={dailyTasksBadgeContextValue}>
+                <FloorNotesBadgeRefreshContext.Provider value={floorNotesBadgeContextValue}>
+                  <div className="app-shell">
+                    <Sidebar
+                      folders={NAV}
+                      activeTabId={activeTabId}
+                      onSelectTab={selectTab}
+                      badgeCounts={badgeCounts}
+                      badgeStatus={automationStatus}
+                    />
+                    <div className="main">
+                      <Topbar
+                        title={isVisibleTabId(activeTabId) ? (tab?.label ?? null) : null}
+                        greeting={`Prihlásený: ${me.displayName} (${me.role})`}
+                        role={me.role}
+                        onSessionExpired={reload}
+                        onLogout={logout}
+                        passwordPanelOpen={passwordPanelOpen}
+                        onTogglePasswordPanel={() => {
+                          setPasswordPanelOpen((open) => !open);
+                        }}
+                      >
+                        <ChangePasswordForm email={me.email} onSessionExpired={reload} />
+                      </Topbar>
+                      <main className={tab?.wide === true ? "main-wide" : undefined}>
+                        {logoutError !== "" && <p role="alert">{logoutError}</p>}
+                        {ActiveComponent !== null && <ActiveComponent role={me.role} onSessionExpired={reload} />}
+                      </main>
+                    </div>
+                  </div>
+                </FloorNotesBadgeRefreshContext.Provider>
+              </DailyTasksBadgeRefreshContext.Provider>
             </OrderFlagsBadgeRefreshContext.Provider>
           </PairingReviewBadgeRefreshContext.Provider>
         </DpdBadgeRefreshContext.Provider>

--- a/apps/web/src/components/DailyTasksSection.badgeRefresh.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.badgeRefresh.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { DailyTasksBadgeRefreshContext } from "../dailyTasksBadgeContext.js";
+import { DailyTasksSection } from "./DailyTasksSection.js";
+
+// issue 473: odznak počtu v ľavom menu klamal, kým sa stránka neobnovila —
+// mutácia (pridať/odfajknúť/zmazať) na PRÁVE otvorenej obrazovke nemala žiadny
+// spúšťač refetchu. Tento test overuje, že `DailyTasksSection` po KAŽDEJ
+// count-meniacej mutácii zavolá `refresh()` z `DailyTasksBadgeRefreshContext`
+// (v `App.tsx` je nahradený spy funkciou) — rovnaký vzor ako
+// `UpozorneniaSection.badgeRefresh.test.tsx`. Úprava textu count NEMENÍ, takže
+// refresh NEvolá.
+
+const { fetchDailyTasks, createDailyTask, setDailyTaskDone, deleteDailyTask, updateDailyTaskText } = vi.hoisted(() => ({
+  fetchDailyTasks: vi.fn(),
+  createDailyTask: vi.fn(),
+  setDailyTaskDone: vi.fn(),
+  deleteDailyTask: vi.fn(),
+  updateDailyTaskText: vi.fn(),
+}));
+
+vi.mock("../dailyTasksApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../dailyTasksApi.js")>();
+  return { ...actual, fetchDailyTasks, createDailyTask, setDailyTaskDone, deleteDailyTask, updateDailyTaskText };
+});
+
+const ULOHA = {
+  id: "task-1",
+  text: "poslať DPD",
+  emoji: null,
+  doneAt: null,
+  createdAt: "2026-08-23T08:00:00.000Z",
+  updatedAt: "2026-08-23T08:00:00.000Z",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function renderWithRefresh(refresh: () => void) {
+  render(
+    <DailyTasksBadgeRefreshContext.Provider value={{ refresh }}>
+      <DailyTasksSection onSessionExpired={vi.fn()} />
+    </DailyTasksBadgeRefreshContext.Provider>,
+  );
+}
+
+it("pridanie úlohy zavolá refresh() (odznak sa refetchne bez zmeny záložky)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([]).mockResolvedValueOnce([ULOHA]);
+  createDailyTask.mockResolvedValue(undefined);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("ulohy-empty");
+  expect(refresh).not.toHaveBeenCalled();
+
+  fireEvent.change(screen.getByTestId("uloha-new-input"), { target: { value: "poslať DPD" } });
+  fireEvent.click(screen.getByTestId("uloha-new-add"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("odfajknutie úlohy (done toggle) zavolá refresh()", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ULOHA]).mockResolvedValueOnce([{ ...ULOHA, doneAt: "2026-08-23T09:00:00.000Z" }]);
+  setDailyTaskDone.mockResolvedValue(true);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("uloha-row-task-1");
+  expect(refresh).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByTestId("uloha-done-task-1"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("zmazanie úlohy zavolá refresh()", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ULOHA]).mockResolvedValueOnce([]);
+  deleteDailyTask.mockResolvedValue(undefined);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("uloha-row-task-1");
+
+  fireEvent.click(screen.getByTestId("uloha-delete-task-1"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("úprava TEXTU úlohy NEZAVOLÁ refresh() (count sa nemení)", async () => {
+  fetchDailyTasks.mockResolvedValue([ULOHA]);
+  updateDailyTaskText.mockResolvedValue(true);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("uloha-row-task-1");
+
+  fireEvent.click(screen.getByTestId("uloha-edit-task-1"));
+  fireEvent.change(screen.getByTestId("uloha-edit-input-task-1"), { target: { value: "poslať DPD zajtra" } });
+  fireEvent.click(screen.getByTestId("uloha-edit-save-task-1"));
+
+  await waitFor(() => {
+    expect(updateDailyTaskText).toHaveBeenCalledTimes(1);
+  });
+  expect(refresh).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
 import {
   createDailyTask,
   DailyTasksUnauthorizedError,
@@ -9,6 +9,7 @@ import {
   updateDailyTaskText,
   type DailyTaskRow,
 } from "../dailyTasksApi.js";
+import { DailyTasksBadgeRefreshContext } from "../dailyTasksBadgeContext.js";
 import { EmojiPickerButton } from "./EmojiPickerButton.js";
 
 // issue 342: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané do
@@ -53,6 +54,13 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
   const [creating, setCreating] = useState(false);
   const [editingTextId, setEditingTextId] = useState<string | null>(null);
   const [textDraft, setTextDraft] = useState<Record<string, string>>({});
+
+  // issue 473: po každej count-meniacej mutácii (pridať/odfajknúť/zmazať) sa
+  // zavolá `refresh()` z `DailyTasksBadgeRefreshContext`, aby odznak v ľavom
+  // menu (`App.tsx` ho vlastní a fetchuje) klesol/stúpol HNEĎ bez reloadu —
+  // rovnaký vzor ako `UpozorneniaSection`. Úprava textu/emoji count NEMENÍ,
+  // tie refresh nevolajú.
+  const { refresh: badgeRefresh } = useContext(DailyTasksBadgeRefreshContext);
 
   // issue 471: emoji picker vkladá na pozíciu kurzora týchto polí. Nový vstup má
   // vlastný ref; inline edit má JEDEN zdieľaný ref — appka dovolí najviac jeden
@@ -113,6 +121,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
       .then(() => {
         setNewText("");
         load();
+        badgeRefresh();
       })
       .catch((err: unknown) => {
         handleActionError(err, "Úlohu sa nepodarilo pridať — skúste to znova.");
@@ -120,7 +129,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
       .finally(() => {
         setCreating(false);
       });
-  }, [newText, creating, load, handleActionError]);
+  }, [newText, creating, load, handleActionError, badgeRefresh]);
 
   const toggleDone = useCallback(
     (row: DailyTaskRow) => {
@@ -129,6 +138,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
       setDailyTaskDone(row.id, row.doneAt === null)
         .then(() => {
           load();
+          badgeRefresh();
         })
         .catch((err: unknown) => {
           handleActionError(err, "Akcia zlyhala — skúste to znova.");
@@ -137,7 +147,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
           setBusyId("");
         });
     },
-    [load, handleActionError],
+    [load, handleActionError, badgeRefresh],
   );
 
   const saveText = useCallback(
@@ -198,6 +208,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
       deleteDailyTask(id)
         .then(() => {
           load();
+          badgeRefresh();
         })
         .catch((err: unknown) => {
           handleActionError(err, "Úlohu sa nepodarilo odstrániť — skúste to znova.");
@@ -206,7 +217,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
           setBusyId("");
         });
     },
-    [load, handleActionError],
+    [load, handleActionError, badgeRefresh],
   );
 
   const intro = <p>Osobný zoznam úloh — nahrádza poznámky písané do Discordu. Vidíš len svoje vlastné úlohy.</p>;

--- a/apps/web/src/components/FloorNotesSection.badgeRefresh.test.tsx
+++ b/apps/web/src/components/FloorNotesSection.badgeRefresh.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { FloorNotesBadgeRefreshContext } from "../floorNotesBadgeContext.js";
+import { FloorNotesSection } from "./FloorNotesSection.js";
+
+// issue 473: odznak počtu nevybavených zápisov v ľavom menu — `FloorNotesSection`
+// musí po count-meniacej mutácii zavolať `refresh()` z
+// `FloorNotesBadgeRefreshContext`. Count MENÍ len: pridanie, zmazanie a
+// prepnutie ✅ vybavené (`resolved`). Značky 🛒 objednané / 📞 zavolané count
+// NEMENIA — tie refresh NEvolajú (kľúčové rozlíšenie tohto testu, design
+// komentár na issue 473).
+
+const { fetchFloorNotes, createFloorNote, deleteFloorNote, setFloorNoteResolved, setFloorNoteOrdered } = vi.hoisted(() => ({
+  fetchFloorNotes: vi.fn(),
+  createFloorNote: vi.fn(),
+  deleteFloorNote: vi.fn(),
+  setFloorNoteResolved: vi.fn(),
+  setFloorNoteOrdered: vi.fn(),
+}));
+
+vi.mock("../floorNotesApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../floorNotesApi.js")>();
+  return { ...actual, fetchFloorNotes, createFloorNote, deleteFloorNote, setFloorNoteResolved, setFloorNoteOrdered };
+});
+
+const ZAPIS = {
+  id: "note-1",
+  text: "Matúš Dubec, 0949 647 802",
+  resolved: false,
+  ordered: false,
+  called: false,
+  createdAt: "2026-08-23T08:00:00.000Z",
+  updatedAt: "2026-08-23T08:00:00.000Z",
+  products: [],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function renderWithRefresh(refresh: () => void) {
+  render(
+    <FloorNotesBadgeRefreshContext.Provider value={{ refresh }}>
+      <FloorNotesSection role="manazer" onSessionExpired={vi.fn()} />
+    </FloorNotesBadgeRefreshContext.Provider>,
+  );
+}
+
+it("pridanie zápisu zavolá refresh() (odznak sa refetchne bez zmeny záložky)", async () => {
+  fetchFloorNotes.mockResolvedValueOnce([]).mockResolvedValueOnce([ZAPIS]);
+  createFloorNote.mockResolvedValue(undefined);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("floor-notes-empty");
+  expect(refresh).not.toHaveBeenCalled();
+
+  fireEvent.change(screen.getByTestId("floor-note-new-input"), { target: { value: "Matúš Dubec, 0949 647 802" } });
+  fireEvent.click(screen.getByTestId("floor-note-new-add"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("prepnutie ✅ vybavené zavolá refresh()", async () => {
+  fetchFloorNotes.mockResolvedValueOnce([ZAPIS]).mockResolvedValueOnce([{ ...ZAPIS, resolved: true }]);
+  setFloorNoteResolved.mockResolvedValue(true);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("floor-note-row-note-1");
+  expect(refresh).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByTestId("floor-note-marker-resolved-note-1"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("zmazanie zápisu zavolá refresh()", async () => {
+  fetchFloorNotes.mockResolvedValueOnce([ZAPIS]).mockResolvedValueOnce([]);
+  deleteFloorNote.mockResolvedValue(true);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("floor-note-row-note-1");
+
+  fireEvent.click(screen.getByTestId("floor-note-delete-note-1"));
+
+  await waitFor(() => {
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("prepnutie 🛒 objednané NEZAVOLÁ refresh() (nevybavené = len ✅ resolved)", async () => {
+  fetchFloorNotes.mockResolvedValue([ZAPIS]);
+  setFloorNoteOrdered.mockResolvedValue(true);
+  const refresh = vi.fn();
+  renderWithRefresh(refresh);
+  await screen.findByTestId("floor-note-row-note-1");
+
+  fireEvent.click(screen.getByTestId("floor-note-marker-ordered-note-1"));
+
+  await waitFor(() => {
+    expect(setFloorNoteOrdered).toHaveBeenCalledTimes(1);
+  });
+  expect(refresh).not.toHaveBeenCalled();
+});

--- a/apps/web/src/components/FloorNotesSection.tsx
+++ b/apps/web/src/components/FloorNotesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useContext, useEffect, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { autoResizeTextarea } from "../autoResizeTextarea.js";
 import {
@@ -15,6 +15,7 @@ import {
   updateFloorNoteText,
   type FloorNoteRow as FloorNoteRowData,
 } from "../floorNotesApi.js";
+import { FloorNotesBadgeRefreshContext } from "../floorNotesBadgeContext.js";
 import type { ProductSearchHit } from "../searchApi.js";
 import { FloorNoteRow } from "./FloorNoteRow.js";
 
@@ -38,6 +39,13 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
   const [creating, setCreating] = useState(false);
   const [busyId, setBusyId] = useState("");
   const canEdit = CAN_EDIT_ROLES.has(role);
+
+  // issue 473: odznak počtu nevybavených zápisov v ľavom menu (`App.tsx` ho
+  // vlastní/fetchuje) — po count-meniacej mutácii zavolá `refresh()`, aby číslo
+  // kleslo/stúplo hneď bez reloadu. Count MENÍ len: pridanie, zmazanie a
+  // prepnutie ✅ vybavené (`resolved`). Značky 🛒 objednané / 📞 zavolané count
+  // NEMENIA, tie refresh nevolajú (design komentár na issue 473).
+  const { refresh: badgeRefresh } = useContext(FloorNotesBadgeRefreshContext);
 
   const load = useCallback(() => {
     fetchFloorNotes()
@@ -77,6 +85,7 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
       .then(() => {
         setNewText("");
         load();
+        badgeRefresh();
       })
       .catch((err: unknown) => {
         handleActionError(err, "Zápis sa nepodarilo pridať — skúste to znova.");
@@ -84,7 +93,7 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
       .finally(() => {
         setCreating(false);
       });
-  }, [newText, creating, load, handleActionError]);
+  }, [newText, creating, load, handleActionError, badgeRefresh]);
 
   const saveText = useCallback(
     (id: string, text: string) => {
@@ -112,6 +121,9 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
       setter(id, value)
         .then(() => {
           load();
+          // LEN ✅ vybavené (`resolved`) mení počet nevybavených zápisov —
+          // 🛒 objednané / 📞 zavolané sú nezávislé značky bez vplyvu na odznak.
+          if (marker === "resolved") badgeRefresh();
         })
         .catch((err: unknown) => {
           handleActionError(err, `${MARKER_LABELS[marker]} — akcia zlyhala, skúste to znova.`);
@@ -120,7 +132,7 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
           setBusyId("");
         });
     },
-    [load, handleActionError],
+    [load, handleActionError, badgeRefresh],
   );
 
   const removeNote = useCallback(
@@ -130,6 +142,7 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
       deleteFloorNote(id)
         .then(() => {
           load();
+          badgeRefresh();
         })
         .catch((err: unknown) => {
           handleActionError(err, "Zápis sa nepodarilo odstrániť — skúste to znova.");
@@ -138,7 +151,7 @@ export function FloorNotesSection({ role, onSessionExpired }: { readonly role: M
           setBusyId("");
         });
     },
-    [load, handleActionError],
+    [load, handleActionError, badgeRefresh],
   );
 
   const attachProduct = useCallback(

--- a/apps/web/src/dailyTasksApi.ts
+++ b/apps/web/src/dailyTasksApi.ts
@@ -14,6 +14,7 @@ const rowSchema = z.object({
 export type DailyTaskRow = z.infer<typeof rowSchema>;
 
 const listSchema = z.object({ rows: z.array(rowSchema) });
+const countSchema = z.object({ count: z.number() });
 
 export class DailyTasksUnauthorizedError extends Error {
   constructor() {
@@ -42,6 +43,17 @@ async function readJson(response: Response, fallback: string): Promise<unknown> 
 export async function fetchDailyTasks(): Promise<readonly DailyTaskRow[]> {
   const response = await fetch("/api/daily-tasks");
   return listSchema.parse(await readJson(response, "Úlohy sa nepodarilo načítať")).rows;
+}
+
+// issue 473: odznak počtu v ľavom menu — počet mojich otvorených úloh. Rovnaký
+// vzor ako `fetchUpozorneniaCount` (`upozorneniaApi.ts`): odznak nie je
+// kritický, takže pri 401/chybe vráti 0 namiesto vyhodenia (App.tsx nechá
+// odznak na poslednej známej hodnote).
+export async function fetchOpenDailyTasksCount(): Promise<number> {
+  const response = await fetch("/api/daily-tasks/count");
+  if (response.status === 401) return 0;
+  if (!response.ok) return 0;
+  return countSchema.parse(await response.json()).count;
 }
 
 export async function createDailyTask(text: string): Promise<void> {

--- a/apps/web/src/dailyTasksBadgeContext.ts
+++ b/apps/web/src/dailyTasksBadgeContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from "react";
+
+// issue 473: most medzi `DailyTasksSection` (mutuje dáta) a `App.tsx` (vlastní
+// odznak v ľavom menu, `badgeCounts`). Rovnaký vzor ako
+// `upozorneniaBadgeContext.ts` — context nesie LEN účinok "niečo sa zmenilo",
+// `App.tsx` si count naďalej načítava a vlastní SÁM (musí byť známy hneď po
+// prihlásení, nie až po prvom otvorení záložky), len dostáva DRUHÝ spúšťač
+// refetchu okrem zmeny záložky.
+export interface DailyTasksBadgeRefreshContextValue {
+  readonly refresh: () => void;
+}
+
+export const DailyTasksBadgeRefreshContext = createContext<DailyTasksBadgeRefreshContextValue>({
+  refresh: () => {
+    // Predvolená hodnota mimo Provider-a (napr. test, čo rendruje
+    // DailyTasksSection samostatne bez App.tsx) — bezpečné no-op.
+  },
+});

--- a/apps/web/src/floorNotesApi.ts
+++ b/apps/web/src/floorNotesApi.ts
@@ -28,6 +28,7 @@ const rowSchema = z.object({
 export type FloorNoteRow = z.infer<typeof rowSchema>;
 
 const listSchema = z.object({ rows: z.array(rowSchema) });
+const countSchema = z.object({ count: z.number() });
 
 export class FloorNotesUnauthorizedError extends Error {
   constructor() {
@@ -56,6 +57,16 @@ async function readJson(response: Response, fallback: string): Promise<unknown> 
 export async function fetchFloorNotes(): Promise<readonly FloorNoteRow[]> {
   const response = await fetch("/api/floor-notes");
   return listSchema.parse(await readJson(response, "Zoznam zápisov sa nepodarilo načítať")).rows;
+}
+
+// issue 473: odznak počtu v ľavom menu — počet nevybavených zápisov. Rovnaký
+// vzor ako `fetchUpozorneniaCount` (`upozorneniaApi.ts`): odznak nie je
+// kritický, pri 401/chybe vráti 0 namiesto vyhodenia.
+export async function fetchUnresolvedFloorNotesCount(): Promise<number> {
+  const response = await fetch("/api/floor-notes/count");
+  if (response.status === 401) return 0;
+  if (!response.ok) return 0;
+  return countSchema.parse(await response.json()).count;
 }
 
 export async function createFloorNote(text: string): Promise<void> {

--- a/apps/web/src/floorNotesBadgeContext.ts
+++ b/apps/web/src/floorNotesBadgeContext.ts
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+
+// issue 473: most medzi `FloorNotesSection` (mutuje dáta) a `App.tsx` (vlastní
+// odznak v ľavom menu, `badgeCounts`). Rovnaký vzor ako
+// `upozorneniaBadgeContext.ts`/`dailyTasksBadgeContext.ts` — context nesie LEN
+// účinok "niečo sa zmenilo", `App.tsx` si count naďalej načítava a vlastní SÁM.
+export interface FloorNotesBadgeRefreshContextValue {
+  readonly refresh: () => void;
+}
+
+export const FloorNotesBadgeRefreshContext = createContext<FloorNotesBadgeRefreshContextValue>({
+  refresh: () => {
+    // Predvolená hodnota mimo Provider-a (napr. test, čo rendruje
+    // FloorNotesSection samostatne bez App.tsx) — bezpečné no-op.
+  },
+});

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -143,6 +143,20 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
   await expect(upozornOdznak).toBeVisible();
   await expect(upozornOdznak).toHaveText(/^\d+$/);
 
+  // issue 473: rovnaký odznak vzor pre "Úlohy na dnes" (počet mojich otvorených
+  // úloh, per-používateľ) a "Objednávky predajňa" (počet nevybavených zápisov,
+  // globálne) — obe známe HNEĎ po prihlásení (`App.tsx` si ich fetchuje priamo).
+  // Presné číslo sa zámerne NEOVERUJE (zdieľaná e2e DB, `.claude/rules/
+  // frontend-design.md` issue 445 vzor) — len že odznak existuje a nesie platné
+  // celé číslo (odznak sa ukazuje aj pri 0, ako "upozornenia"/"dpd").
+  const ulohyOdznak = page.getByTestId("nav-badge-ulohy");
+  await expect(ulohyOdznak).toBeVisible();
+  await expect(ulohyOdznak).toHaveText(/^\d+$/);
+
+  const predajnaOdznak = page.getByTestId("nav-badge-floor-orders");
+  await expect(predajnaOdznak).toBeVisible();
+  await expect(predajnaOdznak).toHaveText(/^\d+$/);
+
   // issue 185: tri obrazovky, ktoré dovtedy sedeli len v `HIDDEN_TABS` — klik
   // na každú otvorí svoju obrazovku (samostatný `<h1>` titulok v Topbar-e,
   // žiadny duplicitný `<h2>` — obrazovky si ho pri presune odstránili). Dve z

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.276",
+  "version": "0.3.0-dev.277",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Rieši issue 473 — súčtové čísla (odznaky) otvorených položiek v ľavom menu pre
"Úlohy na dnes" a "Objednávky predajňa", presne v štýle odznaku pri Upozornenia.

(Ticket sa NEZATVÁRA automaticky — má post-deploy naživo overenie, preto BEZ
zatváracieho kľúčového slova; zatvorí sa ručne až po overení po nasadení.)

## Čo pribudlo

**API (dva `COUNT(*)` endpointy, vzor `GET /api/upozornenia/count`):**
- `GET /api/daily-tasks/count` (`requireUser`) → `{ count }` z
  `COUNT(*) WHERE user_id = prihlásený AND done_at IS NULL` — PER-POUŽÍVATEĽ.
- `GET /api/floor-notes/count` (`requireUser`) → `{ count }` z
  `COUNT(*) WHERE resolved = false` — globálne; značky 🛒 objednané / 📞
  zavolané do počtu NEVSTUPUJÚ.
- Literálna `/count` trasa registrovaná pred `:id` trasami
  (`.claude/rules/http-routes.md`).

**Frontend:**
- `App.tsx` vlastní/fetchuje oba počty (vzor Upozornenia — známe HNEĎ po
  prihlásení), publikuje kľúče `ulohy` a `floor-orders` do `badgeCounts`;
  `Sidebar` ich vykreslí genericky. Odznak sa ukazuje aj pri 0.
- Dva nové refresh contexty (`dailyTasksBadgeContext`/`floorNotesBadgeContext`)
  — sekcie po každej count-meniacej mutácii zavolajú `refresh()`, takže číslo
  klesne/stúpne hneď bez reloadu:
  - `DailyTasksSection`: pridať / zmazať / odfajknúť done (toggle oboma smermi).
  - `FloorNotesSection`: pridať / zmazať / prepnúť ✅ vybavené (oboma smermi).
    Značky 🛒/📞 count nemenia → refresh nevolajú.

## Testy

- **API integračné:** oba count endpointy s kontrolovanými dátami — 0; len
  otvorené/nevybavené sa rátajú; toggle done/resolved oboma smermi; per-user
  izolácia (daily-tasks); ordered/called nemenia floor-notes count; globálny
  zdieľaný floor-notes count.
- **Web unit (badgeRefresh):** obe sekcie volajú `refresh()` po count-meniacej
  mutácii; FloorNotesSection NEvolá refresh pri 🛒 objednané; DailyTasksSection
  NEvolá refresh pri úprave textu.
- **E2E (`nav.spec.ts`):** oba odznaky viditeľné + `/^\d+$/`.

Lokálne overené: `pnpm gates:local` zelené (typecheck + lint + unit — API 1010,
web 722). Integračné + e2e bežia v CI.
