### PR TITLE
Riešiť: rýchle pole 200 {ok:false} pri omyle (issue 476 follow-up)

### DIFF
--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -111,11 +111,19 @@ export function registerOrdersRoutes(
         actorUserId: user.userId,
         now: new Date(),
       });
+      // Neznáme/zatvorené číslo je BEŽNÝ, OČAKÁVANÝ používateľský omyl (preklep
+      // v čísle), nie HTTP chyba — vraciame 200 s `{ok:false,error}`, nie 4xx.
+      // Chromium loguje „Failed to load resource" pre KAŽDÝ fetch s 4xx, čo by
+      // pri rýchlom poli (overovanom cez Playwright s kontrolou nulovej konzoly)
+      // porušilo zákaz konzolových chýb (`.claude/rules/testing.md`, rovnaký
+      // vzor ako `/api/catalog/ingest`'s `{status:"busy"}` a `/api/me/password`).
+      // Naživo overené (post-deploy 0.3.0-dev.278): 400 SKUTOČNE zalogovalo
+      // konzolovú chybu na prode — preto táto oprava.
       if (result.status === "order_not_found") {
-        return c.json({ error: `Objednávka s číslom „${code}" sa nenašla.` }, 400);
+        return c.json({ ok: false as const, error: `Objednávka s číslom „${code}" sa nenašla.` });
       }
       if (result.status === "order_not_open") {
-        return c.json({ error: `Objednávka „${code}" už nie je otvorená — nedá sa presunúť do Riešiť.` }, 400);
+        return c.json({ ok: false as const, error: `Objednávka „${code}" už nie je otvorená — nedá sa presunúť do Riešiť.` });
       }
       log.info({ actorUserId: user.userId, code, lineCount: result.lineCount }, "hromadné označenie objednávky stavom Riešiť");
       return c.json({ ok: true as const, lineCount: result.lineCount });

--- a/apps/api/tests/riesit-http.integration.test.ts
+++ b/apps/api/tests/riesit-http.integration.test.ts
@@ -205,18 +205,22 @@ it("POST /api/orders/riesit/by-code: keď je objednávka UŽ celá v riesit, vr�
   expect(audit.length).toBe(2);
 });
 
-it("POST /api/orders/riesit/by-code: neznáme číslo vráti 400 so zrozumiteľnou hláškou", async () => {
+it("POST /api/orders/riesit/by-code: neznáme číslo vráti 200 {ok:false} so zrozumiteľnou hláškou (NIE 4xx — konzola)", async () => {
   const { app, cookie } = await boot("manazer");
   const res = await app.request("/api/orders/riesit/by-code", {
     method: "POST",
     headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ code: "999999" }),
   });
-  expect(res.status).toBe(400);
-  expect(((await res.json()) as { error: string }).error).toContain("nenašla");
+  // 200, nie 4xx — bežný používateľský omyl nesmie logovať konzolovú chybu
+  // (Chromium loguje 4xx; `.claude/rules/testing.md`), naživo overené na prode.
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { ok: boolean; error?: string };
+  expect(telo.ok).toBe(false);
+  expect(telo.error).toContain("nenašla");
 });
 
-it("POST /api/orders/riesit/by-code: zatvorená objednávka vráti 400 (nie je otvorená)", async () => {
+it("POST /api/orders/riesit/by-code: zatvorená objednávka vráti 200 {ok:false} (nie je otvorená, NIE 4xx)", async () => {
   const { app, cookie, db } = await boot("manazer");
   const zatvorena = await vlozObjednavku(db, 1, "Vybavená");
 
@@ -225,8 +229,10 @@ it("POST /api/orders/riesit/by-code: zatvorená objednávka vráti 400 (nie je o
     headers: { cookie, "content-type": "application/json" },
     body: JSON.stringify({ code: zatvorena.code }),
   });
-  expect(res.status).toBe(400);
-  expect(((await res.json()) as { error: string }).error).toContain("nie je otvorená");
+  expect(res.status).toBe(200);
+  const telo = (await res.json()) as { ok: boolean; error?: string };
+  expect(telo.ok).toBe(false);
+  expect(telo.error).toContain("nie je otvorená");
 
   // stav riadku sa nezmenil
   const [r] = await db.select({ state: orderLines.state }).from(orderLines).where(eq(orderLines.id, zatvorena.lineIds[0] ?? ""));

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -205,12 +205,20 @@ export async function fetchRiesitCount(): Promise<number> {
   }
 }
 
-const riesitByCodeResultSchema = z.object({ ok: z.literal(true), lineCount: z.number() });
+// issue 476: server vracia 200 v OBOCH prípadoch — úspech `{ok:true,lineCount}`
+// aj OČAKÁVANÝ používateľský omyl (neznáme/zatvorené číslo) `{ok:false,error}`
+// — NIKDY 4xx za taký omyl (Chromium by zalogoval konzolovú chybu, viď server
+// komentár + `.claude/rules/testing.md`; rovnaký vzor ako `sendSupplierOrderMail`).
+const riesitByCodeResultSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), lineCount: z.number() }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
 
