### PR TITLE
playbook(riesit): záznamy issue 476 + bump .280

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -428,3 +428,14 @@ paths:
   drizzle.__drizzle_migrations` ukazuje „nejaké" aplikované — porovnaj počet
   `.sql` súborov (`ls apps/api/drizzle/*.sql | wc -l`) vs. riadkov v
   `__drizzle_migrations`.
+- **POZITÍVNY precedens k issue 399 (issue 476): SAMOSTATNÝ `ALTER TYPE ... ADD
+  VALUE 'x'`, ktorého hodnotu používa LEN runtime kód (WHERE/porovnania), a
+  NIKDY žiadna DDL (CHECK/index/generated-column), je BEZPEČNÝ aj v drizzle-ho
+  single-transakcii, aj keď je viac migrácií čakajúcich naraz.** `order_line_
+  state ADD VALUE 'riesit'` (migrácia `0058`) — 55P04 „unsafe use of new value"
+  vyžaduje, aby sa hodnota v TEJ ISTEJ `migrate()` transakcii aj POUŽILA v DDL
+  proti NEPRÁZDNEJ tabuľke; samotné pridanie hodnoty túto stráž nespustí.
+  `db:generate` z rozšíreného `pgEnum` poľa vygeneruje presne jeden riadok bez
+  breakpointu — over, že migrácia NEOBSAHUJE žiadny CHECK/index/generated-column
+  s novou hodnotou (ak áno, platí plná obrana issue 399: `::text` porovnanie
+  alebo samostatný deploy len s ADD VALUE pred použitím).

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -746,3 +746,20 @@ paths:
   apps/web/src`), inak netypovaná fixtúra nesie `undefined` a napr.
   `undefined < 2` je `false`, takže odznak sa VYKRESLÍ s textom "undefined"
   (pravidlo "každé pole explicitne, nikdy undefined" vyššie v tomto súbore).
+- **Sekcia „Riešiť" (issue 476, piaty EXKLUZÍVNY stav `riesit`, princíp
+  `nedostupne`) znovupoužíva jadro „Na objednanie" cez zdieľaný hook
+  `apps/web/src/useOrderLinesBoard.ts` — NIE cez kópiu OrdersSection.** Hook
+  nesie `suppliers` + všetky mutácie (stav/objednané/priradenie/odkaz/poznámka/
+  hromadné) + sub-hooky (drafts, dirtyEditors, email, mail, supplier-link).
+  OrdersSection aj RiesitSection ho konzumujú; OrdersSection správanie ostalo
+  1:1 (`keepOnlyState` undefined → pôvodný optimistický map; `onStateChanged`
+  no-op default). RiesitSection posiela `keepOnlyState:"riesit"` (riadok pri
+  zmene stavu na iný sa lokálne odstráni) + vlastné rýchle pole. **Backend:**
+  `listOpenOrderLinesBySupplier(db, adminBaseUrl, { stateFilter })` (NEduplikuje
+  query), `countOpenOrderLinesByState`, `setOrderLinesStateByCode` (bulk podľa
+  `externalOrderId`); trasy `GET /api/orders/riesit(/count)`, `POST /riesit/
+  by-code` — VŠETKY PRED `GET /api/orders/:id` (literal-pred-`:param`).
+  `by-code` vracia 200 `{ok:false,error}` pri neznámom/zatvorenom čísle (NIE 4xx
+  — konzola, `.claude/rules/testing.md`). Menu odznak `riesit` vzor issue 473.
+  KAŽDÁ ďalšia „obrazovka nad podmnožinou otvorených objednávok" nech použije
+  `useOrderLinesBoard` + `stateFilter`, nie novú kópiu.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -796,3 +796,35 @@ paths:
   "[0-9]+"' scripts/e2e-setup.ts scripts/e2e-fixtures-*.ts | sort -u` a vyber
   číslo, ktoré tam NIE JE (napr. `9099`). (Grep len `e2e-setup.ts` je presne tá
   pasca, čo spôsobila oba zbytočné cykly.)
+- **Endpoint, ktorého BEŽNÝ používateľský OMYL sa overuje cez Playwright s
+  kontrolou nulovej konzoly, NESMIE vracať 4xx — a e2e s prepichnutým
+  `window.fetch` túto pascu SKRYJE, chytí ju až naživo overenie na prode
+  (issue 476).** Rýchle pole „Riešiť" (`POST /api/orders/riesit/by-code`) vracalo
+  pri neznámom/zatvorenom čísle objednávky (typický preklep) 400. Chromium
+  loguje „Failed to load resource" pre KAŽDÝ 4xx `fetch()` (existujúci bod
+  vyššie), takže reálny používateľský omyl zaложил konzolovú chybu. **`riesit
+  .spec.ts` to NECHYTILO**, lebo mockuje `window.fetch` na JS-úrovni (vracia
+  `new Response(..., {status:400})` z overridu, NIE cez sieť) — a JS-level
+  Response 4xx do konzoly NELOGUJE, na rozdiel od skutočnej sieťovej odpovede.
+  `pnpm gates:local` (unit only) ani e2e teda nič nehlásili; chybu odhalil až
+  post-deploy Playwright klik na prode (`console_messages` = 1 error). Fix
+  (vzor `/api/catalog/ingest` `{status:"busy"}` / `POST /api/me/password`):
+  server vracia **200 `{ok:false,error}`** pri očakávanom omyle, 4xx si necháva
+  pre skutočné HTTP chyby (401/CSRF/malformed). **Dve poučenia:** (1) nový
+  endpoint, ktorého doménový neúspech je bežný používateľský omyl, vracaj 200
+  `{ok:false,error}`, nie 4xx; (2) keď e2e MOCKUJE `window.fetch`, over jeho
+  status-kódy proti REÁLNEMU serveru — mock 4xx neodhalí konzolovú chybu, ktorú
+  reálna 4xx odpoveď spôsobí (post-deploy naživo klik cez Playwright +
+  `browser_console_messages` je jediná spoľahlivá kontrola tejto triedy).
+- **Nová e2e obrazovka nad ZDIEĽANÝMI objednávkami sa NEDÁ testovať reálne
+  seedovanými dátami — `orders.spec.ts`'s prvý test asertuje PRESNÉ GLOBÁLNE
+  počty otvorených riadkov („Všetci (N)", „Ostáva vybaviť X z N") naprieč
+  VŠETKÝMI dodávateľmi, takže KAŽDÁ nová objednávka ich rozbije, a mutovanie
+  zdieľaných objednávok medzi paralelnými workermi je race (issue 476).**
+  Riešenie: prepichnutý `window.fetch` (`addInitScript`, vzor
+  `orders-write-failures.spec.ts`) — mockni len endpointy tej sekcie
+  (`/api/orders/riesit(/count|/by-code)`, `.../lines/:id/state`), zvyšok (login,
+  `/api/me`, ostatné badge counts) nechaj ísť reálne. Retry-safe, žiadna
+  kolízia, reálne kliky + kontrola konzoly. Reálny endpoint end-to-end pokrýva
+  API integračný test, komponent+hook unit test. (Pozor na status-kódy mocku —
+  viď bod vyššie.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.279",
+  "version": "0.3.0-dev.280",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
playbook-review záznamy po issue 476 (`.claude/rules/*`) + bump `0.3.0-dev.280`. Bez zmeny aplikačného kódu.

- testing.md: očakávaný používateľský omyl nesmie vracať 4xx (Chromium loguje konzolovú chybu) a e2e s mock `window.fetch` to SKRYJE — chytí až post-deploy naživo klik; mock-fetch vzor pre novú obrazovku nad zdieľanými objednávkami.
- database.md: pozitívny precedens k issue 399 (samostatný ADD VALUE bez DDL použitia je bezpečný).
- orders.md: sekcia Riešiť cez `useOrderLinesBoard` + `stateFilter`, trasy riesit, by-code 200 `{ok:false}`.

issue 476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
