### PR TITLE
Na objednanie: predajňové položky (🛍️) zo zápisov Objednávky predajňa (issue 480)

### DIFF
--- a/apps/api/drizzle/0059_slimy_stranger.sql
+++ b/apps/api/drizzle/0059_slimy_stranger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "floor_note_product" ADD COLUMN "ordered_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0059_snapshot.json
+++ b/apps/api/drizzle/meta/0059_snapshot.json
@@ -1,0 +1,3891 @@
+{
+  "id": "5725a3bc-52b2-4856-af3b-c279cabaa7f0",
+  "prevId": "177fcaa2-c836-4a7e-9655-4c0e4c2daa23",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "shop_product_url_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\"::text IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\"::text IN ('unavailable','discontinued','split') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_variant_link": {
+      "name": "pairing_variant_link",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_variant_link_code_variant_code_fk": {
+          "name": "pairing_variant_link_code_variant_code_fk",
+          "tableFrom": "pairing_variant_link",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note_product": {
+      "name": "floor_note_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "floor_note_id": {
+          "name": "floor_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ordered_at": {
+          "name": "ordered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_product_note_idx": {
+          "name": "floor_note_product_note_idx",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "floor_note_product_note_variant_uq": {
+          "name": "floor_note_product_note_variant_uq",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_product_floor_note_id_floor_note_id_fk": {
+          "name": "floor_note_product_floor_note_id_floor_note_id_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "floor_note",
+          "columnsFrom": [
+            "floor_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_note_product_variant_code_variant_code_fk": {
+          "name": "floor_note_product_variant_code_variant_code_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "floor_note_product_quantity_ck": {
+          "name": "floor_note_product_quantity_ck",
+          "value": "\"floor_note_product\".\"quantity\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.floor_note": {
+      "name": "floor_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "called": {
+          "name": "called",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_created_at_idx": {
+          "name": "floor_note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_created_by_user_id_users_id_fk": {
+          "name": "floor_note_created_by_user_id_users_id_fk",
+          "tableFrom": "floor_note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_created_at_idx": {
+          "name": "note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_author_user_id_users_id_fk": {
+          "name": "note_author_user_id_users_id_fk",
+          "tableFrom": "note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne",
+        "riesit"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.shop_product_url_source": {
+      "name": "shop_product_url_source",
+      "schema": "public",
+      "values": [
+        "feed",
+        "sitemap",
+        "probe"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued",
+        "split"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1787514781727,
       "tag": "0058_faithful_blue_shield",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1787524179494,
+      "tag": "0059_slimy_stranger",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-floor-notes.ts
+++ b/apps/api/src/db/schema-floor-notes.ts
@@ -73,6 +73,15 @@ export const floorNoteProducts = pgTable(
     // riziko 55P04 (`.claude/rules/database.md`). CHECK `>= 1` nižšie je
     // druhá obrana popri zod `int().min(1)` na trase.
     quantity: integer("quantity").notNull().default(1),
+    // issue 480: kedy sa TÁTO položka zápisu objednala u dodávateľa v board-e
+    // „Na objednanie" (nullable, `NULL` = ešte neobjednané). Priamy náprotivok
+    // `order_line.ordered` (issue 60), len ako časová pečiatka namiesto boolean
+    // — timestamp nesie aj „kedy" a je konzistentný s audit-ovanými zápismi.
+    // `floor_note.ordered` (🛒) sa z neho PREPOČÍTA (`floor-notes/service.ts`'s
+    // `recomputeFloorNoteOrdered`): true práve keď má zápis ≥1 položku a VŠETKY
+    // majú `ordered_at`. Predajňové riadky do „Na objednanie" pridáva
+    // `orders/queries.ts` (rovnaká efektívna dodávateľská cesta ako order_line).
+    orderedAt: timestamp("ordered_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/apps/api/src/http/floor-notes-routes.ts
+++ b/apps/api/src/http/floor-notes-routes.ts
@@ -9,6 +9,7 @@ import {
   detachFloorNoteProduct,
   setFloorNoteCalled,
   setFloorNoteOrdered,
+  setFloorNoteProductOrdered,
   setFloorNoteResolved,
   updateFloorNoteProductQuantity,
   updateFloorNoteText,
@@ -149,6 +150,38 @@ export function registerFloorNotesRoutes(app: Hono<AppBindings>, db: Database): 
       const { quantity } = c.req.valid("json");
       const updated = await updateFloorNoteProductQuantity(db, { floorNoteId: id, variantCode, quantity });
       return c.json({ ok: true as const, updated });
+    },
+  );
+
+  // issue 480: „objednané" na predajňovom riadku v board-e „Na objednanie" —
+  // nastaví `floor_note_product.ordered_at` a prepočíta note-level 🛒
+  // (`setFloorNoteProductOrdered`). Rovnaké oprávnenie + CSRF disciplína ako
+  // ostatné zápisy. 6-segmentová trasa (`.../products/:variantCode/ordered`) sa
+  // NEKOLÍDUJE so 4-segmentovým `POST .../products` (attach) ani s
+  // 5-segmentovým `DELETE .../:variantCode` (iný počet segmentov / iná metóda,
+  // `.claude/rules/http-routes.md`).
+  app.post(
+    "/api/floor-notes/:id/products/:variantCode/ordered",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("param", productParam),
+    zValidator("json", markerBody),
+    async (c) => {
+      const { id, variantCode } = c.req.valid("param");
+      const { value } = c.req.valid("json");
+      const user = c.get("user");
+      const result = await setFloorNoteProductOrdered(db, {
+        floorNoteId: id,
+        variantCode,
+        ordered: value,
+        actorUserId: user.userId,
+        now: new Date(),
+      });
+      if (result === "not_found") {
+        return c.json({ error: "Položka zápisu sa nenašla" }, 404);
+      }
+      return c.json({ ok: true as const, ordered: value });
     },
   );
 

--- a/apps/api/src/modules/floor-notes/service.ts
+++ b/apps/api/src/modules/floor-notes/service.ts
@@ -108,20 +108,27 @@ export type AttachFloorNoteProductResult =
 // (`onConflictDoNothing`, unique index `floor_note_product_note_variant_uq`)
 // — appka to nerieši chybou, "Pripnúť" jednoducho nič nezmení.
 export async function attachFloorNoteProduct(db: Database, input: AttachFloorNoteProductInput): Promise<AttachFloorNoteProductResult> {
-  const [note] = await db.select({ id: floorNotes.id }).from(floorNotes).where(eq(floorNotes.id, input.floorNoteId));
-  if (note === undefined) return { ok: false, error: "note_not_found" };
-  const [variant] = await db.select({ code: variants.code }).from(variants).where(eq(variants.code, input.variantCode));
-  if (variant === undefined) return { ok: false, error: "product_not_found" };
+  return db.transaction(async (tx) => {
+    const [note] = await tx.select({ id: floorNotes.id }).from(floorNotes).where(eq(floorNotes.id, input.floorNoteId));
+    if (note === undefined) return { ok: false, error: "note_not_found" };
+    const [variant] = await tx.select({ code: variants.code }).from(variants).where(eq(variants.code, input.variantCode));
+    if (variant === undefined) return { ok: false, error: "product_not_found" };
 
-  await db
-    .insert(floorNoteProducts)
-    .values({ floorNoteId: input.floorNoteId, variantCode: input.variantCode, quantity: input.quantity, createdAt: input.now })
-    // Opätovné pripnutie TOHO ISTÉHO produktu ostáva idempotentné
-    // (`.claude/rules/floor-notes.md`) — počet sa mení VÝHRADNE cez
-    // `updateFloorNoteProductQuantity` (samostatná PATCH trasa), nie
-    // opätovným pinom.
-    .onConflictDoNothing();
-  return { ok: true };
+    await tx
+      .insert(floorNoteProducts)
+      .values({ floorNoteId: input.floorNoteId, variantCode: input.variantCode, quantity: input.quantity, createdAt: input.now })
+      // Opätovné pripnutie TOHO ISTÉHO produktu ostáva idempotentné
+      // (`.claude/rules/floor-notes.md`) — počet sa mení VÝHRADNE cez
+      // `updateFloorNoteProductQuantity` (samostatná PATCH trasa), nie
+      // opätovným pinom.
+      .onConflictDoNothing();
+    // issue 480: `floor_note.ordered` (🛒) je odvodené z objednaného stavu
+    // VŠETKÝCH položiek zápisu — nová položka je neobjednaná, takže po pripnutí
+    // treba prepočítať (inak by 🛒 z predchádzajúceho „všetko objednané" ostalo
+    // zavádzajúco true).
+    await recomputeFloorNoteOrdered(tx, input.floorNoteId);
+    return { ok: true };
+  });
 }
 
 export interface UpdateFloorNoteProductQuantityInput {
@@ -226,9 +233,15 @@ export interface DetachFloorNoteProductInput {
 }
 
 export async function detachFloorNoteProduct(db: Database, input: DetachFloorNoteProductInput): Promise<boolean> {
-  const result = await db
-    .delete(floorNoteProducts)
-    .where(and(eq(floorNoteProducts.floorNoteId, input.floorNoteId), eq(floorNoteProducts.variantCode, input.variantCode)))
-    .returning({ id: floorNoteProducts.id });
-  return result.length > 0;
+  return db.transaction(async (tx) => {
+    const result = await tx
+      .delete(floorNoteProducts)
+      .where(and(eq(floorNoteProducts.floorNoteId, input.floorNoteId), eq(floorNoteProducts.variantCode, input.variantCode)))
+      .returning({ id: floorNoteProducts.id });
+    // issue 480: po odobratí položky sa mohlo stať, že VŠETKY zvyšné položky sú
+    // objednané (🛒 → true), alebo že zápis ostal bez položiek (🛒 → false) —
+    // prepočítaj. No-op, keď sa nič neodobralo (neexistujúca dvojica).
+    await recomputeFloorNoteOrdered(tx, input.floorNoteId);
+    return result.length > 0;
+  });
 }

--- a/apps/api/src/modules/floor-notes/service.ts
+++ b/apps/api/src/modules/floor-notes/service.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { floorNoteProducts, floorNotes, variants } from "../../db/schema.js";
+import { record } from "../audit/service.js";
 
 export interface CreateFloorNoteInput {
   readonly text: string;
@@ -139,6 +140,84 @@ export async function updateFloorNoteProductQuantity(db: Database, input: Update
     .where(and(eq(floorNoteProducts.floorNoteId, input.floorNoteId), eq(floorNoteProducts.variantCode, input.variantCode)))
     .returning({ id: floorNoteProducts.id });
   return result.length > 0;
+}
+
+// issue 480: prepočíta note-level 🛒 (`floor_note.ordered`) z objednaného stavu
+// POLOŽIEK zápisu — `true` práve keď má zápis ≥1 položku a VŠETKY majú
+// `ordered_at` nastavené, inak `false` (symetricky: odškrtnutie ktorejkoľvek
+// položky 🛒 zhodí). Spúšťa sa po KAŽDEJ zmene objednaného stavu položky
+// (per-item `setFloorNoteProductOrdered` nižšie AJ hromadné cez skupinu
+// dodávateľa v `orders/state.ts`'s `setSupplierLinesOrdered`), VŽDY v tej istej
+// transakcii. Ručný 🛒 prepínač (`setFloorNoteOrdered`) ostáva NEZÁVISLÝ —
+// tento prepočet sa spúšťa len pri zmene objednaného stavu položky, nikdy pri
+// pin/odpin (počty aj tak čítajú `ordered_at` per položku, ostávajú správne).
+// `updated_at` sa NEbumpuje — je to odvodený dôsledok zmeny junction riadku,
+// rovnaký zámer ako `updateFloorNoteProductQuantity` (množstvo je atribút
+// junction riadku, nie textu zápisu). `Pick<Database, "select" | "update">` —
+// prijíma aj `tx` (`PgTransaction` nemá `Database.$client`, rovnaký vzor ako
+// `queries.ts`'s `Pick<Database, "select">`).
+export async function recomputeFloorNoteOrdered(
+  db: Pick<Database, "select" | "update">,
+  floorNoteId: string,
+): Promise<void> {
+  const productRows = await db
+    .select({ orderedAt: floorNoteProducts.orderedAt })
+    .from(floorNoteProducts)
+    .where(eq(floorNoteProducts.floorNoteId, floorNoteId));
+  const allOrdered = productRows.length > 0 && productRows.every((r) => r.orderedAt !== null);
+  await db.update(floorNotes).set({ ordered: allOrdered }).where(eq(floorNotes.id, floorNoteId));
+}
+
+export interface SetFloorNoteProductOrderedInput {
+  readonly floorNoteId: string;
+  readonly variantCode: string;
+  readonly ordered: boolean;
+  readonly actorUserId: string;
+  readonly now: Date;
+}
+
+export type SetFloorNoteProductOrderedResult = "ok" | "not_found";
+
+// issue 480: „objednané" na predajňovom riadku v board-e „Na objednanie" —
+// nastaví `floor_note_product.ordered_at` (NULL = zrušené), prepočíta note-level
+// 🛒 a zapíše audit, VŠETKO v jednej transakcii (rovnaký vzor ako
+// `orders/state.ts`'s `setOrderLineOrdered`). `.for("update")` proti súbežnej
+// zmene TEJ ISTEJ položky (audit `from` by inak mohol prečítať zastaraný stav).
+export async function setFloorNoteProductOrdered(
+  db: Database,
+  input: SetFloorNoteProductOrderedInput,
+): Promise<SetFloorNoteProductOrderedResult> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ id: floorNoteProducts.id, orderedAt: floorNoteProducts.orderedAt })
+      .from(floorNoteProducts)
+      .where(and(eq(floorNoteProducts.floorNoteId, input.floorNoteId), eq(floorNoteProducts.variantCode, input.variantCode)))
+      .for("update")
+      .limit(1);
+    if (row === undefined) return "not_found";
+
+    await tx
+      .update(floorNoteProducts)
+      .set({ orderedAt: input.ordered ? input.now : null })
+      .where(eq(floorNoteProducts.id, row.id));
+    await recomputeFloorNoteOrdered(tx, input.floorNoteId);
+
+    await record(tx, {
+      at: input.now,
+      actorUserId: input.actorUserId,
+      action: "floor_note_product.ordered.changed",
+      entity: "floor_note_product",
+      entityId: row.id,
+      data: {
+        floorNoteId: input.floorNoteId,
+        variantCode: input.variantCode,
+        from: row.orderedAt !== null,
+        to: input.ordered,
+      },
+    });
+
+    return "ok";
+  });
 }
 
 export interface DetachFloorNoteProductInput {

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,6 +1,8 @@
 import { and, asc, count, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import {
+  floorNoteProducts,
+  floorNotes,
   orderLines,
   orders,
   productSupplierLinkOverrides,
@@ -109,9 +111,42 @@ export interface OpenOrderLine {
   readonly customerOpenOrderCount: number;
 }
 
+// issue 480: predajňový (floor) riadok v board-e „Na objednanie" — produkt
+// pripnutý na NEVYBAVENOM zápise „Objednávky predajňa" (`floor_note_product`),
+// zaradený pod svojho dodávateľa rovnakou efektívnou cestou ako `order_line`
+// (viď `listOpenOrderLinesBySupplier` nižšie). NEMÁ stavový automat ani väzbu
+// na `order_line` — nesie LEN značku „objednané" (`ordered`, z
+// `floor_note_product.ordered_at`). Klik na obrazovke vedie na zápis v
+// „Objednávky predajňa" (`?tab=floor-orders`), preto tu nie je žiadny
+// admin/Shoptet odkaz. Do e-mailu dodávateľovi sa NEZAHŔŇA (`mail.ts` číta len
+// `order_line`).
+export interface FloorOrderRow {
+  // `floor_note_product` je kľúčované dvojicou (noteId, variantCode) — obe
+  // treba na zapisovaciu trasu „objednané" aj ako stabilný React key.
+  readonly noteId: string;
+  readonly variantCode: string;
+  readonly productName: string;
+  readonly sizeLabel: string | null;
+  // Meno zákazníka = PRVÝ riadok voľného textu zápisu, orezaný (zadanie
+  // klienta). Prázdny reťazec, keď je text prázdny (v praxi nenastane —
+  // `createBody`'s `.min(1)`).
+  readonly customerName: string;
+  readonly quantity: number;
+  // `floor_note.created_at` (dátum zápisu) — ISO 8601 reťazec, rovnaký tvar
+  // ako `OpenOrderLine.placedAt`, aby triedenie skupín fungovalo jednotne.
+  readonly createdAt: string;
+  // `floor_note_product.ordered_at !== null` — jediná „vybavené" sémantika
+  // floor riadku (žiadny stav).
+  readonly ordered: boolean;
+}
+
 export interface SupplierOpenOrders {
   readonly supplier: string;
   readonly lines: readonly OpenOrderLine[];
+  // issue 480: predajňové riadky pod tým istým dodávateľom (vždy prítomné pole,
+  // prázdne pre sekciu „Riešiť" — tá `stateFilter` nastavuje, floor riadky sa
+  // pridávajú LEN keď `stateFilter === undefined`).
+  readonly floorRows: readonly FloorOrderRow[];
   // E-mailový kontakt dodávateľa (#31), `null` keď zatiaľ nenastavený —
   // `supplier_contact` je samostatná tabuľka (manažér ju edituje nezávisle
   // od importu objednávok), preto sa dopytuje osobitne od hlavného
@@ -167,6 +202,53 @@ export async function countOpenOrdersByCustomer(
   return counts;
 }
 
+// issue 480: predajňové riadky pre board „Na objednanie" — produkty pripnuté na
+// NEVYBAVENÝCH zápisoch (`floor_note.resolved = false`) s efektívnym
+// dodávateľom počítaným TOU ISTOU cestou ako `order_line`
+// (`effectiveSupplierSql = coalesce(products.supplier, override)`,
+// `supplier-key.ts`). Zámerne SAMOSTATNÝ dopyt (nie JOIN na hlavný riadkový),
+// keďže floor riadky sa zoskupujú per dodávateľ AŽ v JS spolu s riadkami
+// objednávok. Zoradené najnovšie-prvé (zhodne s hlavným dopytom), aby
+// `floorRows[0]` bol najnovší floor riadok skupiny (triedenie skupín nižšie).
+// Vracia `effectiveSupplier` ako surový reťazec (`null` = bez dodávateľa) —
+// normalizáciu/kanonický pravopis rieši volajúci rovnako ako pri order_line.
+async function listUnresolvedFloorOrderRows(
+  db: Pick<Database, "select">,
+): Promise<readonly (FloorOrderRow & { readonly effectiveSupplier: string | null })[]> {
+  const rows = await db
+    .select({
+      noteId: floorNoteProducts.floorNoteId,
+      noteText: floorNotes.text,
+      noteCreatedAt: floorNotes.createdAt,
+      variantCode: floorNoteProducts.variantCode,
+      productName: variants.name,
+      sizeLabel: variants.sizeLabel,
+      quantity: floorNoteProducts.quantity,
+      orderedAt: floorNoteProducts.orderedAt,
+      effectiveSupplier: effectiveSupplierSql,
+    })
+    .from(floorNoteProducts)
+    .innerJoin(floorNotes, eq(floorNotes.id, floorNoteProducts.floorNoteId))
+    .innerJoin(variants, eq(variants.code, floorNoteProducts.variantCode))
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .leftJoin(productSupplierOverrides, eq(productSupplierOverrides.productKey, products.key))
+    .where(eq(floorNotes.resolved, false))
+    .orderBy(desc(floorNotes.createdAt), desc(floorNoteProducts.id));
+
+  return rows.map((row) => ({
+    noteId: row.noteId,
+    variantCode: row.variantCode,
+    productName: row.productName,
+    sizeLabel: row.sizeLabel,
+    // Meno zákazníka = prvý riadok textu zápisu, orezaný (zadanie klienta).
+    customerName: (row.noteText.split(/\r?\n/)[0] ?? "").trim(),
+    quantity: row.quantity,
+    createdAt: row.noteCreatedAt.toISOString(),
+    ordered: row.orderedAt !== null,
+    effectiveSupplier: row.effectiveSupplier,
+  }));
+}
+
 export async function listOpenOrderLinesBySupplier(
   db: Database,
   adminBaseUrl: string,
@@ -178,15 +260,29 @@ export async function listOpenOrderLinesBySupplier(
   opts?: { readonly stateFilter?: OrderLineState },
 ): Promise<readonly SupplierOpenOrders[]> {
   const openStatuses = await listOpenStatusNames(db);
-  if (openStatuses.length === 0) return [];
   const stateFilter = opts?.stateFilter;
+  // issue 480: sekcia „Riešiť" (stateFilter) potrebuje nastavené otvorené stavy
+  // — bez nich niet čo filtrovať, vráť prázdno (nezmenené správanie). „Na
+  // objednanie" (stateFilter undefined) môže mať PREDAJŇOVÉ riadky aj bez
+  // otvorených objednávok/stavov, takže sa NEsmie predčasne vrátiť — order-line
+  // dopyt sa len preskočí (prázdne `rows`), floor riadky sa pridajú nižšie.
+  if (openStatuses.length === 0 && stateFilter !== undefined) return [];
 
   // issue 431: počet otvorených objednávok na zákazníka, spočítaný RAZ pre
   // celý zoznam (nie per riadok) — priloží sa ku každému riadku nižšie podľa
-  // jeho `customerIdentityKey`.
-  const openOrderCountByCustomer = await countOpenOrdersByCustomer(db, openStatuses);
+  // jeho `customerIdentityKey`. Prázdna mapa, keď nie sú nastavené otvorené
+  // stavy (order-line dopyt sa aj tak preskočí).
+  const openOrderCountByCustomer =
+    openStatuses.length > 0 ? await countOpenOrdersByCustomer(db, openStatuses) : new Map<string, number>();
 
-  const rows = await db
+  // issue 480: `inArray(..., [])` je nekorektné (viď komentár pri
+  // `countOpenOrdersByCustomer`), preto sa order-line dopyt pri prázdnych
+  // otvorených stavoch VÔBEC nespustí — `rows` je prázdne a nižší cyklus
+  // jednoducho nič nepridá (predajňové riadky sa pridajú samostatne).
+  const rows =
+    openStatuses.length === 0
+      ? []
+      : await db
     .select({
       lineId: orderLines.id,
       orderId: orders.id,
@@ -246,6 +342,8 @@ export async function listOpenOrderLinesBySupplier(
   const NULL_GROUP_KEY = " none";
   interface GroupAccumulator {
     readonly lines: OpenOrderLine[];
+    // issue 480: predajňové riadky tej istej dodávateľskej skupiny.
+    readonly floorRows: FloorOrderRow[];
     readonly spellingCounts: Map<string, number>;
   }
   const bySupplier = new Map<string, GroupAccumulator>();
@@ -282,12 +380,35 @@ export async function listOpenOrderLinesBySupplier(
     const groupKey = row.effectiveSupplier === null ? NULL_GROUP_KEY : normalizeSupplierKeyJs(row.effectiveSupplier);
     let acc = bySupplier.get(groupKey);
     if (acc === undefined) {
-      acc = { lines: [], spellingCounts: new Map() };
+      acc = { lines: [], floorRows: [], spellingCounts: new Map() };
       bySupplier.set(groupKey, acc);
     }
     acc.lines.push(line);
     if (row.effectiveSupplier !== null) {
       acc.spellingCounts.set(row.effectiveSupplier, (acc.spellingCounts.get(row.effectiveSupplier) ?? 0) + 1);
+    }
+  }
+
+  // issue 480: predajňové (floor) riadky sa pridávajú LEN do „Na objednanie"
+  // (`stateFilter === undefined`) — NIKDY do sekcie „Riešiť" (tá filtruje na
+  // stav `riesit`, ktorý floor riadky nemajú). Zaraďujú sa do TEJ ISTEJ
+  // `bySupplier` mapy rovnakým normalizovaným kľúčom, takže produkt bez
+  // otvorenej objednávky vytvorí novú skupinu (aj `NEZNAMY_DODAVATEL`), a
+  // prispievajú do `spellingCounts`, aby floor-only skupina mala kanonický
+  // pravopis pre `pickCanonicalSupplierSpelling` nižšie.
+  if (stateFilter === undefined) {
+    const floorRawRows = await listUnresolvedFloorOrderRows(db);
+    for (const { effectiveSupplier, ...floorRow } of floorRawRows) {
+      const groupKey = effectiveSupplier === null ? NULL_GROUP_KEY : normalizeSupplierKeyJs(effectiveSupplier);
+      let acc = bySupplier.get(groupKey);
+      if (acc === undefined) {
+        acc = { lines: [], floorRows: [], spellingCounts: new Map() };
+        bySupplier.set(groupKey, acc);
+      }
+      acc.floorRows.push(floorRow);
+      if (effectiveSupplier !== null) {
+        acc.spellingCounts.set(effectiveSupplier, (acc.spellingCounts.get(effectiveSupplier) ?? 0) + 1);
+      }
     }
   }
 
@@ -298,7 +419,7 @@ export async function listOpenOrderLinesBySupplier(
 
   const groups = [...bySupplier.entries()].map(([groupKey, acc]) => {
     const supplier = groupKey === NULL_GROUP_KEY ? NEZNAMY_DODAVATEL : pickCanonicalSupplierSpelling(acc.spellingCounts);
-    return { supplier, lines: acc.lines, email: emailBySupplier.get(supplier) ?? null };
+    return { supplier, lines: acc.lines, floorRows: acc.floorRows, email: emailBySupplier.get(supplier) ?? null };
   });
   // issue 152: skupiny podľa NAJNOVŠEJ objednávky (najčerstvejšia prvá),
   // pri zhode abecedne — priamy náprotivok starej appky (`app.js:2470-2476`,
@@ -311,12 +432,23 @@ export async function listOpenOrderLinesBySupplier(
   // skupina pri iterácii dostane, je vždy jej najnovší (žiadny ďalší dopyt
   // ani prepočet netreba). `placedAt` je už ISO 8601 reťazec, takže
   // reťazcové porovnanie zodpovedá chronologickému poradiu bez parsovania.
+  // issue 480: „najnovšie" skupiny je teraz max z najnovšej objednávky
+  // (`lines[0].placedAt`) A najnovšieho predajňového zápisu (`floorRows[0]
+  // .createdAt`) — obe sú ISO 8601 reťazce (reťazcové porovnanie = chronológia),
+  // obe polia sú UŽ zoradené najnovšie-prvé pred zoskupením, takže index [0] je
+  // najnovší člen daného druhu. Floor-only skupina (bez objednávok) sa tak
+  // zaradí podľa dátumu svojho najnovšieho zápisu.
+  const groupNewest = (g: { readonly lines: readonly OpenOrderLine[]; readonly floorRows: readonly FloorOrderRow[] }): string => {
+    const newestLine = g.lines[0]?.placedAt ?? "";
+    const newestFloor = g.floorRows[0]?.createdAt ?? "";
+    return newestLine > newestFloor ? newestLine : newestFloor;
+  };
   groups.sort((a, b) => {
     const aNull = a.supplier === NEZNAMY_DODAVATEL;
     const bNull = b.supplier === NEZNAMY_DODAVATEL;
     if (aNull !== bNull) return aNull ? 1 : -1;
-    const aNewest = a.lines[0]?.placedAt ?? "";
-    const bNewest = b.lines[0]?.placedAt ?? "";
+    const aNewest = groupNewest(a);
+    const bNewest = groupNewest(b);
     if (aNewest !== bNewest) return aNewest > bNewest ? -1 : 1;
     return a.supplier < b.supplier ? -1 : a.supplier > b.supplier ? 1 : 0;
   });
@@ -390,6 +522,38 @@ export async function listOpenOrderLineIdsForSupplier(
     .for("update", { of: [orderLines, orders] });
 
   return rows.map((row) => row.lineId);
+}
+
+// issue 480: predajňové produkty (`floor_note_product`) NEVYBAVENÝCH zápisov
+// patriace jednému dodávateľovi — pre hromadné „označiť skupinu ako objednané"
+// (`orders/state.ts`'s `setSupplierLinesOrdered`). Priamy náprotivok
+// `listOpenOrderLineIdsForSupplier` vyššie: rovnaké override-aware,
+// normalizované porovnanie dodávateľa (aj zástupná skupina `NEZNAMY_DODAVATEL`),
+// samostatný úzky dopyt (len id + noteId), a `.for("update", { of:
+// [floorNoteProducts] })` — zamyká LEN mutované floor riadky (nie katalógové
+// `product`/`variant`), takže žiadna kolízia poradia zámkov s `catalog/ingest`
+// (rovnaký dôvod ako `of: [orderLines, orders]` vyššie). `floorNoteId` sa vracia
+// na následný prepočet note-level 🛒 (`recomputeFloorNoteOrdered`).
+export async function listUnresolvedFloorProductIdsForSupplier(
+  db: Pick<Database, "select">,
+  supplier: string,
+): Promise<readonly { readonly productId: string; readonly floorNoteId: string }[]> {
+  const supplierFilter =
+    supplier === NEZNAMY_DODAVATEL
+      ? and(isNull(products.supplier), isNull(productSupplierOverrides.supplier))
+      : eq(normalizedSupplierKeySql(effectiveSupplierSql), normalizeSupplierKeyJs(supplier));
+
+  const rows = await db
+    .select({ productId: floorNoteProducts.id, floorNoteId: floorNoteProducts.floorNoteId })
+    .from(floorNoteProducts)
+    .innerJoin(floorNotes, eq(floorNotes.id, floorNoteProducts.floorNoteId))
+    .innerJoin(variants, eq(variants.code, floorNoteProducts.variantCode))
+    .innerJoin(products, eq(products.key, variants.productKey))
+    .leftJoin(productSupplierOverrides, eq(productSupplierOverrides.productKey, products.key))
+    .where(and(eq(floorNotes.resolved, false), supplierFilter))
+    .for("update", { of: [floorNoteProducts] });
+
+  return rows.map((row) => ({ productId: row.productId, floorNoteId: row.floorNoteId }));
 }
 
 // issue 476: odznak počtu v ľavom menu pre „Riešiť" — počet OTVORENÝCH

--- a/apps/api/src/modules/orders/state.ts
+++ b/apps/api/src/modules/orders/state.ts
@@ -1,9 +1,10 @@
 import { eq, inArray } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
-import { orderLines, orders, type OrderLineState } from "../../db/schema.js";
+import { floorNoteProducts, orderLines, orders, type OrderLineState } from "../../db/schema.js";
 import { record } from "../audit/service.js";
+import { recomputeFloorNoteOrdered } from "../floor-notes/service.js";
 import { listOpenStatusNames } from "./open-statuses.js";
-import { listOpenOrderLineIdsForSupplier } from "./queries.js";
+import { listOpenOrderLineIdsForSupplier, listUnresolvedFloorProductIdsForSupplier } from "./queries.js";
 
 export type SetOrderLineStateResult = "ok" | "not_found";
 
@@ -236,6 +237,10 @@ export interface SetSupplierLinesOrderedInput {
 
 export interface SetSupplierLinesOrderedResult {
   readonly lineCount: number;
+  // issue 480: koľko predajňových (floor) riadkov skupiny akcia zasiahla —
+  // interné (log/audit/test), do HTTP odpovede sa NEpridáva (existujúce testy
+  // `toEqual({ ok, ordered, lineCount })`).
+  readonly floorRowCount: number;
 }
 
 // issue 60: hromadné "označiť celú skupinu dodávateľa ako objednané"/zrušenie
@@ -259,9 +264,28 @@ export async function setSupplierLinesOrdered(
 ): Promise<SetSupplierLinesOrderedResult> {
   return db.transaction(async (tx) => {
     const lineIds = await listOpenOrderLineIdsForSupplier(tx, input.supplier);
-    if (lineIds.length === 0) return { lineCount: 0 };
+    // issue 480: hromadná akcia zahŕňa aj PREDAJŇOVÉ riadky skupiny — skupina
+    // môže mať dokonca LEN floor riadky (žiadne objednávky), takže sa nesmie
+    // predčasne vrátiť pri prázdnom `lineIds`. Prázdne OBOJE = neškodný no-op.
+    const floorProducts = await listUnresolvedFloorProductIdsForSupplier(tx, input.supplier);
+    if (lineIds.length === 0 && floorProducts.length === 0) return { lineCount: 0, floorRowCount: 0 };
 
-    await tx.update(orderLines).set({ ordered: input.ordered }).where(inArray(orderLines.id, [...lineIds]));
+    if (lineIds.length > 0) {
+      await tx.update(orderLines).set({ ordered: input.ordered }).where(inArray(orderLines.id, [...lineIds]));
+    }
+
+    // issue 480: nastav `ordered_at` všetkých floor produktov skupiny a
+    // prepočítaj note-level 🛒 každého DOTKNUTÉHO zápisu (jeden zápis môže mať
+    // viac produktov v skupine — deduplikuj noteId, aby sa prepočet nezopakoval).
+    if (floorProducts.length > 0) {
+      await tx
+        .update(floorNoteProducts)
+        .set({ orderedAt: input.ordered ? input.now : null })
+        .where(inArray(floorNoteProducts.id, floorProducts.map((f) => f.productId)));
+      for (const noteId of [...new Set(floorProducts.map((f) => f.floorNoteId))]) {
+        await recomputeFloorNoteOrdered(tx, noteId);
+      }
+    }
 
     // Review of PR 75, finding 1: pôvodne `entity: "supplier_contact"` —
     // tento zápis mutuje `order_line` riadky, nie e-mailový kontakt
@@ -272,15 +296,22 @@ export async function setSupplierLinesOrdered(
     // `entityId` ostáva `null` (žiadny JEDEN riadok, na ktorý by mal
     // ukazovať — rovnaký vzor ako `orders-routes.ts`'s bulk
     // `orders.ingest.trigger` udalosť), dodávateľ + zasiahnuté ID zostávajú v
-    // `data`.
+    // `data`. issue 480: `floorRowCount` doplnené (počet zasiahnutých floor
+    // riadkov) — JEDEN agregovaný audit záznam pokrýva order aj floor riadky.
     await record(tx, {
       at: input.now,
       actorUserId: input.actorUserId,
       action: "order_line.ordered.bulk_changed",
       entity: "order_line",
-      data: { supplier: input.supplier, ordered: input.ordered, lineIds, lineCount: lineIds.length },
+      data: {
+        supplier: input.supplier,
+        ordered: input.ordered,
+        lineIds,
+        lineCount: lineIds.length,
+        floorRowCount: floorProducts.length,
+      },
     });
 
-    return { lineCount: lineIds.length };
+    return { lineCount: lineIds.length, floorRowCount: floorProducts.length };
   });
 }

--- a/apps/api/tests/floor-orders-http.integration.test.ts
+++ b/apps/api/tests/floor-orders-http.integration.test.ts
@@ -205,6 +205,36 @@ it("keď sú objednané VŠETKY produkty zápisu, floor_note.ordered (🛒) sa n
   expect(note?.ordered).toBe(false); // symetricky späť
 });
 
+it("pripnutie novej položky do plne objednaného zápisu zhodí 🛒; odopnutie neobjednanej ho zdvihne", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-ATT-A", "Dod");
+  await insertTestVariant(db, "FLOOR-ATT-B", "Dod");
+  const noteId = await createNote(app, cookie, "Attach/detach prepočet");
+  await attach(app, cookie, noteId, "FLOOR-ATT-A");
+
+  const noteOrdered = async () => (await db.select().from(floorNotes).where(eq(floorNotes.id, noteId)))[0]?.ordered;
+
+  // Objednaj jediný produkt → 🛒 true.
+  await app.request(`/api/floor-notes/${noteId}/products/FLOOR-ATT-A/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ value: true }),
+  });
+  expect(await noteOrdered()).toBe(true);
+
+  // Pripni druhý (neobjednaný) produkt → už NIE sú všetky objednané → 🛒 false.
+  await attach(app, cookie, noteId, "FLOOR-ATT-B");
+  expect(await noteOrdered()).toBe(false);
+
+  // Odopni neobjednaný produkt → zostáva len objednaný → 🛒 späť true.
+  const del = await app.request(`/api/floor-notes/${noteId}/products/FLOOR-ATT-B`, {
+    method: "DELETE",
+    headers: { cookie, "content-type": "application/json" },
+  });
+  expect(del.status).toBe(200);
+  expect(await noteOrdered()).toBe(true);
+});
+
 it("vybavený (resolved) zápis → jeho predajňové riadky z Na objednanie zmiznú", async () => {
   const { app, cookie, db } = await boot("manazer");
   await insertTestVariant(db, "FLOOR-RES", "Dod");

--- a/apps/api/tests/floor-orders-http.integration.test.ts
+++ b/apps/api/tests/floor-orders-http.integration.test.ts
@@ -1,0 +1,357 @@
+import { eq } from "drizzle-orm";
+import { afterEach, expect, it } from "vitest";
+import { auditEvents, floorNoteProducts, floorNotes, orderLines, orderOpenStatuses, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import { buildSupplierOrderMailContent } from "../src/modules/orders/mail.js";
+import { NEZNAMY_DODAVATEL } from "../src/modules/orders/queries.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 480: predajňové (floor) riadky v board-e „Na objednanie" — produkty
+// pripnuté na nevybavených zápisoch „Objednávky predajňa", zaradené pod svojho
+// dodávateľa; per-item + hromadné „objednané"; 🛒 auto-set; vylúčenie z e-mailu;
+// filter „Riešiť". Model harnessu je zhodný s `orders-http-ordered.integration
+// .test.ts`.
+
+const HESLO = "test-heslo-abc"; // testovacie údaje, nie tajomstvo
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const [pouzivatel] = await ctx.db
+    .insert(users)
+    .values({ email: "manazer@forestshop.sk", passwordHash: await hashPassword(HESLO), displayName: "Manažér", role })
+    .returning({ id: users.id });
+  if (pouzivatel === undefined) throw new Error("testovací používateľ sa nepodarilo vložiť");
+  const app = createApp(ctx.db, { cookieSecure: false });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "manazer@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db, userId: pouzivatel.id };
+}
+
+type Db = Awaited<ReturnType<typeof boot>>["db"];
+type App = Awaited<ReturnType<typeof boot>>["app"];
+
+async function createNote(app: App, cookie: string, text: string): Promise<string> {
+  const res = await app.request("/api/floor-notes", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function attach(app: App, cookie: string, noteId: string, variantCode: string, quantity = 1): Promise<void> {
+  const res = await app.request(`/api/floor-notes/${noteId}/products`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ variantCode, quantity }),
+  });
+  if (res.status !== 200) throw new Error(`attach zlyhal: ${String(res.status)}`);
+}
+
+interface BoardGroup {
+  readonly supplier: string;
+  readonly lines: readonly { readonly lineId: string; readonly ordered: boolean }[];
+  readonly floorRows: readonly {
+    readonly noteId: string;
+    readonly variantCode: string;
+    readonly productName: string;
+    readonly customerName: string;
+    readonly quantity: number;
+    readonly ordered: boolean;
+    readonly createdAt: string;
+  }[];
+}
+
+async function board(app: App, cookie: string, path = "/api/orders/open"): Promise<readonly BoardGroup[]> {
+  const res = await app.request(path, { headers: { cookie } });
+  return ((await res.json()) as { suppliers: readonly BoardGroup[] }).suppliers;
+}
+
+let poradie = 0;
+async function insertOrderLine(db: Db, supplier: string | null, code?: string): Promise<{ orderId: string; lineId: string }> {
+  poradie += 1;
+  const kod = code ?? `OL-${String(poradie)}`;
+  await insertTestVariant(db, kod, supplier);
+  const [objednavka] = await db
+    .insert(orders)
+    .values({ externalOrderId: `900${String(poradie)}`, customerName: "Zákazník", placedAt: new Date("2026-07-20T00:00:00Z") })
+    .returning();
+  if (objednavka === undefined) throw new Error("insert objednávky zlyhal");
+  const [riadok] = await db.insert(orderLines).values({ orderId: objednavka.id, variantCode: kod, quantity: 1 }).returning();
+  if (riadok === undefined) throw new Error("insert riadku zlyhal");
+  return { orderId: objednavka.id, lineId: riadok.id };
+}
+
+it("pripnutý produkt nevybaveného zápisu sa objaví v Na objednanie pod svojím dodávateľom", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-A", "Dodávateľ Alfa");
+  const noteId = await createNote(app, cookie, "Jozko Mrkvička\ntel 0900");
+  await attach(app, cookie, noteId, "FLOOR-A", 3);
+
+  const groups = await board(app, cookie);
+  const alfa = groups.find((g) => g.supplier === "Dodávateľ Alfa");
+  expect(alfa).toBeDefined();
+  expect(alfa?.floorRows).toHaveLength(1);
+  const row = alfa?.floorRows[0];
+  expect(row?.variantCode).toBe("FLOOR-A");
+  expect(row?.noteId).toBe(noteId);
+  // Meno = PRVÝ riadok textu zápisu, orezaný.
+  expect(row?.customerName).toBe("Jozko Mrkvička");
+  expect(row?.quantity).toBe(3);
+  expect(row?.ordered).toBe(false);
+  expect(row?.productName).toBe("Test produkt FLOOR-A");
+});
+
+it("produkt bez dodávateľa spadne do skupiny '(bez dodávateľa)'", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-NIL", null);
+  const noteId = await createNote(app, cookie, "Bezmenný");
+  await attach(app, cookie, noteId, "FLOOR-NIL");
+
+  const groups = await board(app, cookie);
+  const neznamy = groups.find((g) => g.supplier === NEZNAMY_DODAVATEL);
+  expect(neznamy?.floorRows.map((r) => r.variantCode)).toEqual(["FLOOR-NIL"]);
+});
+
+it("predajňový riadok a riadok objednávky toho istého dodávateľa sú v JEDNEJ skupine", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  // `withCleanDb()` seeduje otvorený stav „Vybavuje sa" (= default `order
+  // .status_name`), takže order riadok sa v board-e zobrazí bez ďalšieho setupu.
+  const { lineId } = await insertOrderLine(db, "Spol Dodávateľ");
+  await insertTestVariant(db, "FLOOR-SPOL", "Spol Dodávateľ");
+  const noteId = await createNote(app, cookie, "Spoločný zákazník");
+  await attach(app, cookie, noteId, "FLOOR-SPOL");
+
+  const groups = await board(app, cookie);
+  const spol = groups.find((g) => g.supplier === "Spol Dodávateľ");
+  expect(spol?.lines.map((l) => l.lineId)).toContain(lineId);
+  expect(spol?.floorRows.map((r) => r.variantCode)).toEqual(["FLOOR-SPOL"]);
+});
+
+it("manažér odškrtne predajňový riadok ako objednaný, zápis sa uloží aj do auditu; späť tiež", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-ORD", "Dod");
+  const noteId = await createNote(app, cookie, "X");
+  await attach(app, cookie, noteId, "FLOOR-ORD");
+
+  const res = await app.request(`/api/floor-notes/${noteId}/products/FLOOR-ORD/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ value: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, ordered: true });
+
+  const [p] = await db.select().from(floorNoteProducts).where(eq(floorNoteProducts.variantCode, "FLOOR-ORD"));
+  expect(p?.orderedAt).not.toBeNull();
+
+  const ev = (await db.select().from(auditEvents)).find((e) => e.action === "floor_note_product.ordered.changed");
+  expect(ev).toBeDefined();
+  expect(ev?.actorUserId).toBe(userId);
+  expect(ev?.entity).toBe("floor_note_product");
+  expect(ev?.data).toMatchObject({ floorNoteId: noteId, variantCode: "FLOOR-ORD", from: false, to: true });
+
+  const zrus = await app.request(`/api/floor-notes/${noteId}/products/FLOOR-ORD/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ value: false }),
+  });
+  expect(zrus.status).toBe(200);
+  const [p2] = await db.select().from(floorNoteProducts).where(eq(floorNoteProducts.variantCode, "FLOOR-ORD"));
+  expect(p2?.orderedAt).toBeNull();
+});
+
+it("keď sú objednané VŠETKY produkty zápisu, floor_note.ordered (🛒) sa nastaví; odškrtnutie ho zhodí", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-M1", "Dod");
+  await insertTestVariant(db, "FLOOR-M2", "Dod");
+  const noteId = await createNote(app, cookie, "Dvojprodukt");
+  await attach(app, cookie, noteId, "FLOOR-M1");
+  await attach(app, cookie, noteId, "FLOOR-M2");
+
+  const setOrdered = async (code: string, value: boolean) =>
+    app.request(`/api/floor-notes/${noteId}/products/${code}/ordered`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+
+  await setOrdered("FLOOR-M1", true);
+  let [note] = await db.select().from(floorNotes).where(eq(floorNotes.id, noteId));
+  expect(note?.ordered).toBe(false); // len 1 z 2 objednaných
+
+  await setOrdered("FLOOR-M2", true);
+  [note] = await db.select().from(floorNotes).where(eq(floorNotes.id, noteId));
+  expect(note?.ordered).toBe(true); // všetky objednané → 🛒
+
+  await setOrdered("FLOOR-M1", false);
+  [note] = await db.select().from(floorNotes).where(eq(floorNotes.id, noteId));
+  expect(note?.ordered).toBe(false); // symetricky späť
+});
+
+it("vybavený (resolved) zápis → jeho predajňové riadky z Na objednanie zmiznú", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-RES", "Dod");
+  const noteId = await createNote(app, cookie, "Bude vybavený");
+  await attach(app, cookie, noteId, "FLOOR-RES");
+
+  expect((await board(app, cookie)).some((g) => g.floorRows.some((r) => r.variantCode === "FLOOR-RES"))).toBe(true);
+
+  await app.request(`/api/floor-notes/${noteId}/resolved`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ value: true }),
+  });
+  expect((await board(app, cookie)).some((g) => g.floorRows.some((r) => r.variantCode === "FLOOR-RES"))).toBe(false);
+});
+
+it("sekcia Riešiť predajňové riadky NEobsahuje", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-RIE", "Dod");
+  const noteId = await createNote(app, cookie, "Nepatrí do Riešiť");
+  await attach(app, cookie, noteId, "FLOOR-RIE");
+
+  const riesit = await board(app, cookie, "/api/orders/riesit");
+  expect(riesit.some((g) => g.floorRows.length > 0)).toBe(false);
+});
+
+it("predajňové riadky sa zobrazia aj keď nie sú nastavené žiadne otvorené stavy objednávok", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  // `withCleanDb()` seeduje default otvorený stav — pre tento test ho ZMAŽ, aby
+  // sme dokázali, že predajňové riadky sa zobrazia aj bez akýchkoľvek otvorených
+  // stavov (nezávisia od nich, na rozdiel od riadkov objednávok).
+  await db.delete(orderOpenStatuses);
+  await insertTestVariant(db, "FLOOR-NOSTAT", "Dod");
+  const noteId = await createNote(app, cookie, "Bez otvorených stavov");
+  await attach(app, cookie, noteId, "FLOOR-NOSTAT");
+
+  const groups = await board(app, cookie);
+  expect(groups.find((g) => g.supplier === "Dod")?.floorRows.map((r) => r.variantCode)).toEqual(["FLOOR-NOSTAT"]);
+});
+
+it("hromadné 'označiť skupinu ako objednané' zahŕňa aj predajňové riadky a prepočíta 🛒", async () => {
+  const { app, cookie, db, userId } = await boot("manazer");
+  const { lineId } = await insertOrderLine(db, "Bulk Dod");
+  await insertTestVariant(db, "FLOOR-BULK", "Bulk Dod");
+  const noteId = await createNote(app, cookie, "Bulk zákazník");
+  await attach(app, cookie, noteId, "FLOOR-BULK");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Bulk Dod")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(200);
+  // HTTP odpoveď nesie LEN lineCount (floor sa do nej nepridáva — spätná
+  // kompatibilita existujúcich testov).
+  expect(await res.json()).toEqual({ ok: true, ordered: true, lineCount: 1 });
+
+  expect((await db.select().from(orderLines).where(eq(orderLines.id, lineId)))[0]?.ordered).toBe(true);
+  expect((await db.select().from(floorNoteProducts).where(eq(floorNoteProducts.variantCode, "FLOOR-BULK")))[0]?.orderedAt).not.toBeNull();
+  // Jediný produkt zápisu je teraz objednaný → 🛒.
+  expect((await db.select().from(floorNotes).where(eq(floorNotes.id, noteId)))[0]?.ordered).toBe(true);
+
+  const ev = (await db.select().from(auditEvents)).find((e) => e.action === "order_line.ordered.bulk_changed");
+  expect(ev?.actorUserId).toBe(userId);
+  expect(ev?.data).toMatchObject({ supplier: "Bulk Dod", ordered: true, lineCount: 1, floorRowCount: 1 });
+});
+
+it("hromadné označenie skupiny, ktorá má LEN predajňové riadky (žiadne objednávky), funguje", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-ONLY", "Only Dod");
+  const noteId = await createNote(app, cookie, "Len predajňa");
+  await attach(app, cookie, noteId, "FLOOR-ONLY");
+
+  const res = await app.request(`/api/suppliers/${encodeURIComponent("Only Dod")}/order-lines/ordered`, {
+    method: "PUT",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ ordered: true }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ ok: true, ordered: true, lineCount: 0 });
+  expect((await db.select().from(floorNoteProducts).where(eq(floorNoteProducts.variantCode, "FLOOR-ONLY")))[0]?.orderedAt).not.toBeNull();
+  expect((await db.select().from(floorNotes).where(eq(floorNotes.id, noteId)))[0]?.ordered).toBe(true);
+});
+
+it("e-mail dodávateľovi predajňové riadky NEZAHŔŇA (existujúci e-mail tok nezmenený)", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertOrderLine(db, "Mail Dod", "MAIL-OL");
+  await insertTestVariant(db, "MAIL-FLOOR", "Mail Dod");
+  const noteId = await createNote(app, cookie, "Mailový zákazník");
+  await attach(app, cookie, noteId, "MAIL-FLOOR");
+
+  const content = await buildSupplierOrderMailContent(db, "Mail Dod");
+  // Len order_line položka (MAIL-OL), NIKDY predajňový MAIL-FLOOR.
+  expect(content.itemCount).toBe(1);
+  expect(content.body).toContain("MAIL-OL");
+  expect(content.body).not.toContain("MAIL-FLOOR");
+});
+
+it("rola citanie ani sef nesmie meniť príznak objednané predajňového riadku; cudzí Origin 403", async () => {
+  for (const role of ["citanie", "sef"] as const) {
+    const { app, cookie, db } = await boot(role);
+    await insertTestVariant(db, `FLOOR-RBAC-${role}`, "Dod");
+    // Zápis aj pripnutie potrebujú admin/manazer — pre readonly rolu ich vlož
+    // priamo cez DB, aby sme izolovane overili gating SAMOTNEJ „ordered" trasy.
+    const [note] = await db.insert(floorNotes).values({ text: "x", createdAt: new Date(), updatedAt: new Date() }).returning({ id: floorNotes.id });
+    if (note === undefined) throw new Error("insert zápisu zlyhal");
+    const noteId = note.id;
+    await db.insert(floorNoteProducts).values({ floorNoteId: noteId, variantCode: `FLOOR-RBAC-${role}`, quantity: 1, createdAt: new Date() });
+    const res = await app.request(`/api/floor-notes/${noteId}/products/FLOOR-RBAC-${role}/ordered`, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({ value: true }),
+    });
+    expect(res.status).toBe(403);
+    await close?.();
+    close = undefined;
+  }
+
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-ORIGIN", "Dod");
+  const noteId = await createNote(app, cookie, "x");
+  await attach(app, cookie, noteId, "FLOOR-ORIGIN");
+  const cudzi = await app.request(`/api/floor-notes/${noteId}/products/FLOOR-ORIGIN/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json", origin: "https://utocnik.example", host: "forestshop.example" },
+    body: JSON.stringify({ value: true }),
+  });
+  expect(cudzi.status).toBe(403);
+});
+
+it("neznáma položka zápisu vráti 404, neplatné telo 400", async () => {
+  const { app, cookie, db } = await boot("manazer");
+  await insertTestVariant(db, "FLOOR-404", "Dod");
+  const noteId = await createNote(app, cookie, "x");
+  await attach(app, cookie, noteId, "FLOOR-404");
+
+  const neznamy = await app.request(`/api/floor-notes/${noteId}/products/NEEXISTUJE/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ value: true }),
+  });
+  expect(neznamy.status).toBe(404);
+
+  const neplatny = await app.request(`/api/floor-notes/${noteId}/products/FLOOR-404/ordered`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ value: "ano" }),
+  });
+  expect(neplatny.status).toBe(400);
+});