-// issue 476: rýchle pole „číslo objednávky → Enter" — nastaví stav `riesit`
-// na všetkých riadkoch danej objednávky. Neznáme/zatvorené číslo vráti server
-// ako 400 `{error}`, ktoré `readJson` premení na `Error` so slovenskou
-// hláškou (zobrazí ju volajúci `RiesitSection`).
+// issue 476: rýchle pole „číslo objednávky → Enter" — nastaví stav `riesit` na
+// všetkých riadkoch danej objednávky. Doménový neúspech (neznáme/zatvorené
+// číslo) príde ako 200 `{ok:false,error}` — vyhodíme `Error(error)`, aby ju
+// `RiesitSection` zobrazila cez existujúci `catch`; 4xx/5xx (401, CSRF, ...) sú
+// SKUTOČNÉ HTTP chyby a rieši ich `readJson`.
 export async function setOrderLinesRiesitByCode(code: string): Promise<{ readonly lineCount: number }> {
   const response = await fetch("/api/orders/riesit/by-code", {
     method: "POST",
@@ -218,6 +226,7 @@ export async function setOrderLinesRiesitByCode(code: string): Promise<{ readonl
     body: JSON.stringify({ code }),
   });
   const telo = riesitByCodeResultSchema.parse(await readJson(response, "Označenie objednávky sa nepodarilo"));
+  if (!telo.ok) throw new Error(telo.error);
   return { lineCount: telo.lineCount };
 }
 

--- a/apps/web/tests/e2e/riesit.spec.ts
+++ b/apps/web/tests/e2e/riesit.spec.ts
@@ -71,7 +71,9 @@ test("Riešiť: riadok sa zobrazí, zmena stavu ho odstráni, odznak svieti, rý
       if (url.includes("/api/orders/riesit/by-code")) {
         const telo = typeof init?.body === "string" ? init.body : "{}";
         const code = (JSON.parse(telo) as { code?: string }).code ?? "";
-        if (code === "9999") return Promise.resolve(json({ error: `Objednávka s číslom „${code}“ sa nenašla.` }, 400));
+        // Neznáme číslo = 200 `{ok:false,error}` (NIE 4xx) — verné reálnemu
+        // serveru, aby konzola ostala čistá (viď server komentár / testing.md).
+        if (code === "9999") return Promise.resolve(json({ ok: false, error: `Objednávka s číslom „${code}“ sa nenašla.` }));
         return Promise.resolve(json({ ok: true, lineCount: 1 }));
       }
       if (url.includes("/api/orders/riesit")) return Promise.resolve(json({ suppliers: [skupina] }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.278",
+  "version": "0.3.0-dev.279",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Následná oprava issue 476 — rýchle pole „Riešiť" vracia 200 `{ok:false}` pri omyle, nie 4xx.

Post-deploy naživo overenie `0.3.0-dev.278` odhalilo, že `POST /api/orders/riesit/by-code` vracalo 400 pri neznámom/zatvorenom čísle objednávky (bežný používateľský omyl). Chromium loguje „Failed to load resource" pre KAŽDÝ 4xx fetch → porušenie zákazu konzolových chýb (`.claude/rules/testing.md`). Naživo na prode 400 SKUTOČNE zalogovalo konzolovú chybu; e2e to nechytilo, lebo mockuje fetch.

- Server: 200 `{ok:false,error}` pri neznámom/zatvorenom čísle (úspech ostáva 200 `{ok:true,lineCount}`), vzor `/api/catalog/ingest` / `sendSupplierOrderMail`.
- Frontend: `setOrderLinesRiesitByCode` parsuje discriminated union, `{ok:false}` → Error (zobrazí RiesitSection).
- Integračné testy + e2e mock zosúladené s reálnym správaním.
- bump `0.3.0-dev.279`.

`pnpm gates:local` zelené (typecheck + lint + api unit 1010 + web unit 728), CI dev zelené (5/5).

issue 476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
