### PR TITLE
docs(playbook): sekcia Riešiť nová podoba + finalizácia autopilot-log (issue 484)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -756,10 +756,27 @@ paths:
   no-op default). RiesitSection posiela `keepOnlyState:"riesit"` (riadok pri
   zmene stavu na iný sa lokálne odstráni) + vlastné rýchle pole. **Backend:**
   `listOpenOrderLinesBySupplier(db, adminBaseUrl, { stateFilter })` (NEduplikuje
-  query), `countOpenOrderLinesByState`, `setOrderLinesStateByCode` (bulk podľa
+  query), `countOpenOrdersByState` (issue 484: pôvodne `countOpenOrderLinesByState`),
+  `setOrderLinesStateByCode` (bulk podľa
   `externalOrderId`); trasy `GET /api/orders/riesit(/count)`, `POST /riesit/
   by-code` — VŠETKY PRED `GET /api/orders/:id` (literal-pred-`:param`).
   `by-code` vracia 200 `{ok:false,error}` pri neznámom/zatvorenom čísle (NIE 4xx
   — konzola, `.claude/rules/testing.md`). Menu odznak `riesit` vzor issue 473.
   KAŽDÁ ďalšia „obrazovka nad podmnožinou otvorených objednávok" nech použije
   `useOrderLinesBoard` + `stateFilter`, nie novú kópiu.
+- **Sekcia „Riešiť" ZJEDNODUŠENÁ (issue 484, Štěpán): NEskupuje po dodávateľoch —
+  je to PLOCHÝ zoznam OBJEDNÁVOK.** `RiesitSection` už NErenderuje
+  `board.suppliers.map(SupplierOrderGroup)`; namiesto toho `groupRiesitLinesByOrder`
+  (`apps/web/src/riesitOrders.ts`) preskupí `board.suppliers[].lines[]` (NAPRIEČ
+  dodávateľmi — jedna objednávka môže mať riadky u viacerých) podľa `orderId` do
+  plochého zoznamu, najnovšia prvá. 1 objednávka = 1 kompaktný `RiesitOrderRow`
+  (šípka ▾ · číslo objednávky preklik na `adminUrl` · zákazník · `formatItemCount`
+  „N položiek" · dátum · poznámka); rozrolovanie ukáže PLNÉ položkové riadky
+  (znovupoužitý `OrderLineRow`, `supplierBusy={false}`, `variantTotal` per-objednávka).
+  Vypnutie stavu Riešiť POSLEDNEJ položky objednávku z odvodeného zoznamu zloží
+  (`keepOnlyState:"riesit"` odstráni riadok z boardu → `groupRiesitLinesByOrder`
+  ju už nevytvorí). **Nav odznak `riesit` počíta DISTINCT OBJEDNÁVKY** (nie riadky):
+  `countOpenOrdersByState` = `countDistinct(order_line.order_id)` (drizzle `countDistinct`).
+  `colgroup`+`thead` 9-stĺpcovej tabuľky sú vyčlenené do `OrderLinesTableHead`
+  (jeden zdroj pravdy, zdieľaný `SupplierOrderGroup` AJ rozrolovaním Riešiť — DOM
+  bajt-identický, „Na objednanie" testy nezmenené). Rýchle pole `by-code` bezo zmeny.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4397,4 +4397,20 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   `riesitOrders.ts` (nový agregátor), `ordersSummary.ts` (+`formatItemCount` paucal),
   `OrderLinesTableHead.tsx` (nový, colgroup+thead, zdieľaný so `SupplierOrderGroup`),
   `RiesitOrderRow.tsx` (nový), `RiesitSection.tsx` (plochý zoznam), `app.css`.
-- Commity/PR/nasadenie: dopĺňa sa po merge.
+- Testy: API integ `riesit-http` (count = DISTINCT objednávky), unit
+  `riesitOrders`/`formatItemCount`/`RiesitSection` (kompaktný riadok → expand →
+  vypnutie Riešiť zloží), e2e `riesit.spec` (nulová konzola). `pnpm gates:local`
+  zelené (741 web unit).
+- Commity: `7815054` (bump .284 + log), `a051d61` (feat). PR #485 (merge
+  `72638cc`). Nasadené `v0.3.0-dev.284` na main (telo PR + commity = plain
+  „issue 484", žiadny Closes — ticket ostáva OTVORENÝ na ručné zatvorenie po
+  potvrdení klientom Štěpánom). Post-deploy naživo overené na
+  forestshop.newlevel.media: `/api/version`=0.3.0-dev.284, DOM `v0.3.0-dev.284`,
+  odznak „Riešiť: 2" (DISTINCT objednávky — 2 objednávky, nie 4 riadky),
+  kompaktné riadky (20261249 Jan Mészáros „1 položka"; 20261172 Zuzana Kereštan
+  „3 položky" = Štěpánov príklad, teraz 1 riadok namiesto 3 skupín), rozrolovanie
+  → 9-stĺpcová tabuľka s 3 plnými riadkami, preklik čísla → Shoptet admin, rýchle
+  pole neznáme číslo → 200 + „nenašla", konzola 0 chýb.
+- Playbook: `.claude/rules/orders.md` — sekcia „Riešiť" ZJEDNODUŠENÁ (plochý
+  zoznam objednávok, `groupRiesitLinesByOrder`, `countOpenOrdersByState` distinct,
+  `OrderLinesTableHead` zdieľaný). Doplnené v tomto docs follow-upe.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.284",
+  "version": "0.3.0-dev.285",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only follow-up k issue 484 (feature PR #485 už zmergnutý, v0.3.0-dev.284 nasadené + naživo overené).

- `.claude/rules/orders.md`: sekcia „Riešiť" ZJEDNODUŠENÁ — plochý zoznam objednávok (`groupRiesitLinesByOrder`), nav odznak počíta DISTINCT objednávky (`countOpenOrdersByState`/`countDistinct`), `OrderLinesTableHead` zdieľaný colgroup+thead. Opravená stará referencia `countOpenOrderLinesByState`.
- `docs/autopilot-log.md`: finalizácia záznamu issue 484 (commity, PR #485, merge 72638cc, naživo overenie).
- bump 0.3.0-dev.285.

Bez funkčnej zmeny appky. Ticket ostáva OTVORENÝ — zavrie sa RUČNE po potvrdení klientom (bez zatváracieho kľúčového slova).