--- a/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
+++ b/apps/api/tests/orders-supplier-bulk-lock.integration.test.ts
@@ -153,7 +153,10 @@ it("hromadné označenie čaká na riadkový zámok objednávky — lookup bež�
     // Skutočný dôkaz dokončenia je samotný úspešný `await bulk` +
     // očakávaný výsledok nižšie — žiadna ďalšia kontrola `settled` netreba.
     const result = await bulk;
-    expect(result).toEqual({ lineCount: 1 });
+    // issue 480: `setSupplierLinesOrdered` teraz vracia aj `floorRowCount`
+    // (počet zasiahnutých predajňových riadkov) — tu 0 (skupina má len order
+    // riadok, žiadny predajňový).
+    expect(result).toEqual({ lineCount: 1, floorRowCount: 0 });
   } finally {
     await rawClient.end();
   }
@@ -222,7 +225,10 @@ it("hromadné označenie NEČAKÁ na zámok katalógovej tabuľky (product) — 
       now: new Date("2026-07-30T10:00:00Z"),
     });
 
-    expect(result).toEqual({ lineCount: 1 });
+    // issue 480: `setSupplierLinesOrdered` teraz vracia aj `floorRowCount`
+    // (počet zasiahnutých predajňových riadkov) — tu 0 (skupina má len order
+    // riadok, žiadny predajňový).
+    expect(result).toEqual({ lineCount: 1, floorRowCount: 0 });
   } finally {
     await rawClient.query("COMMIT");
     await rawClient.end();

--- a/apps/web/src/components/FloorOrderRow.tsx
+++ b/apps/web/src/components/FloorOrderRow.tsx
@@ -1,0 +1,99 @@
+import type { JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
+import type { FloorOrderRow as FloorOrderRowData } from "../ordersApi.js";
+
+// issue 480: JEDEN predajňový riadok v tabuľke „Na objednanie" — produkt
+// pripnutý na nevybavenom zápise „Objednávky predajňa", zaradený pod svojho
+// dodávateľa. Vykresľuje sa v TEJ ISTEJ tabuľke ako `OrderLineRow` (rovnakých
+// 9 stĺpcov `<colgroup>` v `SupplierOrderGroup.tsx`), aby vizuálne zapadol —
+// ale NEMÁ stavové tlačidlá ani odkaz do Shoptet administrácie (zadanie): na
+// mieste čísla objednávky je znak 🛍️ + odkaz na zápis (`?tab=floor-orders`),
+// a jediná ovládateľná vec je checkbox „objednané". Kľúčované dvojicou
+// (noteId, variantCode) — `floor_note_product` unikátny kľúč, a jeden produkt
+// môže byť pripnutý na viacerých zápisoch.
+//
+// Testid ZÁMERNE nezačína „order-line-" — viacero e2e testov hľadá hlavný
+// riadok cez `[data-testid^='order-line-']` (`.claude/rules/frontend-design.md`,
+// issue 162); zhodný prefix by spôsobil Playwright strict-mode kolíziu.
+export function FloorOrderRow({
+  row,
+  canChangeState,
+  busyFloorRowKey,
+  supplierBusy,
+  onChangeOrdered,
+}: {
+  readonly row: FloorOrderRowData;
+  readonly canChangeState: boolean;
+  // Kľúč (`noteId::variantCode`) floor riadku, ktorého zápis „objednané" PRÁVE
+  // TERAZ prebieha — `null` keď žiadny.
+  readonly busyFloorRowKey: string | null;
+  // TRUE, keď beží hromadné „označiť/zrušiť skupinu" pre dodávateľa tohto
+  // riadku (zrkadlí `OrderLineRow`'s `supplierBusy`, issue 60 — obojsmerný
+  // busy-guard).
+  readonly supplierBusy: boolean;
+  readonly onChangeOrdered: (noteId: string, variantCode: string, ordered: boolean) => void;
+}): JSX.Element {
+  const rowKey = `${row.noteId}::${row.variantCode}`;
+  const busyHere = busyFloorRowKey === rowKey;
+
+  return (
+    <tr
+      className={"order-row floor-order-row" + (row.ordered ? " ordered" : "")}
+      data-testid={`floor-order-row-${row.noteId}-${row.variantCode}`}
+    >
+      <td>
+        <input
+          type="checkbox"
+          data-testid={`floor-ordered-checkbox-${row.noteId}-${row.variantCode}`}
+          aria-label={`Označiť predajňový riadok ${row.variantCode} (zápis predajne) ako objednané u dodávateľa`}
+          checked={row.ordered}
+          disabled={!canChangeState || busyHere || supplierBusy}
+          onChange={(e) => {
+            onChangeOrdered(row.noteId, row.variantCode, e.target.checked);
+          }}
+        />
+      </td>
+      {/* Na mieste čísla objednávky: 🛍️ + odkaz na zápis v „Objednávky
+          predajňa" (`?tab=floor-orders`). Rovnaký tab v tom istom okne (na
+          rozdiel od order riadku, ktorý otvára Shoptet v novom okne) — obsluha
+          ide zápis rovno upraviť/vybaviť. */}
+      <td className="ord-order-cell">
+        <a
+          href="?tab=floor-orders"
+          className="floor-order-link"
+          data-testid={`floor-order-link-${row.noteId}-${row.variantCode}`}
+          aria-label="Otvoriť zápis v Objednávky predajňa"
+          title="Objednávka predajňa — otvoriť zápis"
+        >
+          <span aria-hidden="true">🛍️</span>
+        </a>
+      </td>
+      {/* Meno zákazníka = prvý riadok textu zápisu (server ho už orezal). */}
+      <td>{row.customerName}</td>
+      {/* Produkt: názov + veľkosť (ako order riadok) + kód produktu (zadanie
+          klienta „Kód produktu") ako tlmený druhý riadok. */}
+      <td>
+        <div className="ord-product-name">
+          {row.productName}
+          {row.sizeLabel !== null && <span className="ord-size">{row.sizeLabel}</span>}
+        </div>
+        <div className="floor-order-code" data-testid={`floor-code-${row.noteId}-${row.variantCode}`}>
+          {row.variantCode}
+        </div>
+      </td>
+      <td className="ord-qty">
+        <div className="ord-qty-stack">
+          <span>{row.quantity} ks</span>
+        </div>
+      </td>
+      {/* Dodávateľ: prázdne — floor riadok je už v skupine svojho dodávateľa. */}
+      <td />
+      {/* Stav: ŽIADNE stavové tlačidlá (zadanie) — predajňový riadok má len
+          „objednané". */}
+      <td />
+      <td className="ord-date-cell">{formatSkDate(row.createdAt)}</td>
+      {/* Poznámky: prázdne — text zápisu je v „Objednávky predajňa". */}
+      <td />
+    </tr>
+  );
+}

--- a/apps/web/src/components/OrdersSection.floorRows.test.tsx
+++ b/apps/web/src/components/OrdersSection.floorRows.test.tsx
@@ -1,0 +1,203 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useCallback, useMemo, useState, type JSX } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 480: predajňové (floor) riadky v board-e „Na objednanie" — vykreslenie
+// pod dodávateľom, per-item „objednané", počet v odznaku, hromadná akcia,
+// filter „skryť vybavené", skupina LEN s predajňovými riadkami. Full-board
+// integrácia cez `OrdersSection` (rovnaký vzor ako `OrdersSection.ordered.test
+// .tsx`), mockujúci API vrstvu.
+
+const { fetchOpenOrders, fetchOrdersOverview, setFloorRowOrdered, setSupplierLinesOrdered } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  fetchOrdersOverview: vi.fn(),
+  setFloorRowOrdered: vi.fn(),
+  setSupplierLinesOrdered: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchOpenOrders, fetchOrdersOverview, setFloorRowOrdered, setSupplierLinesOrdered };
+});
+
+const NOTE_ID = "note-1111-1111-1111-111111111111";
+
+function floorRow(overrides: Record<string, unknown> = {}) {
+  return {
+    noteId: NOTE_ID,
+    variantCode: "FLOOR-1",
+    productName: "Čelovka FOREST",
+    sizeLabel: null,
+    customerName: "Jožko Predajňa",
+    quantity: 2,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    ordered: false,
+    ...overrides,
+  };
+}
+
+const ORDER_LINE = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník E-shop",
+  comment: null,
+  remark: null,
+  shopRemark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST",
+  sizeLabel: null,
+  quantity: 1,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+  customerOpenOrderCount: 1,
+  ourUrl: null,
+};
+
+const CHECKBOX = `floor-ordered-checkbox-${NOTE_ID}-FLOOR-1`;
+const ROW = `floor-order-row-${NOTE_ID}-FLOOR-1`;
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({ today: { orderCount: 0, revenue: "0.00" }, week: { orderCount: 0, revenue: "0.00" }, month: { orderCount: 0, revenue: "0.00" } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+  window.localStorage.clear();
+});
+
+it("predajňový riadok sa vykreslí pod svojím dodávateľom: 🛍️ odkaz, meno, produkt, kód, ks, checkbox", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [], floorRows: [floorRow()], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const row = await screen.findByTestId(ROW);
+  expect(row.textContent).toContain("Jožko Predajňa");
+  expect(row.textContent).toContain("Čelovka FOREST");
+  expect(row.textContent).toContain("2 ks");
+  expect(screen.getByTestId(`floor-code-${NOTE_ID}-FLOOR-1`).textContent).toBe("FLOOR-1");
+  // 🛍️ odkaz vedie na zápis v „Objednávky predajňa".
+  const link = screen.getByTestId(`floor-order-link-${NOTE_ID}-FLOOR-1`);
+  expect(link.getAttribute("href")).toBe("?tab=floor-orders");
+  const checkbox = screen.getByTestId<HTMLInputElement>(CHECKBOX);
+  expect(checkbox.checked).toBe(false);
+  expect(checkbox.disabled).toBe(false);
+});
+
+it("rola citanie vidí predajňový checkbox needitovateľný", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [], floorRows: [floorRow()], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(CHECKBOX);
+  expect(checkbox.disabled).toBe(true);
+});
+
+it("manažér odškrtne predajňový riadok — zavolá API a riadok sa vizuálne stlmí bez refetchu", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [], floorRows: [floorRow()], email: null }]);
+  setFloorRowOrdered.mockResolvedValue(undefined);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const checkbox = await screen.findByTestId<HTMLInputElement>(CHECKBOX);
+  fireEvent.click(checkbox);
+
+  await waitFor(() => {
+    expect(setFloorRowOrdered).toHaveBeenCalledWith(NOTE_ID, "FLOOR-1", true);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(true);
+  });
+  expect(screen.getByTestId(ROW).className).toContain("ordered");
+  expect(fetchOpenOrders).toHaveBeenCalledTimes(1);
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+it("odznak Na objednanie počíta aj NEOBJEDNANÉ predajňové riadky", async () => {
+  // 1 nevybavený order riadok + 2 predajňové riadky (jeden objednaný) → 1 + 1 = 2.
+  fetchOpenOrders.mockResolvedValue([
+    {
+      supplier: "Dodávateľ Alfa",
+      lines: [ORDER_LINE],
+      floorRows: [floorRow(), floorRow({ variantCode: "FLOOR-2", ordered: true })],
+      email: null,
+    },
+  ]);
+
+  function Harness(): JSX.Element {
+    const [count, setCount] = useState<number | null>(null);
+    const onSessionExpired = useCallback(() => {}, []);
+    const value = useMemo(() => ({ count, setCount }), [count]);
+    return (
+      <OrdersRemainingCountContext.Provider value={value}>
+        <span data-testid="remaining-count">{count === null ? "null" : count}</span>
+        <OrdersSection role="manazer" onSessionExpired={onSessionExpired} />
+      </OrdersRemainingCountContext.Provider>
+    );
+  }
+
+  render(<Harness />);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("remaining-count").textContent).toBe("2");
+  });
+});
+
+it("hromadné Označiť skupinu ako objednané zahŕňa aj predajňové riadky", async () => {
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [ORDER_LINE], floorRows: [floorRow()], email: null },
+  ]);
+  setSupplierLinesOrdered.mockResolvedValue({ lineCount: 1 });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const oznacit = await screen.findByRole("button", { name: "✔ Označiť skupinu ako objednané" });
+  fireEvent.click(oznacit);
+
+  await waitFor(() => {
+    expect(setSupplierLinesOrdered).toHaveBeenCalledWith("Dodávateľ Alfa", true);
+  });
+  // Predajňový riadok sa optimisticky prekreslí ako objednaný.
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(true);
+  });
+  // Skupina je teraz celá objednaná (order riadok aj predajňový) — tlačidlo prepne smer.
+  expect(await screen.findByRole("button", { name: "↺ Zrušiť označenie skupiny" })).toBeDefined();
+});
+
+it("skupina LEN s predajňovými riadkami (bez objednávok) sa vykreslí, nie prázdny stav", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Len Predajňa", lines: [], floorRows: [floorRow()], email: null }]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  expect(await screen.findByTestId(ROW)).toBeDefined();
+  expect(screen.queryByTestId("orders-empty")).toBeNull();
+  // Hlavička skupiny počíta predajňový riadok (nie „0 riadky").
+  expect(screen.getByTestId("supplier-Len Predajňa").textContent).toContain("Len Predajňa — 1 riadok");
+});
+
+it("skryť vybavené skryje objednaný predajňový riadok", async () => {
+  window.localStorage.setItem("forestshop.orders.hideResolved", "1");
+  fetchOpenOrders.mockResolvedValue([
+    { supplier: "Dodávateľ Alfa", lines: [], floorRows: [floorRow({ ordered: true })], email: null },
+  ]);
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  // Skupina má len objednaný predajňový riadok → pri „skryť vybavené" sa
+  // nevykreslí a zobrazí sa hláška „všetko vybavené".
+  await waitFor(() => {
+    expect(screen.getByTestId("orders-hidden-empty")).toBeDefined();
+  });
+  expect(screen.queryByTestId(ROW)).toBeNull();
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -8,7 +8,7 @@ import {
 } from "../ordersDisplayPreferences.js";
 import { OrdersRemainingCountContext } from "../ordersRemainingCountContext.js";
 import { RiesitBadgeRefreshContext } from "../riesitBadgeContext.js";
-import { isLineHiddenByFilter, isLineResolved } from "../ordersSummary.js";
+import { isFloorRowHidden, isLineHiddenByFilter, isLineResolved } from "../ordersSummary.js";
 import { useOrderLinesBoard } from "../useOrderLinesBoard.js";
 import { useSelectedSupplierFallback } from "../useSelectedSupplierFallback.js";
 import { OrderOpenStatusesPanel } from "./OrderOpenStatusesPanel.js";
@@ -62,6 +62,7 @@ export function OrdersSection({
     busySupplierLineId,
     busySupplierLinkLineId,
     busyCommentOrderId,
+    busyFloorRowKey,
     supplierDrafts,
     dirtyEditorLineIds,
     onEditorActivityChange,
@@ -71,6 +72,7 @@ export function OrdersSection({
     load,
     changeState,
     changeOrdered,
+    changeFloorOrdered,
     assignSupplier,
     changeComment,
     toggleGroupOrdered,
@@ -110,7 +112,12 @@ export function OrdersSection({
   useEffect(() => {
     if (!loaded) return;
     const allLines = suppliers.flatMap((group) => group.lines);
-    setOrdersRemainingCount(allLines.filter((l) => !isLineResolved(l)).length);
+    // issue 480: odznak počíta aj NEOBJEDNANÉ predajňové riadky (konzistentne s
+    // tým, ako sa počítajú e-shopové — neobjednaný sa počíta, objednaný nie).
+    const allFloorRows = suppliers.flatMap((group) => group.floorRows ?? []);
+    setOrdersRemainingCount(
+      allLines.filter((l) => !isLineResolved(l)).length + allFloorRows.filter((r) => !r.ordered).length,
+    );
   }, [loaded, suppliers, setOrdersRemainingCount]);
 
   // issue 148 (vyňaté do `useSelectedSupplierFallback.ts`).
@@ -120,6 +127,11 @@ export function OrdersSection({
   // (dodávateľ vzostupne, potom najnovšia objednávka prvá) — žiadne ďalšie
   // preskupovanie na klientovi.
   const totalLines = suppliers.reduce((sum, group) => sum + group.lines.length, 0);
+  // issue 480: prázdny stav / toolbar / hláška „skryť vybavené" berú do úvahy aj
+  // predajňové riadky — skupina môže mať LEN predajňové riadky (žiadne
+  // objednávky), a vtedy zoznam NIE JE prázdny.
+  const totalFloorRows = suppliers.reduce((sum, group) => sum + (group.floorRows?.length ?? 0), 0);
+  const totalRows = totalLines + totalFloorRows;
 
   // issue 61: dodávatelia zúžení podľa vybraného chipu — hromadné akcie
   // (`SupplierActionsPanel`) dostávajú vždy PLNÉ `group.lines` (nefiltrované
@@ -129,7 +141,10 @@ export function OrdersSection({
     (group) => selectedSupplier === null || group.supplier === selectedSupplier,
   );
   const visibleLinesCount = filteredGroups.reduce(
-    (sum, group) => sum + group.lines.filter((line) => !isLineHiddenByFilter(line, hideResolved, dirtyEditorLineIds)).length,
+    (sum, group) =>
+      sum +
+      group.lines.filter((line) => !isLineHiddenByFilter(line, hideResolved, dirtyEditorLineIds)).length +
+      (group.floorRows ?? []).filter((row) => !isFloorRowHidden(row, hideResolved)).length,
     0,
   );
 
@@ -157,10 +172,10 @@ export function OrdersSection({
         }}
       />
       {canChangeState && <OrderOpenStatusesPanel onSessionExpired={onSessionExpired} onSaved={load} />}
-      {loaded && totalLines === 0 && (
+      {loaded && totalRows === 0 && (
         <p className="empty" data-testid="orders-empty">Zatiaľ nie sú žiadne otvorené objednávky.</p>
       )}
-      {loaded && totalLines > 0 && (
+      {loaded && totalRows > 0 && (
         <OrdersToolbar
           suppliers={suppliers}
           selectedSupplier={selectedSupplier}
@@ -169,7 +184,7 @@ export function OrdersSection({
           onToggleHideResolved={toggleHideResolved}
         />
       )}
-      {loaded && totalLines > 0 && hideResolved && visibleLinesCount === 0 && (
+      {loaded && totalRows > 0 && hideResolved && visibleLinesCount === 0 && (
         <p className="empty" data-testid="orders-hidden-empty">
           {selectedSupplier === null
             ? "Všetko vybavené — vybavené riadky sú skryté."
@@ -199,8 +214,10 @@ export function OrdersSection({
           busySupplierLineId={busySupplierLineId}
           busySupplierLinkLineId={busySupplierLinkLineId}
           busyCommentOrderId={busyCommentOrderId}
+          busyFloorRowKey={busyFloorRowKey}
           onChangeState={changeState}
           onChangeOrdered={changeOrdered}
+          onChangeFloorOrdered={changeFloorOrdered}
           onAssignSupplier={assignSupplier}
           onSetSupplierLink={setSupplierLink}
           onChangeComment={changeComment}

--- a/apps/web/src/components/OrdersToolbar.test.tsx
+++ b/apps/web/src/components/OrdersToolbar.test.tsx
@@ -225,3 +225,47 @@ it("čipy dodávateľov sú zoradené abecedne, 'Všetci' prvý a '(bez dodávat
     "(bez dodávateľa) (1)",
   ]);
 });
+
+it("issue 480 — chip zahŕňa predajňové riadky v počte aj v done farbe, floor-only skupina", () => {
+  const floorRow = (ordered: boolean) => ({
+    noteId: "n1",
+    variantCode: "F-1",
+    productName: "Produkt",
+    sizeLabel: null,
+    customerName: "Zákazník",
+    quantity: 1,
+    createdAt: "2026-08-20T00:00:00.000Z",
+    ordered,
+  });
+  const suppliers: readonly SupplierOpenOrders[] = [
+    // Floor-only skupina, predajňový riadok objednaný → chip je „done".
+    { supplier: "Len Predajňa", email: null, lines: [], floorRows: [floorRow(true)] },
+    // Order riadok vybavený, ALE predajňový riadok neobjednaný → NIE „done".
+    {
+      supplier: "Zmiešaná",
+      email: null,
+      lines: [makeLine({ lineId: "m1", ordered: true, state: "skladom" })],
+      floorRows: [floorRow(false)],
+    },
+  ];
+  render(
+    <OrdersToolbar
+      suppliers={suppliers}
+      selectedSupplier={null}
+      onSelectSupplier={() => {}}
+      hideResolved={false}
+      onToggleHideResolved={() => {}}
+    />,
+  );
+
+  const lenPredajna = screen.getByTestId("supplier-chip-Len Predajňa");
+  expect(lenPredajna.textContent).toBe("Len Predajňa (1)");
+  expect(lenPredajna.className).toContain("done");
+
+  const zmiesana = screen.getByTestId("supplier-chip-Zmiešaná");
+  expect(zmiesana.textContent).toBe("Zmiešaná (2)"); // 1 order + 1 predajňový
+  expect(zmiesana.className).not.toContain("done"); // predajňový riadok ešte neobjednaný
+
+  // „Všetci" = 0+1 (Len Predajňa) + 1+1 (Zmiešaná) = 3.
+  expect(screen.getByTestId("supplier-chip-all").textContent).toBe("Všetci (3)");
+});

--- a/apps/web/src/components/OrdersToolbar.tsx
+++ b/apps/web/src/components/OrdersToolbar.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "react";
-import type { OrderLine, SupplierOpenOrders } from "../ordersApi.js";
+import type { FloorOrderRow, OrderLine, SupplierOpenOrders } from "../ordersApi.js";
 import { formatOrderSummaryText, sortSuppliersForChips, summarizeOrderLines } from "../ordersSummary.js";
 
 // issue 61 — filtrovacie štítky dodávateľov + súhrn "ostáva vybaviť" +
@@ -21,8 +21,22 @@ export function OrdersToolbar({
   readonly onToggleHideResolved: () => void;
 }): JSX.Element {
   const allLines: readonly OrderLine[] = suppliers.flatMap((group) => group.lines);
-  const scopedLines =
-    selectedSupplier === null ? allLines : (suppliers.find((g) => g.supplier === selectedSupplier)?.lines ?? []);
+  // issue 480: predajňové riadky vstupujú do počtov čipov aj do súhrnu rovnako
+  // ako riadky objednávok (inak by čip/„Všetci"/súhrn driftovali od nástenkového
+  // odznaku a od hlavičky skupiny — issue 263 invariant „čip == panel").
+  const allFloorRows: readonly FloorOrderRow[] = suppliers.flatMap((group) => group.floorRows ?? []);
+  const scopedGroup = selectedSupplier === null ? null : suppliers.find((g) => g.supplier === selectedSupplier);
+  const scopedLines = selectedSupplier === null ? allLines : (scopedGroup?.lines ?? []);
+  const scopedFloorRows = selectedSupplier === null ? allFloorRows : (scopedGroup?.floorRows ?? []);
+
+  // Súhrn „ostáva vybaviť N z M" — predajňové riadky pridávajú svoje KUSY do
+  // total/remaining (neobjednaný = remaining, ako order riadok). Rozpis
+  // (Objednané/Čaká sa/…) ostáva iba pre order riadky (predajňový riadok nemá
+  // stav), takže sa doň nemieša.
+  const baseSummary = summarizeOrderLines(scopedLines);
+  const floorTotalQty = scopedFloorRows.reduce((sum, row) => sum + row.quantity, 0);
+  const floorRemainingQty = scopedFloorRows.filter((row) => !row.ordered).reduce((sum, row) => sum + row.quantity, 0);
+  const summary = { ...baseSummary, total: baseSummary.total + floorTotalQty, remaining: baseSummary.remaining + floorRemainingQty };
 
   return (
     <div className="orders-toolbar" data-testid="orders-toolbar">
@@ -40,15 +54,22 @@ export function OrdersToolbar({
             onSelectSupplier(null);
           }}
         >
-          {`Všetci (${String(allLines.length)})`}
+          {`Všetci (${String(allLines.length + allFloorRows.length)})`}
         </button>
         {/* issue 452: čipy dodávateľov zoradené abecedne (slovenské locale,
             case-insensitive), "(bez dodávateľa)" naposledy — čip "Všetci" vyššie
             ostáva vždy prvý. Farby/počty/správanie sa nemenia, len poradie;
             `allLines`/`scopedLines` (súčty) ostávajú nad pôvodným `suppliers`. */}
         {sortSuppliersForChips(suppliers).map((group) => {
-          const groupSummary = summarizeOrderLines(group.lines);
-          const done = group.lines.length > 0 && groupSummary.remaining === 0;
+          const groupFloorRows = group.floorRows ?? [];
+          // issue 480: `done` (a počet) zhodné s hlavičkou skupiny
+          // (`SupplierActionsPanel`) — vybavené je VŠETKO: objednávky aj
+          // predajňové riadky. `[].every() === true`, takže skupina bez
+          // predajňových riadkov sa správa presne ako doteraz.
+          const done =
+            group.lines.length + groupFloorRows.length > 0 &&
+            summarizeOrderLines(group.lines).remaining === 0 &&
+            groupFloorRows.every((row) => row.ordered);
           return (
             <button
               key={group.supplier}
@@ -59,14 +80,14 @@ export function OrdersToolbar({
                 onSelectSupplier(group.supplier);
               }}
             >
-              {`${group.supplier} (${String(group.lines.length)})`}
+              {`${group.supplier} (${String(group.lines.length + groupFloorRows.length)})`}
             </button>
           );
         })}
       </div>
       <div className="orders-toolbar-summary-row">
         <p className="orders-summary" data-testid="orders-summary">
-          {formatOrderSummaryText(summarizeOrderLines(scopedLines), selectedSupplier)}
+          {formatOrderSummaryText(summary, selectedSupplier)}
         </p>
         <button
           type="button"

--- a/apps/web/src/components/RiesitSection.tsx
+++ b/apps/web/src/components/RiesitSection.tsx
@@ -164,8 +164,13 @@ export function RiesitSection({
           busySupplierLineId={board.busySupplierLineId}
           busySupplierLinkLineId={board.busySupplierLinkLineId}
           busyCommentOrderId={board.busyCommentOrderId}
+          // issue 480: predajňové riadky sú LEN v „Na objednanie" (server vracia
+          // pre „Riešiť" prázdne `floorRows`), tieto props sú tu de facto no-op,
+          // ale `SupplierOrderGroup` ich vyžaduje.
+          busyFloorRowKey={board.busyFloorRowKey}
           onChangeState={board.changeState}
           onChangeOrdered={board.changeOrdered}
+          onChangeFloorOrdered={board.changeFloorOrdered}
           onAssignSupplier={board.assignSupplier}
           onSetSupplierLink={board.setSupplierLink}
           onChangeComment={board.changeComment}

--- a/apps/web/src/components/SupplierActionsPanel.groupColor.test.tsx
+++ b/apps/web/src/components/SupplierActionsPanel.groupColor.test.tsx
@@ -63,6 +63,7 @@ function renderPanel(group: SupplierOpenOrders, selectedSupplier: string | null)
       onClosePreview={() => {}}
       onConfirmSend={() => {}}
       selectedSupplier={selectedSupplier}
+      busyFloorRowKey={null}
     />,
   );
 }

--- a/apps/web/src/components/SupplierActionsPanel.tsx
+++ b/apps/web/src/components/SupplierActionsPanel.tsx
@@ -34,6 +34,7 @@ export function SupplierActionsPanel({
   onClosePreview,
   onConfirmSend,
   selectedSupplier,
+  busyFloorRowKey,
 }: {
   readonly group: SupplierOpenOrders;
   readonly canChangeState: boolean;
@@ -61,6 +62,11 @@ export function SupplierActionsPanel({
   // nosič tých istých troch stavov ako filtračný čip (`OrdersToolbar.tsx`) —
   // `active` presne vtedy, keď je TÁTO skupina PRÁVE TERAZ vybraný filter.
   readonly selectedSupplier: string | null;
+  // issue 480: kľúč (`noteId::variantCode`) predajňového riadku, ktorého zápis
+  // „objednané" PRÁVE TERAZ prebieha — hromadné tlačidlo skupiny sa musí
+  // znefunkčniť aj kým beží per-floor-row zápis TEJTO skupiny (obojsmerný
+  // busy-guard, issue 60).
+  readonly busyFloorRowKey: string | null;
 }): JSX.Element {
   // Riadky, ktoré ešte treba objednať u dodávateľa (rovnaký zámer ako stará
   // appka's `outstandingOf`/`!isHandled`, #31) — východiskový stav pred tým,
@@ -70,16 +76,36 @@ export function SupplierActionsPanel({
   // odoslať/skopírovať bez ohľadu na to, či je riadok už odškrtnutý. Jediné
   // miesto, ktoré túto konštantu po extrakcii (issue 61) potrebuje.
   const outstandingState = "objednane";
-  // issue 263: rovnaký výpočet "done" ako čip (`OrdersToolbar.tsx`), aby
-  // OBIDVA nosiče vždy zhodne zobrazovali TÚ ISTÚ farbu pre TÚ ISTÚ skupinu.
-  const done = group.lines.length > 0 && summarizeOrderLines(group.lines).remaining === 0;
+  // issue 480: predajňové riadky skupiny (server ich vždy posiela, `?? []`
+  // poistka pre staré testové literály bez tohto poľa).
+  const floorRows = group.floorRows ?? [];
+  // issue 480: skupina je „všetko objednané" (pre smer aj popis hromadného
+  // tlačidla) keď sú objednané VŠETKY riadky objednávok AJ všetky predajňové
+  // riadky. `[].every() === true`, takže skupina bez floor riadkov sa správa
+  // presne ako doteraz.
+  const allOrdered = group.lines.every((l) => l.ordered) && floorRows.every((r) => r.ordered);
+  // issue 263/480: rovnaký výpočet "done" ako čip (`OrdersToolbar.tsx`), aby
+  // OBIDVA nosiče zhodne zobrazili TÚ ISTÚ farbu — rozšírené o predajňové riadky
+  // (skupina je „done" len keď je vybavené VŠETKO: objednávky aj predajňa).
+  const done =
+    group.lines.length + floorRows.length > 0 &&
+    summarizeOrderLines(group.lines).remaining === 0 &&
+    floorRows.every((r) => r.ordered);
+  // issue 480: hromadné tlačidlo je znefunkčnené aj kým beží per-floor-row zápis
+  // niektorého riadku TEJTO skupiny (mirror `busyOrderedLineId`, obojsmerný
+  // busy-guard z issue 60).
+  const floorBusyInGroup =
+    busyFloorRowKey !== null && floorRows.some((r) => `${r.noteId}::${r.variantCode}` === busyFloorRowKey);
   const isSelected = selectedSupplier === group.supplier;
 
   return (
     <>
       <div className={"toorder-supplier" + (done ? " done" : "") + (isSelected ? " active" : "")}>
+        {/* issue 480: počet zahŕňa aj predajňové riadky, aby skupina LEN s
+            predajňovými riadkami neukazovala „0 riadky". */}
         <span className="tosup-label">
-          {group.supplier} — {group.lines.length} {group.lines.length === 1 ? "riadok" : "riadky"}
+          {group.supplier} — {group.lines.length + floorRows.length}{" "}
+          {group.lines.length + floorRows.length === 1 ? "riadok" : "riadky"}
         </span>
         <div className="tosup-contact" data-testid={`supplier-contact-${group.supplier}`}>
           {editingEmailSupplier === group.supplier ? (
@@ -141,13 +167,17 @@ export function SupplierActionsPanel({
               className="btn sm ghost"
               disabled={
                 busyOrderedSupplier === group.supplier ||
-                (busyOrderedLineId !== null && group.lines.some((l) => l.lineId === busyOrderedLineId))
+                (busyOrderedLineId !== null && group.lines.some((l) => l.lineId === busyOrderedLineId)) ||
+                floorBusyInGroup
               }
               onClick={() => {
-                onToggleGroupOrdered(group.supplier, !group.lines.every((l) => l.ordered));
+                // issue 480: hromadné označenie zahŕňa objednávkové AJ predajňové
+                // riadky (server `setSupplierLinesOrdered` nastaví oboje) — smer
+                // podľa `allOrdered` (všetko objednané → zruší, inak označí).
+                onToggleGroupOrdered(group.supplier, !allOrdered);
               }}
             >
-              {group.lines.every((l) => l.ordered) ? "↺ Zrušiť označenie skupiny" : "✔ Označiť skupinu ako objednané"}
+              {allOrdered ? "↺ Zrušiť označenie skupiny" : "✔ Označiť skupinu ako objednané"}
             </button>
             {/* issue 118: majiteľ, doslovne "zatial skry este to nebudeme
                 pouzivat" — SKRYTÉ (nie zmazané), `orderScreenFlags.ts`'s

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
-import { computeVariantTotals, isLineHiddenByFilter } from "../ordersSummary.js";
+import { computeVariantTotals, isFloorRowHidden, isLineHiddenByFilter } from "../ordersSummary.js";
 import type { SupplierDraftsApi } from "../useSupplierDrafts.js";
+import { FloorOrderRow } from "./FloorOrderRow.js";
 import { OrderLineRow } from "./OrderLineRow.js";
 import { SupplierActionsPanel } from "./SupplierActionsPanel.js";
 import type { OrderLine, OrderMailPreview, SupplierOpenOrders } from "../ordersApi.js";
@@ -26,8 +27,10 @@ export function SupplierOrderGroup({
   busySupplierLineId,
   busySupplierLinkLineId,
   busyCommentOrderId,
+  busyFloorRowKey,
   onChangeState,
   onChangeOrdered,
+  onChangeFloorOrdered,
   onAssignSupplier,
   onSetSupplierLink,
   onChangeComment,
@@ -79,8 +82,13 @@ export function SupplierOrderGroup({
   readonly busySupplierLinkLineId: string | null;
   // issue 64: objednávka, ktorej poznámka PRÁVE TERAZ ukladá.
   readonly busyCommentOrderId: string | null;
+  // issue 480: kľúč (`noteId::variantCode`) predajňového riadku, ktorého zápis
+  // „objednané" PRÁVE TERAZ prebieha.
+  readonly busyFloorRowKey: string | null;
   readonly onChangeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly onChangeOrdered: (lineId: string, ordered: boolean) => void;
+  // issue 480: prepnutie „objednané" na predajňovom riadku.
+  readonly onChangeFloorOrdered: (noteId: string, variantCode: string, ordered: boolean) => void;
   readonly onAssignSupplier: (lineId: string, supplier: string) => void;
   // issue 166: `boolean` návratová hodnota — pozri `OrderLineRow.tsx`'s komentár.
   readonly onSetSupplierLink: (lineId: string, url: string) => boolean;
@@ -105,7 +113,11 @@ export function SupplierOrderGroup({
   readonly onConfirmSend: (supplier: string) => void;
 }): JSX.Element | null {
   const visibleLines = group.lines.filter((line) => !isLineHiddenByFilter(line, hideResolved, dirtyEditorLineIds));
-  if (visibleLines.length === 0) return null;
+  // issue 480: predajňové riadky skupiny (skryté pri „skryť vybavené", keď sú
+  // objednané). Skupina zmizne LEN keď nemá ani viditeľnú objednávku ANI
+  // viditeľný predajňový riadok — inak by floor-only skupina vôbec nevykreslila.
+  const visibleFloorRows = (group.floorRows ?? []).filter((row) => !isFloorRowHidden(row, hideResolved));
+  if (visibleLines.length === 0 && visibleFloorRows.length === 0) return null;
   // issue 62: súčty sa počítajú nad CELOU (nefiltrovanou) skupinou
   // dodávateľa, nikdy nad `visibleLines` — chip nesmie zmiznúť/zmeniť
   // hodnotu len preto, že prepínač "skryť vybavené" skryl sesterský riadok
@@ -138,6 +150,7 @@ export function SupplierOrderGroup({
         onClosePreview={onClosePreview}
         onConfirmSend={onConfirmSend}
         selectedSupplier={selectedSupplier}
+        busyFloorRowKey={busyFloorRowKey}
       />
       {/* issue 95: vlastný vodorovný posuvný obal — stránka (`.main-wide`)
           sa sama nikdy neposúva, posúva sa (keď treba) len táto tabuľka.
@@ -214,6 +227,21 @@ export function SupplierOrderGroup({
                 onChangeComment={onChangeComment}
                 onEditorActivityChange={onEditorActivityChange}
                 onSupplierDraftChange={supplierDrafts.setDraft}
+              />
+            ))}
+            {/* issue 480: predajňové riadky POD riadkami objednávok tej istej
+                skupiny dodávateľa — v tej istej tabuľke (rovnaké stĺpce), bez
+                stavových tlačidiel, s 🛍️ namiesto čísla objednávky. */}
+            {visibleFloorRows.map((row) => (
+              <FloorOrderRow
+                key={`${row.noteId}::${row.variantCode}`}
+                row={row}
+                canChangeState={canChangeState}
+                busyFloorRowKey={busyFloorRowKey}
+                // Review of PR 75/76 (issue 60) obojsmerný busy-guard: kým beží
+                // hromadná akcia skupiny, jednotlivý floor riadok sa nedá meniť.
+                supplierBusy={busyOrderedSupplier === group.supplier}
+                onChangeOrdered={onChangeFloorOrdered}
               />
             ))}
           </tbody>

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -93,9 +93,31 @@ const ordersIngestOutcomeSchema = z.discriminatedUnion("status", [
 
 export type OrdersIngestOutcome = z.infer<typeof ordersIngestOutcomeSchema>;
 
+// issue 480: predajňový (floor) riadok — produkt pripnutý na nevybavenom zápise
+// „Objednávky predajňa", zaradený pod svojho dodávateľa. Zrkadlí `FloorOrderRow`
+// z `apps/api/src/modules/orders/queries.ts`. NEMÁ stav ani order/admin odkaz —
+// klik vedie na `?tab=floor-orders`; jediná „vybavené" sémantika je `ordered`.
+const floorRowSchema = z.object({
+  noteId: z.string(),
+  variantCode: z.string(),
+  productName: z.string(),
+  sizeLabel: z.string().nullable(),
+  customerName: z.string(),
+  quantity: z.number(),
+  createdAt: z.string(),
+  ordered: z.boolean(),
+});
+export type FloorOrderRow = z.infer<typeof floorRowSchema>;
+
 const supplierGroupSchema = z.object({
   supplier: z.string(),
   lines: z.array(orderLineSchema),
+  // issue 480: predajňové riadky pod tým istým dodávateľom. `.optional()`
+  // (nie `.default`) ZÁMERNE — server ich VŽDY posiela (board „Na objednanie"
+  // naplnené, sekcia „Riešiť" prázdne `[]`), ale desiatky existujúcich unit
+  // testov konštruujú skupinu ako `{ supplier, lines, email }` bez tohto poľa;
+  // optional typ ich necháva kompilovať a konzumenti čítajú `floorRows ?? []`.
+  floorRows: z.array(floorRowSchema).optional(),
   // E-mailový kontakt dodávateľa (#31), `null` keď zatiaľ nenastavený.
   email: z.string().nullable(),
 });
@@ -358,6 +380,22 @@ export async function setSupplierLinesOrdered(
     await readJson(response, "Hromadné označenie skupiny sa nepodarilo"),
   );
   return { lineCount: telo.lineCount };
+}
+
+// issue 480: „objednané" na predajňovom riadku v board-e „Na objednanie" —
+// volá `POST /api/floor-notes/:id/products/:variantCode/ordered`. Server
+// prepočíta note-level 🛒. 401 hádže `OrdersUnauthorizedError` (cez `readJson`),
+// aby to `useOrderLinesBoard` spracoval rovnako ako ostatné board mutácie.
+export async function setFloorRowOrdered(noteId: string, variantCode: string, ordered: boolean): Promise<void> {
+  const response = await fetch(
+    `/api/floor-notes/${encodeURIComponent(noteId)}/products/${encodeURIComponent(variantCode)}/ordered`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: ordered }),
+    },
+  );
+  await readJson(response, "Zmena príznaku objednané sa nepodarila");
 }
 
 // #31: e-mailový kontakt dodávateľa + odoslanie objednávky mailom.

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -1,4 +1,4 @@
-import { NEZNAMY_DODAVATEL, type OrderLine } from "./ordersApi.js";
+import { NEZNAMY_DODAVATEL, type FloorOrderRow, type OrderLine } from "./ordersApi.js";
 
 // issue 61 — priamy náprotivok starej appky's `isHandled` (`ORDERED[o.key] ||
 // WAITING[o.key] || INSTOCK[o.key] || UNAVAIL[o.key]`, `app.js:2332-2498`).
@@ -23,6 +23,15 @@ export function isLineHiddenByFilter(
   dirtyEditorLineIds: ReadonlySet<string>,
 ): boolean {
   return hideResolved && isLineResolved(line) && !dirtyEditorLineIds.has(line.lineId);
+}
+
+// issue 480: predajňový (floor) riadok je „vybavený" — a teda skrytý pri
+// prepínači „skryť vybavené" — práve keď je objednaný. `ordered` je jediná
+// terminálna sémantika floor riadku (nemá stav ani `dirtyEditorLineIds`
+// výnimku, tie sú len pre order_line inline editory). Samostatná funkcia (nie
+// `isLineHiddenByFilter`), keďže floor riadok nemá `state`/`lineId`.
+export function isFloorRowHidden(row: Pick<FloorOrderRow, "ordered">, hideResolved: boolean): boolean {
+  return hideResolved && row.ordered;
 }
 
 // issue 260: každé pole je súčet `quantity` (počet KUSOV naprieč riadkami),

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1670,6 +1670,27 @@ tr:last-child td {
 .ord-code-link {
   text-decoration: underline;
 }
+/* issue 480: predajňový (floor) riadok v tabuľke „Na objednanie" — vykresľuje
+   sa v tej istej tabuľke ako riadky objednávok (rovnaké stĺpce). `.floor-order-
+   code` = kód produktu pod jeho názvom, tlmený a menší, presný vzor ako
+   `.ord-code-text` (issue 276). `.floor-order-link` = znak 🛍️ na mieste čísla
+   objednávky, odkaz na zápis v „Objednávky predajňa" (`?tab=floor-orders`);
+   bez podčiarknutia (je to ikona, nie text). Dimming objednaného riadku
+   preberá existujúca `.order-row.ordered` (issue 60) — žiadne nové pravidlo. */
+.floor-order-code {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-muted);
+  margin-top: var(--fs-space-1);
+}
+.floor-order-link {
+  text-decoration: none;
+  line-height: 1;
+}
 /* issue 65: upozornenie na starú nevybavenú objednávku (>14 dní) — výrazná
    farba (`--fs-warning`), rovnaká sémantika ako `.orders-table tr.state-
    caka_sa` vyššie, ale nezávislá od stavu riadku (môže sa zobraziť pri

--- a/apps/web/src/useOrderLinesBoard.ts
+++ b/apps/web/src/useOrderLinesBoard.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } 
 import {
   assignOrderLineSupplier as assignOrderLineSupplierApi,
   OrdersUnauthorizedError,
+  setFloorRowOrdered,
   setSupplierLinesOrdered,
   updateOrderComment,
   updateOrderLineOrdered,
@@ -57,6 +58,9 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
   readonly busySupplierLineId: string | null;
   readonly busySupplierLinkLineId: string | null;
   readonly busyCommentOrderId: string | null;
+  // issue 480: kľúč (`noteId::variantCode`) predajňového riadku, ktorého zápis
+  // „objednané" PRÁVE TERAZ prebieha.
+  readonly busyFloorRowKey: string | null;
   readonly supplierDrafts: ReturnType<typeof useSupplierDrafts>;
   readonly dirtyEditorLineIds: ReadonlySet<string>;
   readonly onEditorActivityChange: (lineId: string, active: boolean) => void;
@@ -66,6 +70,8 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
   readonly load: () => void;
   readonly changeState: (lineId: string, newState: OrderLine["state"]) => void;
   readonly changeOrdered: (lineId: string, ordered: boolean) => void;
+  // issue 480: prepnutie „objednané" na predajňovom riadku.
+  readonly changeFloorOrdered: (noteId: string, variantCode: string, ordered: boolean) => void;
   readonly assignSupplier: (lineId: string, supplier: string) => void;
   readonly changeComment: (orderId: string, comment: string | null) => void;
   readonly toggleGroupOrdered: (supplier: string, ordered: boolean) => void;
@@ -81,6 +87,9 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
   const [busyOrderedSupplier, setBusyOrderedSupplier] = useState<string | null>(null);
   const [busySupplierLineId, setBusySupplierLineId] = useState<string | null>(null);
   const [busyCommentOrderId, setBusyCommentOrderId] = useState<string | null>(null);
+  // issue 480: predajňový riadok (`noteId::variantCode`), ktorého zápis
+  // „objednané" PRÁVE TERAZ prebieha.
+  const [busyFloorRowKey, setBusyFloorRowKey] = useState<string | null>(null);
 
   // #31: e-mailový kontakt dodávateľa (editovateľný v zozname).
   const email = useSupplierEmailEditing(setSuppliers, onSessionExpired);
@@ -185,6 +194,48 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
     [onSessionExpired, suppliers],
   );
 
+  // issue 480: „objednané" na predajňovom riadku — volá floor-notes trasu,
+  // lokálne prepne `ordered` daného floor riadku (`noteId`+`variantCode`).
+  // Neinclude `suppliers` v deps — `where` sa počíta z argumentov, aktualizácia
+  // ide cez funkčný `setSuppliers`.
+  const changeFloorOrdered = useCallback(
+    (noteId: string, variantCode: string, ordered: boolean) => {
+      const rowKey = `${noteId}::${variantCode}`;
+      const failureId = `floorOrdered:${rowKey}`;
+      setBusyFloorRowKey(rowKey);
+      setFloorRowOrdered(noteId, variantCode, ordered)
+        .then(() => {
+          setSuppliers((current) =>
+            current.map((group) => ({
+              ...group,
+              floorRows: (group.floorRows ?? []).map((row) =>
+                row.noteId === noteId && row.variantCode === variantCode ? { ...row, ordered } : row,
+              ),
+            })),
+          );
+          setWriteFailures((current) => clearWriteFailure(current, failureId));
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setWriteFailures((current) =>
+            upsertWriteFailure(current, {
+              id: failureId,
+              what: "Príznak objednané (predajňa)",
+              where: `predajňový riadok ${variantCode}`,
+              detail: err instanceof Error ? err.message : "Zmena príznaku objednané sa nepodarila.",
+            }),
+          );
+        })
+        .finally(() => {
+          setBusyFloorRowKey(null);
+        });
+    },
+    [onSessionExpired],
+  );
+
   const assignSupplier = useCallback(
     (lineId: string, supplier: string) => {
       const failureId = `supplier:${lineId}`;
@@ -227,10 +278,16 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
       setBusyOrderedSupplier(supplier);
       setSupplierLinesOrdered(supplier, ordered)
         .then(() => {
+          // issue 480: hromadná akcia prepne objednávkové AJ predajňové riadky
+          // skupiny (server `setSupplierLinesOrdered` mutuje oboje).
           setSuppliers((current) =>
             current.map((group) =>
               group.supplier === supplier
-                ? { ...group, lines: group.lines.map((line) => ({ ...line, ordered })) }
+                ? {
+                    ...group,
+                    lines: group.lines.map((line) => ({ ...line, ordered })),
+                    floorRows: (group.floorRows ?? []).map((row) => ({ ...row, ordered })),
+                  }
                 : group,
             ),
           );
@@ -308,6 +365,7 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
     busySupplierLineId,
     busySupplierLinkLineId,
     busyCommentOrderId,
+    busyFloorRowKey,
     supplierDrafts,
     dirtyEditorLineIds,
     onEditorActivityChange,
@@ -317,6 +375,7 @@ export function useOrderLinesBoard(options: OrderLinesBoardOptions): {
     load,
     changeState,
     changeOrdered,
+    changeFloorOrdered,
     assignSupplier,
     changeComment,
     toggleGroupOrdered,

--- a/apps/web/tests/e2e/floor-orders-board.spec.ts
+++ b/apps/web/tests/e2e/floor-orders-board.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+const E2E_PREDAJNA_EMAIL = "e2e-predajna@forestshop.sk"; // zhoda so scripts/e2e-fixtures-floor-notes.ts
+
+// issue 480: predajňové položky (🛍️) zo zápisov „Objednávky predajňa" v board-e
+// „Na objednanie". Celý tok reálnym prehliadačom: pripnúť produkt na nevybavený
+// zápis → riadok sa objaví v „Na objednanie" → označiť ho ako objednaný →
+// zápis dostane 🛒 automaticky → vybaviť (resolved) zápis → riadok z „Na
+// objednanie" zmizne. Konzola musí zostať čistá (`.claude/rules/testing.md`).
+// Znovupoužíva existujúci izolovaný účet + fixtúru E2E-PREDAJNA-1 (žiadny nový
+// variant → žiadny posun `catalog.spec.ts` počtov).
+test("predajňový produkt sa objaví v Na objednanie, dá sa objednať, zápis dostane 🛒, po vybavení riadok zmizne — konzola čistá", async ({ page }) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  // Prihlásenie + vytvorenie zápisu s pripnutým produktom (v „Objednávky predajňa").
+  await page.goto("/?tab=floor-orders");
+  await page.getByLabel("E-mail").fill(E2E_PREDAJNA_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Objednávky predajňa" })).toBeVisible();
+
+  await page.getByTestId("floor-note-new-input").fill("E2E Board Zákazník");
+  await page.getByTestId("floor-note-new-add").click();
+  await expect(page.getByTestId("floor-notes-list")).toBeVisible();
+  const riadokZapisu = page.locator('[data-testid^="floor-note-row-"]').filter({ hasText: "E2E Board Zákazník" });
+  await expect(riadokZapisu).toHaveCount(1);
+  const noteId = (await riadokZapisu.getAttribute("data-testid"))?.replace("floor-note-row-", "") ?? "";
+  expect(noteId).not.toBe("");
+
+  await page.getByTestId(`floor-note-attach-toggle-${noteId}`).click();
+  await page.getByTestId("floor-note-product-search-input").fill("E2E Predajňa Bunda Rogaland");
+  await page.getByTestId("floor-note-product-search-submit").click();
+  await page.getByTestId("floor-note-product-pin-E2E-PREDAJNA-1").click();
+  await expect(page.getByTestId(`floor-note-product-link-${noteId}-E2E-PREDAJNA-1`)).toBeVisible();
+
+  // „Na objednanie" — pripnutý produkt sa objaví ako predajňový riadok.
+  await page.goto("/?tab=orders");
+  const boardRow = page.getByTestId(`floor-order-row-${noteId}-E2E-PREDAJNA-1`);
+  await expect(boardRow).toBeVisible();
+  await expect(boardRow).toContainText("E2E Board Zákazník");
+  await expect(boardRow).toContainText("E2E-PREDAJNA-1");
+  // 🛍️ odkaz na mieste čísla objednávky vedie na zápis v „Objednávky predajňa".
+  await expect(page.getByTestId(`floor-order-link-${noteId}-E2E-PREDAJNA-1`)).toHaveAttribute("href", "?tab=floor-orders");
+
+  // Označiť predajňový riadok ako objednaný.
+  const checkbox = page.getByTestId(`floor-ordered-checkbox-${noteId}-E2E-PREDAJNA-1`);
+  await expect(checkbox).not.toBeChecked();
+  await checkbox.check();
+  await expect(checkbox).toBeChecked();
+  await expect(boardRow).toHaveClass(/ordered/);
+
+  // Zápis má jediný produkt a ten je teraz objednaný → 🛒 sa nastavilo automaticky.
+  await page.goto("/?tab=floor-orders");
+  await expect(page.getByTestId(`floor-note-marker-ordered-${noteId}`)).toHaveAttribute("aria-pressed", "true");
+
+  // Vybaviť (resolved) zápis → jeho predajňový riadok z „Na objednanie" zmizne.
+  await page.getByTestId(`floor-note-marker-resolved-${noteId}`).click();
+  await expect(page.getByTestId(`floor-note-marker-resolved-${noteId}`)).toHaveAttribute("aria-pressed", "true");
+
+  await page.goto("/?tab=orders");
+  await expect(page.getByTestId(`floor-order-row-${noteId}-E2E-PREDAJNA-1`)).toHaveCount(0);
+
+  // Upratať — zmazať testovací zápis, nech neostáva v zdieľanej e2e DB.
+  await page.goto("/?tab=floor-orders");
+  await page.getByTestId(`floor-note-delete-${noteId}`).click();
+  await expect(page.getByTestId(`floor-note-row-${noteId}`)).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4332,3 +4332,16 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   spresnený názov testu POST /:id/done). PR #475 dev→main, merge `1abefb3`,
   main CI + Deploy zelené, nasadené `v0.3.0-dev.277` (telo PR = plain
   „issue 473", žiadny Closes).
+
+## 2026-08-23 — issue 476 (Riešiť — stav order_line + sekcia)
+- **#476 (piaty stav riadku `riesit` + sekcia „Riešiť" + rýchle pole číslo→Enter):**
+  nový enum `order_line_state` člen `riesit` (migrácia `0058`, samostatná od
+  CHECK/index kvôli 55P04), zdieľaný `listOpenOrderLinesBySupplier` so
+  `stateFilter` (sekcia Riešiť = tie isté zoskupené riadky, len `state=riesit`),
+  `useOrderLinesBoard` vyňaté jadro spoločné pre „Na objednanie" aj „Riešiť",
+  odznak `GET /api/orders/riesit/count`, hromadné `POST /api/orders/riesit/by-code`
+  (číslo objednávky → Enter, 200 aj pri neznámom/zatvorenom čísle kvôli konzole).
+- Commity `8fc4fc9` (bump .278) / `98fc2fe` (feat) / `00d00f6` (review fixes).
+  PR #477 (merge `43a8f04`) + #478 (merge `d85091e`, by-code 400→200 konzolová
+  chyba) + #479 (merge `5ca7955`, playbook). Nasadené `v0.3.0-dev.280` (telá PR
+  = plain „issue 476", žiadny Closes).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.280",
+  "version": "0.3.0-dev.281",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Rieši issue 480 — predajňové položky (🛍️) zo zápisov „Objednávky predajňa" v board-e „Na objednanie".

## Čo sa mení
- Produkty pripnuté na NEVYBAVENÝCH zápisoch „Objednávky predajňa" sa zobrazia v „Na objednanie" ako riadky pod svojím dodávateľom (rovnaká efektívna dodávateľská cesta ako `order_line`: variantCode → productKey → `products.supplier` / `product_supplier_override`). Produkt bez dodávateľa → skupina „(bez dodávateľa)".
- Riadok: Dátum (zápisu) · Zákazník (prvý riadok textu zápisu) · Produkt + kód · ks · 🛍️ (namiesto čísla objednávky, klik → `?tab=floor-orders`) · checkbox „objednané". ŽIADNE stavové tlačidlá.
- Migrácia `0059`: nullable `floor_note_product.ordered_at` (NULL = neobjednané).
- Per-item „objednané" (`POST /api/floor-notes/:id/products/:variantCode/ordered`, audited) + hromadné „Označiť skupinu ako objednané" zahŕňa aj predajňové riadky.
- `floor_note.ordered` (🛒) sa prepočíta: true keď má zápis ≥1 položku a VŠETKY sú objednané, inak false (symetricky).
- Vybavený (resolved) zápis → jeho riadky z „Na objednanie" zmiznú.
- Odznak „Na objednanie" počíta aj neobjednané predajňové riadky; „skryť vybavené" skryje objednaný predajňový riadok.
- E-mail dodávateľovi predajňové riadky NEZAHŔŇA (číta len `order_line`) — regresný test.
- Sekcia „Riešiť" predajňové riadky neobsahuje.

## Testy
- API integračné (`floor-orders-http.integration.test.ts`, 13): zoskupenie pod dodávateľom + „(bez dodávateľa)", spoločná skupina s objednávkami, per-item/hromadné ordered, 🛒 auto-set/unset, resolved filter, filter „Riešiť", zobrazenie bez otvorených stavov, e-mail bez floor riadkov, RBAC + cudzí Origin, 404/400.
- Web unit (`OrdersSection.floorRows.test.tsx`, 7): render, per-item ordered, počet v odznaku, hromadná akcia, floor-only skupina, „skryť vybavené".
- E2E (`floor-orders-board.spec.ts`): pripnúť → riadok v „Na objednanie" → objednať → 🛒 auto-set → vybaviť → riadok zmizne; nulová konzola.

CI (dev push, `7cfe301`): check, integration, e2e, version-check, docker-build — všetko zelené.

Ticket sa zavrie RUČNE až po naživo overení (post-deploy Playwright), preto plain „issue 480" bez zatváracieho kľúčového slova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
