### PR TITLE
issue 484 — Sekcia Riešiť: 1 riadok na objednávku s rozrolovaním

### DIFF
--- a/apps/api/src/http/orders-routes.ts
+++ b/apps/api/src/http/orders-routes.ts
@@ -8,7 +8,7 @@ import { record } from "../modules/audit/service.js";
 import { ORDERS_EXPORT_URL_NOT_CONFIGURED, type OrdersIngestResult, type RunOrdersIngest } from "../modules/orders/ingest.js";
 import { listKnownStatusNames, listOpenStatusNames, replaceOpenStatusNames } from "../modules/orders/open-statuses.js";
 import { getOrdersDashboardOverview } from "../modules/orders/overview.js";
-import { countOpenOrderLinesByState, getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
+import { countOpenOrdersByState, getOrderDetail, listOpenOrderLinesBySupplier } from "../modules/orders/queries.js";
 import { assignOrderLineSupplier } from "../modules/orders/supplier-assignment.js";
 import { setProductSupplierLink, supplierLinkUrlBody } from "../modules/orders/supplier-link-assignment.js";
 import { setOrderComment, setOrderLineOrdered, setOrderLinesStateByCode, setOrderLineState } from "../modules/orders/state.js";
@@ -84,11 +84,12 @@ export function registerOrdersRoutes(
     c.json({ suppliers: await listOpenOrderLinesBySupplier(db, adminBaseUrl, { stateFilter: "riesit" }) }),
   );
 
-  // issue 476: odznak počtu v ľavom menu — počet otvorených riadkov v stave
-  // `riesit` (vzor issue 473 count endpointov). `requireUser`, žiadne
-  // obmedzenie roly (čítanie počtu nie je citlivejšie než čítanie zoznamu).
+  // issue 476/484: odznak počtu v ľavom menu — počet otvorených DISTINCT
+  // OBJEDNÁVOK v stave `riesit` (issue 484, Štěpán: „koľko problémových
+  // objednávok", nie riadkov). `requireUser`, žiadne obmedzenie roly (čítanie
+  // počtu nie je citlivejšie než čítanie zoznamu).
   app.get("/api/orders/riesit/count", requireUser(db), async (c) => {
-    const count = await countOpenOrderLinesByState(db, "riesit");
+    const count = await countOpenOrdersByState(db, "riesit");
     return c.json({ count });
   });
 

--- a/apps/api/src/modules/orders/queries.ts
+++ b/apps/api/src/modules/orders/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, countDistinct, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import {
   floorNoteProducts,
@@ -556,19 +556,20 @@ export async function listUnresolvedFloorProductIdsForSupplier(
   return rows.map((row) => ({ productId: row.productId, floorNoteId: row.floorNoteId }));
 }
 
-// issue 476: odznak počtu v ľavom menu pre „Riešiť" — počet OTVORENÝCH
-// (Shoptet stav ∈ `order_open_status`) riadkov objednávok v danom stave.
-// `COUNT(*) WHERE ...` priamo v SQL (rovnaký vzor ako `countActionable
-// Upozornenia` / issue 473's `countOpenDailyTasks`), nie natiahnutie celého
-// zoznamu cez `listOpenOrderLinesBySupplier` a `.length` v JS. Počíta RIADKY
-// (nie kusy) — rovnaký zámer ako „Na objednanie" nav odznak (issue 147/260,
-// `.claude/rules/orders.md`). `state` je parameter kvôli budúcej
-// znovupoužiteľnosti, dnes ho volá len `riesit` count trasa.
-export async function countOpenOrderLinesByState(db: Database, state: OrderLineState): Promise<number> {
+// issue 476/484: odznak počtu v ľavom menu pre „Riešiť" — počet OTVORENÝCH
+// (Shoptet stav ∈ `order_open_status`) DISTINCT OBJEDNÁVOK, ktoré majú aspoň
+// jeden riadok v danom stave. Issue 484 (Štěpán): pôvodne (issue 476) počítal
+// RIADKY, ale mentálny model je „koľko problémových OBJEDNÁVOK" — jedna
+// objednávka s viacerými riesit riadkami (rôzne varianty/dodávatelia) sa teraz
+// počíta RAZ. `countDistinct(order_line.order_id)` priamo v SQL (rovnaký vzor
+// ako predtým `count()`), nie natiahnutie celého zoznamu a `.length` v JS —
+// DB náprotivok `ordersSummary.ts`'s `countAffectedOrders`. `state` je parameter
+// kvôli budúcej znovupoužiteľnosti, dnes ho volá len `riesit` count trasa.
+export async function countOpenOrdersByState(db: Database, state: OrderLineState): Promise<number> {
   const openStatuses = await listOpenStatusNames(db);
   if (openStatuses.length === 0) return 0;
   const [row] = await db
-    .select({ total: count() })
+    .select({ total: countDistinct(orderLines.orderId) })
     .from(orderLines)
     .innerJoin(orders, eq(orders.id, orderLines.orderId))
     .where(and(inArray(orders.statusName, [...openStatuses]), eq(orderLines.state, state)));

--- a/apps/api/tests/riesit-http.integration.test.ts
+++ b/apps/api/tests/riesit-http.integration.test.ts
@@ -121,22 +121,29 @@ it("GET /api/orders/riesit bez prihlásenia vráti 401", async () => {
 
 // --- GET /api/orders/riesit/count ---
 
-it("GET /api/orders/riesit/count počíta LEN otvorené riadky v stave riesit", async () => {
+it("GET /api/orders/riesit/count počíta DISTINCT otvorené objednávky (nie riadky) v stave riesit", async () => {
   const { app, cookie, db } = await boot("manazer");
-  const a = await vlozObjednavku(db, 2);
+  const a = await vlozObjednavku(db, 2); // JEDNA objednávka s DVOMA riadkami
+  const b = await vlozObjednavku(db, 1);
   await vlozObjednavku(db, 1); // ostane objednane, do počtu nevstúpi
 
   const c0 = await app.request("/api/orders/riesit/count", { headers: { cookie } });
   expect((await c0.json()) as { count: number }).toEqual({ count: 0 });
 
+  // issue 484: OBA riadky objednávky `a` → riesit. To je stále JEDNA problémová
+  // objednávka, takže count = 1 (nie 2 ako pri starom počítaní riadkov).
   await setState(app, cookie, a.lineIds[0] ?? "", "riesit");
   await setState(app, cookie, a.lineIds[1] ?? "", "riesit");
+  const c1 = await app.request("/api/orders/riesit/count", { headers: { cookie } });
+  expect((await c1.json()) as { count: number }).toEqual({ count: 1 });
 
+  // Druhá objednávka v stave riesit → count 2 (DVE distinct objednávky).
+  await setState(app, cookie, b.lineIds[0] ?? "", "riesit");
   const c2 = await app.request("/api/orders/riesit/count", { headers: { cookie } });
   expect((await c2.json()) as { count: number }).toEqual({ count: 2 });
 });
 
-it("GET /api/orders/riesit/count NEpočíta riadky zatvorenej objednávky", async () => {
+it("GET /api/orders/riesit/count NEpočíta zatvorenú objednávku", async () => {
   const { app, cookie, db } = await boot("manazer");
   // objednávka v NEotvorenom Shoptet stave — jej riadky sa nikde neukážu
   const zatvorena = await vlozObjednavku(db, 1, "Vybavená");

--- a/apps/web/src/components/OrderLinesTableHead.tsx
+++ b/apps/web/src/components/OrderLinesTableHead.tsx
@@ -1,0 +1,48 @@
+import type { JSX } from "react";
+
+// issue 484: `<colgroup>` (9 stĺpcov) + `<thead>` tabuľky riadkov objednávok,
+// vyčlenené zo `SupplierOrderGroup.tsx` (BEZ zmeny markupu), aby ho mohla
+// znovupoužiť aj sekcia „Riešiť" v rozrolovanom detaile objednávky. Predtým
+// jediná kópia — teraz JEDEN zdroj pravdy pre 9-stĺpcovú schému (dovtedy ju
+// držal len komentár + `ORDERS_TABLE_COLUMN_COUNT` v `OrderLineRow.tsx`).
+// Statický, bez props — DOM je bajt-identický s pôvodným, takže existujúce
+// testy „Na objednanie" ostávajú v platnosti.
+export function OrderLinesTableHead(): JSX.Element {
+  return (
+    <>
+      {/* issue 95/117: 9 stĺpcov s percentuálnymi šírkami (`app.css`'s `.col-*`),
+          `table-layout: fixed` na `.orders-table`. Popisky sú skrátené (plný
+          význam v `title`), viď `.claude/rules/frontend-design.md` (issue 105). */}
+      <colgroup>
+        <col className="col-ordered" />
+        <col className="col-order" />
+        <col className="col-customer" />
+        <col className="col-product" />
+        <col className="col-qty" />
+        <col className="col-supplier" />
+        <col className="col-state" />
+        <col className="col-date" />
+        <col className="col-notes" />
+      </colgroup>
+      <thead>
+        <tr>
+          <th title="Objednané u dodávateľa (zaškrtávacie políčko)" aria-label="Objednané u dodávateľa">
+            ✓
+          </th>
+          <th title="Číslo objednávky (klik na kód v riadku otvorí objednávku v administrácii Shoptet)">
+            Č. obj.
+          </th>
+          <th>Zákazník</th>
+          <th>Produkt</th>
+          <th title="Množstvo (počet kusov)">Ks</th>
+          <th title="Dodávateľ z katalógu, alebo ručné priradenie pri produkte bez katalógového dodávateľa">
+            Dodávateľ
+          </th>
+          <th>Stav</th>
+          <th title="Dátum objednávky">Dátum obj.</th>
+          <th title="Poznámka zákazníka z e-shopu (na čítanie) + vlastná poznámka tímu">Poznámky</th>
+        </tr>
+      </thead>
+    </>
+  );
+}

--- a/apps/web/src/components/RiesitOrderRow.tsx
+++ b/apps/web/src/components/RiesitOrderRow.tsx
@@ -1,0 +1,113 @@
+import { useState, type JSX } from "react";
+import { formatSkDate } from "../formatDate.js";
+import { computeVariantTotals, formatItemCount } from "../ordersSummary.js";
+import type { RiesitOrder } from "../riesitOrders.js";
+import type { useOrderLinesBoard } from "../useOrderLinesBoard.js";
+import { OrderLineRow } from "./OrderLineRow.js";
+import { OrderLinesTableHead } from "./OrderLinesTableHead.js";
+
+// issue 484 (Štěpán): jedna problémová objednávka = JEDEN kompaktný riadok
+// (číslo objednávky s preklikom · meno zákazníka · počet položiek · dátum ·
+// poznámka), šípka ▾ rozroluje PLNÉ položkové riadky presne ako v „Na
+// objednanie" (znovupoužitý `OrderLineRow` so všetkými funkciami vrátane
+// vypnutia stavu Riešiť). Vypnutie Riešiť POSLEDNEJ položky odstráni riadok z
+// `board` (`keepOnlyState: "riesit"`) a keďže tento zoznam je ODVODENÝ z
+// `board.suppliers` (`groupRiesitLinesByOrder`), objednávka bez riesit riadkov
+// z neho automaticky vypadne pri ďalšom rendri.
+
+type Board = ReturnType<typeof useOrderLinesBoard>;
+
+export function RiesitOrderRow({
+  order,
+  canChangeState,
+  board,
+}: {
+  readonly order: RiesitOrder;
+  readonly canChangeState: boolean;
+  readonly board: Board;
+}): JSX.Element {
+  // Rozbalený/zbalený stav je lokálny per-objednávka. Kľúč zoznamu je `orderId`
+  // (RiesitSection), takže inštancia (a teda aj tento stav) prežije re-render
+  // pri zmene iného riadku; zmizne až keď objednávka opustí zoznam.
+  const [expanded, setExpanded] = useState(false);
+
+  // issue 62: Σ čipy opakovaného produktu — počítané nad položkami TEJTO
+  // objednávky (náprotivok skupiny dodávateľa v „Na objednanie").
+  const variantTotals = computeVariantTotals(order.lines);
+
+  const note = order.comment ?? "";
+
+  return (
+    <div className="riesit-order" data-testid={`riesit-order-${order.externalOrderId}`}>
+      <div className="riesit-order-head">
+        <button
+          type="button"
+          className="btn sm ghost riesit-order-toggle"
+          data-testid={`riesit-order-toggle-${order.externalOrderId}`}
+          aria-expanded={expanded}
+          aria-label={`${expanded ? "Zbaliť" : "Rozbaliť"} položky objednávky ${order.externalOrderId}`}
+          onClick={() => {
+            setExpanded((v) => !v);
+          }}
+        >
+          <span aria-hidden="true">{expanded ? "▾" : "▸"}</span>
+        </button>
+        {/* Preklik čísla objednávky — rovnaký cieľ (Shoptet admin) ako preklik
+            čísla v „Na objednanie" (`OrderLineRow`'s `.ord-admin-link`). */}
+        <a
+          href={order.adminUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="ord-admin-link riesit-order-code"
+          aria-label={`Otvoriť objednávku ${order.externalOrderId} v administrácii Shoptet`}
+          title="Otvoriť v administrácii Shoptet"
+        >
+          {order.externalOrderId}
+        </a>
+        <span className="riesit-order-customer">{order.customerName}</span>
+        <span className="riesit-order-count" data-testid={`riesit-order-count-${order.externalOrderId}`}>
+          {formatItemCount(order.lines.length)}
+        </span>
+        <span className="riesit-order-date">{formatSkDate(order.placedAt)}</span>
+        {note !== "" && (
+          <span className="riesit-order-note" title={note}>
+            {note}
+          </span>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="orders-table-wrap">
+          <table className="orders-table">
+            <OrderLinesTableHead />
+            <tbody>
+              {order.lines.map((line) => (
+                <OrderLineRow
+                  key={line.lineId}
+                  line={line}
+                  canChangeState={canChangeState}
+                  busyLineId={board.busyLineId}
+                  busyOrderedLineId={board.busyOrderedLineId}
+                  // V „Riešiť" niet hromadnej akcie po dodávateľovi → nikdy busy.
+                  supplierBusy={false}
+                  variantTotal={variantTotals.get(line.variantCode)}
+                  busySupplierLineId={board.busySupplierLineId}
+                  busySupplierLinkLineId={board.busySupplierLinkLineId}
+                  busyCommentOrderId={board.busyCommentOrderId}
+                  pendingSupplierDraft={board.supplierDrafts.draftByLineId.get(line.lineId)}
+                  onChangeState={board.changeState}
+                  onChangeOrdered={board.changeOrdered}
+                  onAssignSupplier={board.assignSupplier}
+                  onSetSupplierLink={board.setSupplierLink}
+                  onChangeComment={board.changeComment}
+                  onEditorActivityChange={board.onEditorActivityChange}
+                  onSupplierDraftChange={board.supplierDrafts.setDraft}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/RiesitSection.test.tsx
+++ b/apps/web/src/components/RiesitSection.test.tsx
@@ -4,10 +4,12 @@ import { RiesitBadgeRefreshContext } from "../riesitBadgeContext.js";
 import { RiesitSection } from "./RiesitSection.js";
 import type { OrderLine, SupplierOpenOrders } from "../ordersApi.js";
 
-// issue 476: sekcia „Riešiť" znovupoužíva jadro OrdersSection
+// issue 476/484: sekcia „Riešiť" znovupoužíva jadro OrdersSection
 // (`useOrderLinesBoard`) — mockujeme LEN sieťové funkcie `ordersApi.js`,
 // komponent aj pomocné hooky bežia naozaj (rovnaký vzor ako
-// `OrdersSection.remainingCount.test.tsx`).
+// `OrdersSection.remainingCount.test.tsx`). Issue 484: obrazovka je PLOCHÝ
+// zoznam objednávok (1 objednávka = 1 kompaktný riadok s rozrolovaním), už NIE
+// skupiny po dodávateľoch.
 const { fetchRiesitOrders, setOrderLinesRiesitByCode, updateOrderLineState } = vi.hoisted(() => ({
   fetchRiesitOrders: vi.fn(),
   setOrderLinesRiesitByCode: vi.fn(),
@@ -24,9 +26,11 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+const ORDER_ID = "aaaaaaaa-1111-1111-1111-111111111476";
+
 const LINE_RIESIT: OrderLine = {
   lineId: "11111111-1111-1111-1111-111111111476",
-  orderId: "aaaaaaaa-1111-1111-1111-111111111476",
+  orderId: ORDER_ID,
   externalOrderId: "7001",
   customerName: "Zákazník Riešiť",
   comment: null,
@@ -49,11 +53,17 @@ const LINE_RIESIT: OrderLine = {
   customerOpenOrderCount: 1,
 };
 
-const GROUP: SupplierOpenOrders = {
-  supplier: "DODAVATEL-RIESIT",
-  lines: [LINE_RIESIT],
-  email: null,
+// Druhý riadok TEJ ISTEJ objednávky u INÉHO dodávateľa (Štěpánov prípad:
+// jedna objednávka, viac dodávateľov) — musí sa preskupiť do JEDNEJ objednávky.
+const LINE_RIESIT_2: OrderLine = {
+  ...LINE_RIESIT,
+  lineId: "22222222-1111-1111-1111-111111111476",
+  variantCode: "R-2",
+  variantName: "Druhý produkt",
 };
+
+const GROUP: SupplierOpenOrders = { supplier: "DODAVATEL-RIESIT", lines: [LINE_RIESIT], email: null };
+const GROUP_2: SupplierOpenOrders = { supplier: "INY-DODAVATEL", lines: [LINE_RIESIT_2], email: null };
 
 function renderRiesit(refresh: () => void = () => {}): void {
   render(
@@ -70,13 +80,38 @@ it("nemá vlastný nadpis (Topbar ho renderuje za viditeľné záložky)", async
   expect(screen.queryByRole("heading")).toBeNull();
 });
 
-it("vykreslí riadky v stave riesit zoskupené po dodávateľoch", async () => {
+it("1 objednávka = 1 kompaktný riadok (zbalený); rozrolovanie ukáže položkové riadky", async () => {
   fetchRiesitOrders.mockResolvedValue([GROUP]);
   renderRiesit();
+
+  // Kompaktný riadok objednávky sa zobrazí: meno zákazníka + počet položiek.
+  const compact = await screen.findByTestId("riesit-order-7001");
+  expect(compact.textContent).toContain("Zákazník Riešiť");
+  expect(screen.getByTestId("riesit-order-count-7001").textContent).toBe("1 položka");
+
+  // Zbalený — plný položkový riadok NIE je vidieť.
+  expect(screen.queryByTestId(`order-line-${LINE_RIESIT.lineId}`)).toBeNull();
+
+  // Rozrolovanie → položkový riadok + aktívne tlačidlo „Riešiť".
+  fireEvent.click(screen.getByTestId("riesit-order-toggle-7001"));
+  const riadok = await screen.findByTestId(`order-line-${LINE_RIESIT.lineId}`);
+  expect(riadok).toBeTruthy();
+  expect(screen.getByTestId(`state-btn-riesit-${LINE_RIESIT.lineId}`).getAttribute("aria-checked")).toBe("true");
+});
+
+it("viac riadkov tej istej objednávky (naprieč dodávateľmi) sa preskupí do JEDNEJ objednávky (2 položky)", async () => {
+  fetchRiesitOrders.mockResolvedValue([GROUP, GROUP_2]);
+  renderRiesit();
+
+  // Jediná objednávka, hoci riadky prišli z DVOCH dodávateľských skupín.
+  await screen.findByTestId("riesit-order-7001");
+  expect(screen.getAllByTestId("riesit-order-7001").length).toBe(1);
+  expect(screen.getByTestId("riesit-order-count-7001").textContent).toBe("2 položky");
+
+  // Rozrolovanie ukáže OBA položkové riadky.
+  fireEvent.click(screen.getByTestId("riesit-order-toggle-7001"));
   expect(await screen.findByTestId(`order-line-${LINE_RIESIT.lineId}`)).toBeTruthy();
-  // aktívne je tlačidlo „Riešiť" (radio) tohto riadku
-  const riesitBtn = screen.getByTestId(`state-btn-riesit-${LINE_RIESIT.lineId}`);
-  expect(riesitBtn.getAttribute("aria-checked")).toBe("true");
+  expect(screen.getByTestId(`order-line-${LINE_RIESIT_2.lineId}`)).toBeTruthy();
 });
 
 it("rýchle pole: číslo objednávky → označí a refetchne + refreshne odznak", async () => {
@@ -94,7 +129,6 @@ it("rýchle pole: číslo objednávky → označí a refetchne + refreshne odzna
   await waitFor(() => {
     expect(setOrderLinesRiesitByCode).toHaveBeenCalledWith("7001");
   });
-  // úspech → hláška, refetch zoznamu, refresh odznaku
   expect((await screen.findByTestId("riesit-quick-add-message")).textContent).toContain("7001");
   expect(fetchRiesitOrders).toHaveBeenCalled();
   expect(refresh).toHaveBeenCalled();
@@ -114,18 +148,20 @@ it("rýchle pole: neznáme číslo zobrazí serverovú chybu", async () => {
   expect(err.textContent).toContain("nenašla");
 });
 
-it("zmena stavu na iný → riadok zo sekcie zmizne (keepOnlyState)", async () => {
+it("vypnutie stavu Riešiť poslednej položky objednávku zo zoznamu zloží", async () => {
   fetchRiesitOrders.mockResolvedValue([GROUP]);
   updateOrderLineState.mockResolvedValue(undefined);
   const refresh = vi.fn();
   renderRiesit(refresh);
-  await screen.findByTestId(`order-line-${LINE_RIESIT.lineId}`);
 
-  // klik na „Skladom" — riadok opustí stav riesit, teda z tejto sekcie zmizne
-  fireEvent.click(screen.getByTestId(`state-btn-skladom-${LINE_RIESIT.lineId}`));
+  // Rozroluj objednávku a prepni jej jediný riadok na „Skladom".
+  fireEvent.click(await screen.findByTestId("riesit-order-toggle-7001"));
+  fireEvent.click(await screen.findByTestId(`state-btn-skladom-${LINE_RIESIT.lineId}`));
 
+  // Riadok opustil stav riesit → z boardu zmizne, a keďže bol POSLEDNÝ,
+  // celá objednávka z plochého zoznamu vypadne.
   await waitFor(() => {
-    expect(screen.queryByTestId(`order-line-${LINE_RIESIT.lineId}`)).toBeNull();
+    expect(screen.queryByTestId("riesit-order-7001")).toBeNull();
   });
   expect(updateOrderLineState).toHaveBeenCalledWith(LINE_RIESIT.lineId, "skladom");
   expect(refresh).toHaveBeenCalled();

--- a/apps/web/src/components/RiesitSection.tsx
+++ b/apps/web/src/components/RiesitSection.tsx
@@ -2,18 +2,25 @@ import { useContext, useState, type JSX } from "react";
 import type { Me } from "../api.js";
 import { fetchRiesitOrders, OrdersUnauthorizedError, setOrderLinesRiesitByCode } from "../ordersApi.js";
 import { RiesitBadgeRefreshContext } from "../riesitBadgeContext.js";
+import { groupRiesitLinesByOrder } from "../riesitOrders.js";
 import { useOrderLinesBoard } from "../useOrderLinesBoard.js";
 import { OrderWriteFailuresBanner } from "./OrderWriteFailuresBanner.js";
-import { SupplierOrderGroup } from "./SupplierOrderGroup.js";
+import { RiesitOrderRow } from "./RiesitOrderRow.js";
 
 // issue 450: šéfov kolega Štěpán (Discord 19.8.2026) — pôvodne placeholder.
 // issue 476 (Štěpán, Discord 23.8.2026): funkcia doplnená — sekcia „Riešiť"
-// zobrazuje riadky objednávok v stave `riesit` (piaty exkluzívny stav,
-// princíp `nedostupne`), KOMPLETNE rovnaké ako „Na objednanie" (všetky funkcie
-// riadku + zoskupenie po dodávateľoch). Jadro (dáta + mutácie + pomocné hooky)
-// je ZDIEĽANÉ s OrdersSection cez `useOrderLinesBoard` — tu sa líši len zdroj
-// riadkov (`/api/orders/riesit`), odstránenie riadku po zmene stavu na iný
+// zobrazuje objednávky s riadkami v stave `riesit` (piaty exkluzívny stav,
+// princíp `nedostupne`). Jadro (dáta + mutácie + pomocné hooky) je ZDIEĽANÉ s
+// OrdersSection cez `useOrderLinesBoard` — líši sa len zdroj riadkov
+// (`/api/orders/riesit`), odstránenie riadku po zmene stavu na iný
 // (`keepOnlyState: "riesit"`) a rýchle pole na číslo objednávky.
+//
+// issue 484 (Štěpán, schválené komentárom 5394210094): sekcia sa ZJEDNODUŠILA —
+// už NEskupuje po dodávateľoch (jedna objednávka s 3 produktmi u 3 dodávateľov
+// zaberala celú stranu). Namiesto toho PLOCHÝ zoznam objednávok: 1 objednávka =
+// 1 kompaktný riadok (`RiesitOrderRow`) s rozrolovaním na plné položkové riadky.
+// `board.suppliers` (rovnaký zdroj) sa preskupí podľa `orderId`
+// (`groupRiesitLinesByOrder`) — žiadny nový API dopyt.
 //
 // VIDITEĽNÁ záložka (`nav.ts`, priečinok „eshop"), takže NEMÁ vlastný
 // `<h1>`/`<h2>` — titulok „Riešiť" renderuje `App.tsx` cez `Topbar`
@@ -84,7 +91,9 @@ export function RiesitSection({
       });
   };
 
-  const totalLines = board.suppliers.reduce((sum, group) => sum + group.lines.length, 0);
+  // issue 484: plochý zoznam objednávok odvodený z rovnakého `board.suppliers`
+  // (žiadny nový dopyt) — preskupené podľa `orderId`, najnovšia prvá.
+  const orders = groupRiesitLinesByOrder(board.suppliers);
 
   return (
     <section className="orders-section" data-testid="riesit-section">
@@ -139,61 +148,19 @@ export function RiesitSection({
           board.setWriteFailures([]);
         }}
       />
-      {board.loaded && totalLines === 0 && (
+      {board.loaded && orders.length === 0 && (
         <p className="empty" data-testid="riesit-empty">
-          Zatiaľ tu nie sú žiadne položky na riešenie. Označ riadok tlačidlom „Riešiť" v „Na objednanie",
+          Zatiaľ tu nie sú žiadne objednávky na riešenie. Označ riadok tlačidlom „Riešiť" v „Na objednanie",
           alebo zadaj číslo objednávky vyššie.
         </p>
       )}
-      {board.suppliers.map((group) => (
-        <SupplierOrderGroup
-          key={group.supplier}
-          group={group}
-          selectedSupplier={null}
-          // V sekcii Riešiť sa NEskrývajú „vybavené" riadky — `isLineResolved`
-          // by pri stave `riesit` (!== objednane) skryl VŠETKY riadky. Vždy
-          // `false`, aby bol každý riesit riadok vidno.
-          hideResolved={false}
-          dirtyEditorLineIds={board.dirtyEditorLineIds}
-          onEditorActivityChange={board.onEditorActivityChange}
-          supplierDrafts={board.supplierDrafts}
-          canChangeState={canChangeState}
-          busyLineId={board.busyLineId}
-          busyOrderedLineId={board.busyOrderedLineId}
-          busyOrderedSupplier={board.busyOrderedSupplier}
-          busySupplierLineId={board.busySupplierLineId}
-          busySupplierLinkLineId={board.busySupplierLinkLineId}
-          busyCommentOrderId={board.busyCommentOrderId}
-          // issue 480: predajňové riadky sú LEN v „Na objednanie" (server vracia
-          // pre „Riešiť" prázdne `floorRows`), tieto props sú tu de facto no-op,
-          // ale `SupplierOrderGroup` ich vyžaduje.
-          busyFloorRowKey={board.busyFloorRowKey}
-          onChangeState={board.changeState}
-          onChangeOrdered={board.changeOrdered}
-          onChangeFloorOrdered={board.changeFloorOrdered}
-          onAssignSupplier={board.assignSupplier}
-          onSetSupplierLink={board.setSupplierLink}
-          onChangeComment={board.changeComment}
-          editingEmailSupplier={board.email.editingEmailSupplier}
-          emailDraft={board.email.emailDraft}
-          emailBusy={board.email.emailBusy}
-          emailError={board.email.emailError}
-          onEmailDraftChange={board.email.onEmailDraftChange}
-          onStartEditEmail={board.email.onStartEditEmail}
-          onSaveEmail={board.email.onSaveEmail}
-          onCancelEditEmail={board.email.onCancelEditEmail}
-          onToggleGroupOrdered={board.toggleGroupOrdered}
-          onCopyOrderToClipboard={board.mail.copyOrderToClipboard}
-          previewSupplier={board.mail.previewSupplier}
-          preview={board.mail.preview}
-          previewError={board.mail.previewError}
-          sendBusy={board.mail.sendBusy}
-          sendResult={board.mail.sendResult}
-          onOpenPreview={board.mail.openPreview}
-          onClosePreview={board.mail.closePreview}
-          onConfirmSend={board.mail.confirmSend}
-        />
-      ))}
+      {orders.length > 0 && (
+        <div className="riesit-orders" data-testid="riesit-orders">
+          {orders.map((order) => (
+            <RiesitOrderRow key={order.orderId} order={order} canChangeState={canChangeState} board={board} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -3,6 +3,7 @@ import { computeVariantTotals, isFloorRowHidden, isLineHiddenByFilter } from "..
 import type { SupplierDraftsApi } from "../useSupplierDrafts.js";
 import { FloorOrderRow } from "./FloorOrderRow.js";
 import { OrderLineRow } from "./OrderLineRow.js";
+import { OrderLinesTableHead } from "./OrderLinesTableHead.js";
 import { SupplierActionsPanel } from "./SupplierActionsPanel.js";
 import type { OrderLine, OrderMailPreview, SupplierOpenOrders } from "../ordersApi.js";
 
@@ -164,45 +165,9 @@ export function SupplierOrderGroup({
           komentár), presne kam majiteľ žiadal. */}
       <div className="orders-table-wrap">
         <table className="orders-table">
-          <colgroup>
-            <col className="col-ordered" />
-            <col className="col-order" />
-            <col className="col-customer" />
-            <col className="col-product" />
-            <col className="col-qty" />
-            <col className="col-supplier" />
-            <col className="col-state" />
-            <col className="col-date" />
-            <col className="col-notes" />
-          </colgroup>
-          <thead>
-            <tr>
-              {/* issue 105 bod 1: pri 1280px (tabuľkin skutočný floor —
-                  `min-width: 64rem`) sa jednoslovné VEĽKÉ hlavičky
-                  ("OBJEDNANÉ"/"OBJEDNÁVKA"/"MNOŽSTVO"/"OBJEDNÁVKY") nezmestili
-                  do svojich úzkych stĺpcov a pretekali do suseda (zmerané
-                  `th.scrollWidth`). Namiesto širších percent (väčší diff,
-                  riziko pre PRODUKT/DODÁVATEĽ) sú 4 popisky skrátené — plný
-                  význam nesie `title`. Checkbox stĺpec: JEDINÉ miesto na
-                  obrazovke, ktoré sa smie týkať "objednané u dodávateľa" (viď
-                  `STATE_LABELS`/dátumový stĺpec nižšie, aby sa nekolidovalo). */}
-              <th title="Objednané u dodávateľa (zaškrtávacie políčko)" aria-label="Objednané u dodávateľa">
-                ✓
-              </th>
-              <th title="Číslo objednávky (klik na kód v riadku otvorí objednávku v administrácii Shoptet)">
-                Č. obj.
-              </th>
-              <th>Zákazník</th>
-              <th>Produkt</th>
-              <th title="Množstvo (počet kusov)">Ks</th>
-              <th title="Dodávateľ z katalógu, alebo ručné priradenie pri produkte bez katalógového dodávateľa">
-                Dodávateľ
-              </th>
-              <th>Stav</th>
-              <th title="Dátum objednávky">Dátum obj.</th>
-              <th title="Poznámka zákazníka z e-shopu (na čítanie) + vlastná poznámka tímu">Poznámky</th>
-            </tr>
-          </thead>
+          {/* issue 484: colgroup(9)+thead vyčlenené do `OrderLinesTableHead`
+              (zdieľané s rozrolovaním sekcie „Riešiť") — DOM bajt-identický. */}
+          <OrderLinesTableHead />
           <tbody>
             {visibleLines.map((line) => (
               <OrderLineRow

--- a/apps/web/src/ordersSummary.test.ts
+++ b/apps/web/src/ordersSummary.test.ts
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import {
   computeVariantTotals,
   countAffectedOrders,
+  formatItemCount,
   formatOrderCount,
   formatOrderSummaryText,
   formatVariantTotalChip,
@@ -328,6 +329,17 @@ it("formatOrderCount — 0, 5+ (vrátane 22/23/24) sú rodový pád množného �
   expect(formatOrderCount(22)).toBe("22 objednávok");
   expect(formatOrderCount(23)).toBe("23 objednávok");
   expect(formatOrderCount(24)).toBe("24 objednávok");
+});
+
+// issue 484 — počet položiek na kompaktnom riadku sekcie „Riešiť", rovnaký
+// slovenský 3-tvarový paucal ako `formatOrderCount`.
+it("formatItemCount — 1 / 2-4 / 0,5+ (paucal položka)", () => {
+  expect(formatItemCount(1)).toBe("1 položka");
+  expect(formatItemCount(2)).toBe("2 položky");
+  expect(formatItemCount(4)).toBe("4 položky");
+  expect(formatItemCount(0)).toBe("0 položiek");
+  expect(formatItemCount(5)).toBe("5 položiek");
+  expect(formatItemCount(23)).toBe("23 položiek");
 });
 
 // issue 452 — dodávateľské čipy zoradené abecedne (slovenské locale,

--- a/apps/web/src/ordersSummary.ts
+++ b/apps/web/src/ordersSummary.ts
@@ -263,3 +263,13 @@ export function formatOrderCount(n: number): string {
   if (n === 2 || n === 3 || n === 4) return `${String(n)} objednávky`;
   return `${String(n)} objednávok`;
 }
+
+// issue 484: počet POLOŽIEK objednávky v stave riesit na kompaktnom riadku
+// sekcie „Riešiť" (napr. „3 položky"). Rovnaký slovenský 3-tvarový paucal ako
+// `formatOrderCount` vyššie (1 → jednotné, 2-4 → málopočetné, 0/5+ → rodový
+// pád množného čísla; tvar sa NEODVODZUJE z poslednej číslice).
+export function formatItemCount(n: number): string {
+  if (n === 1) return "1 položka";
+  if (n === 2 || n === 3 || n === 4) return `${String(n)} položky`;
+  return `${String(n)} položiek`;
+}

--- a/apps/web/src/riesitOrders.test.ts
+++ b/apps/web/src/riesitOrders.test.ts
@@ -1,0 +1,65 @@
+import { expect, it } from "vitest";
+import type { OrderLine, SupplierOpenOrders } from "./ordersApi.js";
+import { groupRiesitLinesByOrder } from "./riesitOrders.js";
+
+// issue 484: `groupRiesitLinesByOrder` preskupí `board.suppliers[].lines[]`
+// (naprieč dodávateľmi) do plochého zoznamu OBJEDNÁVOK, najnovšia prvá.
+
+function line(over: Partial<OrderLine> & Pick<OrderLine, "lineId" | "orderId" | "externalOrderId" | "placedAt">): OrderLine {
+  return {
+    customerName: "Zákazník",
+    comment: null,
+    remark: null,
+    shopRemark: null,
+    adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=x&src=orders",
+    variantCode: "R-1",
+    variantName: "Produkt",
+    sizeLabel: null,
+    ourUrl: null,
+    quantity: 1,
+    state: "riesit",
+    ordered: false,
+    supplierUrl: null,
+    supplierNote: null,
+    externalCode: null,
+    supplierAssignable: false,
+    manualSupplierOverride: null,
+    customerOpenOrderCount: 1,
+    ...over,
+  };
+}
+
+const group = (supplier: string, lines: OrderLine[]): SupplierOpenOrders => ({ supplier, lines, email: null });
+
+it("prázdny vstup → prázdny zoznam", () => {
+  expect(groupRiesitLinesByOrder([])).toEqual([]);
+});
+
+it("riadky JEDNEJ objednávky u VIACERÝCH dodávateľov sa preskupia do jednej objednávky", () => {
+  const a1 = line({ lineId: "l1", orderId: "o1", externalOrderId: "20261172", placedAt: "2026-08-01T00:00:00.000Z", customerName: "Novák", comment: "poznámka", variantCode: "A" });
+  const a2 = line({ lineId: "l2", orderId: "o1", externalOrderId: "20261172", placedAt: "2026-08-01T00:00:00.000Z", customerName: "Novák", comment: "poznámka", variantCode: "B" });
+  const a3 = line({ lineId: "l3", orderId: "o1", externalOrderId: "20261172", placedAt: "2026-08-01T00:00:00.000Z", customerName: "Novák", comment: "poznámka", variantCode: "C" });
+
+  const orders = groupRiesitLinesByOrder([group("D1", [a1]), group("D2", [a2]), group("D3", [a3])]);
+
+  expect(orders.length).toBe(1);
+  const o = orders[0];
+  expect(o?.orderId).toBe("o1");
+  expect(o?.externalOrderId).toBe("20261172");
+  expect(o?.customerName).toBe("Novák");
+  expect(o?.comment).toBe("poznámka");
+  // Všetky 3 riadky (naprieč dodávateľmi) pod jednou objednávkou.
+  expect(o?.lines.map((l) => l.lineId)).toEqual(["l1", "l2", "l3"]);
+});
+
+it("viac objednávok → najnovšia (placedAt desc) prvá, pri zhode podľa čísla", () => {
+  const older = line({ lineId: "l1", orderId: "o1", externalOrderId: "7001", placedAt: "2026-08-01T00:00:00.000Z" });
+  const newer = line({ lineId: "l2", orderId: "o2", externalOrderId: "7002", placedAt: "2026-08-05T00:00:00.000Z" });
+  const sameDayA = line({ lineId: "l3", orderId: "o3", externalOrderId: "7009", placedAt: "2026-08-05T00:00:00.000Z" });
+
+  const orders = groupRiesitLinesByOrder([group("D", [older, newer, sameDayA])]);
+
+  // najnovšie prvé; o2 aj o3 majú rovnaký placedAt → deterministicky podľa
+  // externalOrderId (7002 < 7009), o1 (starší) naposledy.
+  expect(orders.map((o) => o.orderId)).toEqual(["o2", "o3", "o1"]);
+});

--- a/apps/web/src/riesitOrders.ts
+++ b/apps/web/src/riesitOrders.ts
@@ -1,0 +1,64 @@
+import type { OrderLine, SupplierOpenOrders } from "./ordersApi.js";
+
+// issue 484 (Štěpán, schválené komentárom 5394210094): sekcia „Riešiť" už
+// NEskupuje po dodávateľoch — je to plochý zoznam OBJEDNÁVOK (1 objednávka =
+// 1 kompaktný riadok s rozrolovaním). Táto čistá funkcia preskupí riadky, ktoré
+// `useOrderLinesBoard` už načítal (`board.suppliers[].lines[]`), podľa `orderId`
+// — žiadny nový API dopyt, len iná prezentácia toho istého zdroja (tiket:
+// „NEduplikuj query logiku — agreguj nad existujúcim zdrojom").
+//
+// Jedna objednávka jedného zákazníka môže mať riadky u VIACERÝCH dodávateľov
+// (Štěpánov príklad: 20261172 = 3 produkty u 3 dodávateľov), preto sa musí
+// ploštiť NAPRIEČ všetkými skupinami, nie len v rámci jednej.
+export interface RiesitOrder {
+  readonly orderId: string;
+  readonly externalOrderId: string;
+  readonly customerName: string;
+  // Poznámka k OBJEDNÁVKE (appkin/manažérov `order.comment`, zdieľaný naprieč
+  // riadkami tej istej objednávky) — zobrazuje sa na kompaktnom riadku.
+  readonly comment: string | null;
+  readonly placedAt: string;
+  // Preklik čísla objednávky — rovnaký cieľ (Shoptet admin) ako v „Na
+  // objednanie" (`OrderLineRow`'s `line.adminUrl`).
+  readonly adminUrl: string;
+  // Všetky riadky objednávky v stave riesit (rozrolovanie ukáže tieto).
+  readonly lines: readonly OrderLine[];
+}
+
+export function groupRiesitLinesByOrder(suppliers: readonly SupplierOpenOrders[]): readonly RiesitOrder[] {
+  // `first` = prvý videný riadok objednávky; jej order-level polia
+  // (`externalOrderId`/`customerName`/`comment`/`placedAt`/`adminUrl`) sú
+  // IDENTICKÉ na každom riadku tej istej objednávky (pochádzajú z `order`
+  // riadku), takže stačí zobrať prvý.
+  const byOrder = new Map<string, { readonly first: OrderLine; readonly lines: OrderLine[] }>();
+  for (const group of suppliers) {
+    for (const line of group.lines) {
+      const existing = byOrder.get(line.orderId);
+      if (existing === undefined) {
+        byOrder.set(line.orderId, { first: line, lines: [line] });
+      } else {
+        existing.lines.push(line);
+      }
+    }
+  }
+
+  const orders = [...byOrder.values()].map(({ first, lines }): RiesitOrder => ({
+    orderId: first.orderId,
+    externalOrderId: first.externalOrderId,
+    customerName: first.customerName,
+    comment: first.comment,
+    placedAt: first.placedAt,
+    adminUrl: first.adminUrl,
+    lines,
+  }));
+
+  // Najnovšia objednávka prvá (rovnaké poradie ako `queries.ts`'s zoskupovacie
+  // triedenie skupín); `placedAt` je ISO 8601, takže reťazcové porovnanie
+  // zodpovedá chronologickému poradiu bez parsovania. Pri zhode `placedAt`
+  // deterministicky podľa čísla objednávky.
+  orders.sort((a, b) => {
+    if (a.placedAt !== b.placedAt) return a.placedAt > b.placedAt ? -1 : 1;
+    return a.externalOrderId < b.externalOrderId ? -1 : a.externalOrderId > b.externalOrderId ? 1 : 0;
+  });
+  return orders;
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1400,6 +1400,59 @@ tr:last-child td {
   min-width: 8rem;
   max-width: 100%;
 }
+/* issue 484: plochý zoznam objednávok v sekcii „Riešiť" — 1 objednávka =
+   1 kompaktný riadok (šípka · číslo · zákazník · počet · dátum · poznámka),
+   šípka rozroluje plnú `.orders-table`. */
+.riesit-orders {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fs-space-2);
+}
+.riesit-order {
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius);
+  background: var(--fs-surface);
+}
+.riesit-order-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--fs-space-2) var(--fs-space-3);
+  padding: var(--fs-space-2) var(--fs-space-3);
+}
+/* Šípka ▾/▸ — malé tlačidlo, nikdy sa nezmenší. */
+.riesit-order-toggle {
+  flex: 0 0 auto;
+}
+/* Číslo objednávky (preklik) — nikdy nezalomiť. */
+.riesit-order-code {
+  flex: 0 0 auto;
+  font-weight: 600;
+}
+/* Meno zákazníka zaberie zvyšné miesto, orezané na jednom riadku. */
+.riesit-order-customer {
+  flex: 1 1 8rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.riesit-order-count,
+.riesit-order-date {
+  flex: 0 0 auto;
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
+/* Poznámka k objednávke — na vlastnom riadku pod hlavičkou, orezaná. */
+.riesit-order-note {
+  flex: 1 1 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fs-ink-muted);
+  font-size: var(--fs-text-sm);
+}
 /* issue 95: DODÁVATEĽ + PRIRADENIE DODÁVATEĽA zlúčené do jednej bunky
    (majiteľ, komentár #1: "neviem čo tam je Priradenie dodávateľa stĺpec" —
    je vidieť len pri riadkoch bez katalógového dodávateľa, `supplierAssignable`

--- a/apps/web/tests/e2e/riesit.spec.ts
+++ b/apps/web/tests/e2e/riesit.spec.ts
@@ -3,8 +3,10 @@ import { expect, test } from "@playwright/test";
 const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
 const E2E_RIESIT_EMAIL = "e2e-riesit@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
 
-// issue 476: sekcia „Riešiť" — klik-flow (riadok v stave riesit sa zobrazí,
-// zmena stavu ho odstráni), menu odznak, rýchle pole a nulová konzola.
+// issue 476/484: sekcia „Riešiť" — klik-flow. Issue 484: PLOCHÝ zoznam
+// objednávok (1 objednávka = 1 kompaktný riadok s rozrolovaním), preklik čísla,
+// vypnutie stavu Riešiť poslednej položky objednávku zloží; menu odznak, rýchle
+// pole a nulová konzola.
 //
 // Prečo prepichnutý `window.fetch` (`addInitScript`), nie reálne seedované
 // dáta: `orders.spec.ts`'s prvý test asertuje PRESNÉ GLOBÁLNE počty otvorených
@@ -19,7 +21,7 @@ const E2E_RIESIT_EMAIL = "e2e-riesit@forestshop.sk"; // musí sa zhodovať s hod
 // komponent+hook `apps/web/src/components/RiesitSection.test.tsx`.
 const FAKE_LINE_ID = "e2e00000-0000-0000-0000-000000000476";
 
-test("Riešiť: riadok sa zobrazí, zmena stavu ho odstráni, odznak svieti, rýchle pole hlási neznáme číslo, konzola je čistá", async ({
+test("Riešiť: kompaktný riadok objednávky → rozrolovanie → vypnutie Riešiť objednávku zloží, odznak svieti, rýchle pole hlási neznáme číslo, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -92,8 +94,23 @@ test("Riešiť: riadok sa zobrazí, zmena stavu ho odstráni, odznak svieti, rý
   // Titulok „Riešiť" renderuje Topbar (viditeľná záložka, `.claude/rules/frontend-design.md`).
   await expect(page.getByRole("heading", { name: "Riešiť" })).toBeVisible();
 
-  // Riadok v stave riesit sa zobrazí, jeho tlačidlo „Riešiť" je aktívne.
+  // issue 484: 1 objednávka = 1 kompaktný riadok (meno zákazníka + počet
+  // položiek); položkové riadky sú ZBALENÉ, kým sa nerozrolujú.
+  const objednavka = page.getByTestId("riesit-order-7001");
+  await expect(objednavka).toBeVisible();
+  await expect(objednavka).toContainText("Zákazník Riešiť");
+  await expect(page.getByTestId("riesit-order-count-7001")).toHaveText("1 položka");
   const riadok = page.getByTestId(`order-line-${FAKE_LINE_ID}`);
+  await expect(riadok).toHaveCount(0);
+
+  // Číslo objednávky je preklik do Shoptet admin (rovnaký cieľ ako v „Na objednanie").
+  await expect(objednavka.getByRole("link", { name: /Otvoriť objednávku 7001/ })).toHaveAttribute(
+    "href",
+    "https://www.forestshop.sk/admin/vyhladavanie/?string=7001&src=orders",
+  );
+
+  // Rozrolovanie → plný položkový riadok + aktívne tlačidlo „Riešiť".
+  await page.getByTestId("riesit-order-toggle-7001").click();
   await expect(riadok).toBeVisible();
   await expect(page.getByTestId(`state-btn-riesit-${FAKE_LINE_ID}`)).toHaveAttribute("aria-checked", "true");
 
@@ -104,9 +121,9 @@ test("Riešiť: riadok sa zobrazí, zmena stavu ho odstráni, odznak svieti, rý
   // Rýchle pole je viditeľné.
   await expect(page.getByTestId("riesit-quick-add-input")).toBeVisible();
 
-  // Zmena stavu na iný → riadok zo sekcie zmizne (optimistické odstránenie).
+  // Vypnutie stavu Riešiť POSLEDNEJ položky → objednávka z plochého zoznamu vypadne.
   await page.getByTestId(`state-btn-skladom-${FAKE_LINE_ID}`).click();
-  await expect(riadok).toHaveCount(0);
+  await expect(objednavka).toHaveCount(0);
 
   // Rýchle pole: neznáme číslo → zrozumiteľná chyba.
   await page.getByTestId("riesit-quick-add-input").fill("9999");

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4375,3 +4375,26 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   overení). Post-deploy naživo overené: floor riadok reálneho zápisu „Galik
   Matúš" (ODIMON, 60285) sa renderuje v „Na objednanie"; write-path (create→pin→
   ordered→🛒→delete) cez throwaway zápis OK, konzola čistá.
+- Finalizácia: PR #483 (merge `8d8d814`) = playbook bump `.283` + tento
+  autopilot-log + testing/floor-notes learnings; nasadené `v0.3.0-dev.283` na
+  main (tela PR = plain „issue 480"). Issue 480 ostáva OTVORENÝ na ručné
+  zatvorenie.
+
+## 2026-08-24 — issue 484 (Riešiť — zjednodušiť: 1 riadok na objednávku s rozrolovaním, Štěpán)
+- **#484 (klientom schválené, komentár 5394210094):** sekcia „Riešiť" prešla zo
+  skupín po dodávateľoch na PLOCHÝ zoznam objednávok. 1 objednávka = 1 kompaktný
+  riadok (šípka ▾ na rozrolovanie · číslo objednávky preklik na Shoptet admin ·
+  meno zákazníka · počet položiek v stave riesit · dátum · poznámka). Rozrolovanie
+  ukáže PLNÉ položkové riadky ako v „Na objednanie" (znovupoužitý `OrderLineRow`
+  vrátane vypnutia stavu Riešiť; vypnutie poslednej položky objednávku zo zoznamu
+  zloží). Rýchle pole „pridať podľa čísla objednávky" bezo zmeny.
+- **Agregácia NAD existujúcim zdrojom (žiadny nový dopyt):** `groupRiesitLinesByOrder`
+  (`riesitOrders.ts`) preskupí `board.suppliers[].lines[]` (naprieč dodávateľmi)
+  podľa `orderId`; `useOrderLinesBoard` (dáta+mutácie) sa nemení. Nav odznak `riesit`
+  po novom počíta DISTINCT objednávky — `countOpenOrdersByState` (`countDistinct`)
+  nahradila `countOpenOrderLinesByState` na trase `GET /api/orders/riesit/count`.
+- **Nové/zmenené:** `queries.ts` (rename+distinct), `orders-routes.ts`; web
+  `riesitOrders.ts` (nový agregátor), `ordersSummary.ts` (+`formatItemCount` paucal),
+  `OrderLinesTableHead.tsx` (nový, colgroup+thead, zdieľaný so `SupplierOrderGroup`),
+  `RiesitOrderRow.tsx` (nový), `RiesitSection.tsx` (plochý zoznam), `app.css`.
+- Commity/PR/nasadenie: dopĺňa sa po merge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.283",
+  "version": "0.3.0-dev.284",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## issue 484 — Sekcia Riešiť: zjednodušiť na 1 riadok na objednávku s rozrolovaním (Štěpán)

Klientom schválené (komentár 5394210094, GO od Štěpána). Sekcia „Riešiť" prešla zo skupín po dodávateľoch na **plochý zoznam objednávok**.

**Čo sa mení**
- 1 problémová objednávka = 1 kompaktný riadok: šípka ▾ (rozrolovanie) · číslo objednávky (preklik do Shoptet admin, rovnaký cieľ ako v „Na objednanie") · meno zákazníka · počet položiek v stave riesit (paucal „N položiek") · dátum · poznámka k objednávke.
- Rozrolovanie ukáže **plné položkové riadky presne ako v „Na objednanie"** (znovupoužitý `OrderLineRow` so všetkými funkciami vrátane vypnutia stavu Riešiť). Vypnutie Riešiť poslednej položky objednávku zo zoznamu zloží.
- Nav odznak `riesit` po novom počíta **DISTINCT objednávky**, nie riadky (`countOpenOrdersByState` cez `countDistinct`).
- Rýchle pole „pridať podľa čísla objednávky" ostáva bezo zmeny.

**Ako (bez novej query logiky)**
- `groupRiesitLinesByOrder` preskupí `board.suppliers[].lines[]` (naprieč dodávateľmi) podľa `orderId` — `useOrderLinesBoard` sa nemení, žiadny nový API dopyt.
- `colgroup`+`thead` tabuľky riadkov vyčlenené do `OrderLinesTableHead` (zdieľané so `SupplierOrderGroup`, DOM bajt-identický) — jeden zdroj pravdy pre 9-stĺpcovú schému.

**Testy**
- API integračný: `riesit/count` = DISTINCT objednávky (viac riadkov jednej objednávky = 1).
- Unit: `groupRiesitLinesByOrder` (multi-dodávateľ → 1 objednávka, poradie), `formatItemCount` (paucal), `RiesitSection` (kompaktný riadok → expand → vypnutie Riešiť zloží).
- E2E: `riesit.spec` — kompaktný riadok, preklik čísla, rozrolovanie, odznak `/^\d+$/`, rýchle pole, nulová konzola.

`pnpm gates:local` zelené (typecheck + lint + 741 unit testov).

Odkaz na tiket: issue 484. Ticket ostáva OTVORENÝ — zavrie sa RUČNE po naživo overení (bez zatváracieho kľúčového slova v tomto tele/commitoch).
