### PR TITLE
Zdieľané úlohy na dnes (issue 487) + monitor bez forestshop-novy (issue 488)

### DIFF
--- a/apps/api/src/db/schema-daily-tasks.ts
+++ b/apps/api/src/db/schema-daily-tasks.ts
@@ -1,15 +1,16 @@
 import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { users } from "./schema-users.js";
 
-// issue 342: "Úlohy na dnes" — nahrádza šéfove poznámky písané do Discord
-// kanála #úlohy-na-dnes. ÚPLNE osobný zoznam, viazaný na `user_id` — každý
-// prihlásený používateľ vidí a upravuje LEN svoje vlastné riadky, server to
-// vynucuje na každom endpointe (`modules/daily-tasks/service.ts`), nikdy len
-// frontend. Zámerne SAMOSTATNÁ tabuľka, nie nová `upozornenie.type` hodnota —
-// plné odôvodnenie na tickete (design komentár pred prvým commitom kódu):
-// Upozornenia sú zdieľaná firemná queue s postpone/resolve/dedupKey
-// sémantikou a odznakom pre VŠETKÝCH zamestnancov, tento zoznam je súkromný
-// poznámkový blok bez toho všetkého.
+// issue 342 + 487: "Úlohy na dnes" — nahrádza šéfove poznámky písané do Discord
+// kanála #úlohy-na-dnes. PÔVODNE súkromný per-`user_id` zoznam (#342); od #487
+// ZDIEĽANÝ — každý prihlásený účet vidí a smie odfajknúť/upraviť/zmazať VŠETKY
+// úlohy (presne ako `note`/Poznámky, #437). `user_id` stĺpec OSTÁVA, ale už NIE
+// ako filter viditeľnosti — je to AUTOR (zapisuje sa zo session pri create,
+// `service.ts`, a zobrazuje sa pri riadku). Server vlastníctvo pri čítaní/zápise
+// ZÁMERNE nevynucuje (`modules/daily-tasks/queries.ts`/`service.ts`). Zámerne
+// SAMOSTATNÁ tabuľka, nie nová `upozornenie.type` hodnota — plné odôvodnenie na
+// tickete: Upozornenia sú firemná queue s postpone/resolve/dedupKey sémantikou a
+// odznakom, tento zoznam je minimalistická zdieľaná nástenka bez toho všetkého.
 export const dailyTask = pgTable(
   "daily_task",
   {
@@ -32,9 +33,12 @@ export const dailyTask = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
-    // Zoznam sa vždy číta zoradený "najnovšie hore" A vždy filtrovaný na
-    // JEDNÉHO používateľa naraz (`.claude/rules/database.md` — index podľa
-    // toho, ako sa dáta SKUTOČNE čítajú).
+    // Index z pôvodnej per-user sémantiky (#342). Od #487 sa zoznam číta
+    // ZDIEĽANE (zoradený "najnovšie hore", bez `user_id` filtra), takže tento
+    // zložený `(user_id, created_at)` index už nie je pre čítanie optimálny —
+    // PONECHÁVA SA ZÁMERNE bez zmeny (#487 nerobí ŽIADNU migráciu; pri 22
+    // riadkoch je rozdiel nepodstatný). Prípadné pretypovanie indexu na samotný
+    // `created_at` je vec budúcej migrácie, nie tejto zmeny správania.
     index("daily_task_user_id_created_at_idx").on(t.userId, t.createdAt),
   ],
 );

--- a/apps/api/src/http/daily-tasks-routes.ts
+++ b/apps/api/src/http/daily-tasks-routes.ts
@@ -7,12 +7,13 @@ import { countOpenDailyTasks, listDailyTasks } from "../modules/daily-tasks/quer
 import { requireSameOrigin } from "./origin-check.js";
 import { requireUser, type AppBindings } from "./middleware.js";
 
-// issue 342: "Úlohy na dnes" — súkromný zoznam, viazaný na prihláseného
-// používateľa. Na rozdiel od zvyšku appky (zápis vyžaduje `requireRole
-// ("admin", "manazer")`) tu STAČÍ `requireUser` na KAŽDÚ akciu vrátane
-// zápisu — server aj tak vynucuje `userId` na každom dopyte, takže žiadna
-// rola nedostane prístup k CUDZÍM úlohám; obmedzenie roly by tu len bránilo
-// zamestnancovi s rolou "citanie" mať VLASTNÝ súkromný zoznam bez dôvodu.
+// issue 342 + 487: "Úlohy na dnes". Pôvodne súkromný per-používateľský zoznam
+// (#342); od #487 ZDIEĽANÝ — každý prihlásený účet vidí a smie odfajknúť/upraviť/
+// zmazať VŠETKY úlohy (presne ako Poznámky `note`, #437). Na KAŽDÚ akciu vrátane
+// zápisu STAČÍ `requireUser` (žiadny `requireRole`) — je to zdieľaný tímový
+// nástroj a aj rola "citanie" musí vedieť pridávať/spracúvať. Autor sa PRI
+// VYTVORENÍ ukladá zo session (`user.userId`) a zobrazuje sa pri riadku; ostatné
+// akcie vlastníctvo ZÁMERNE nevynucujú (server ho nekľúčuje, `service.ts`).
 const createBody = z.object({ text: z.string().trim().min(1).max(300) });
 const updateTextBody = z.object({ text: z.string().trim().min(1).max(300) });
 // Code review: 16 znakov by odmietlo legitímnu VIACPRVKOVÚ emoji sekvenciu
@@ -25,19 +26,17 @@ const idParam = z.object({ id: z.string().uuid() });
 
 export function registerDailyTasksRoutes(app: Hono<AppBindings>, db: Database): void {
   app.get("/api/daily-tasks", requireUser(db), async (c) => {
-    const user = c.get("user");
-    const rows = await listDailyTasks(db, user.userId);
+    const rows = await listDailyTasks(db);
     return c.json({ rows });
   });
 
-  // issue 473: odznak počtu v ľavom menu — počet MOJICH otvorených (bez fajky)
-  // úloh. Literal-path súrodenec MUSÍ byť pred `/:id` trasami rovnakej metódy
-  // (`.claude/rules/http-routes.md` — poradie literal-vs-`:param`); dnes žiadna
-  // GET `/:id` trasa neexistuje, ale poradie sa drží ako zvyk (rovnako ako
-  // `upozornenia-routes.ts`'s `/count`).
+  // issue 473 + 487: odznak počtu v ľavom menu — počet OTVORENÝCH (bez fajky)
+  // úloh VŠETKÝCH účtov (zdieľaný zoznam). Literal-path súrodenec MUSÍ byť pred
+  // `/:id` trasami rovnakej metódy (`.claude/rules/http-routes.md` — poradie
+  // literal-vs-`:param`); dnes žiadna GET `/:id` trasa neexistuje, ale poradie sa
+  // drží ako zvyk (rovnako ako `upozornenia-routes.ts`'s `/count`).
   app.get("/api/daily-tasks/count", requireUser(db), async (c) => {
-    const user = c.get("user");
-    const count = await countOpenDailyTasks(db, user.userId);
+    const count = await countOpenDailyTasks(db);
     return c.json({ count });
   });
 
@@ -51,31 +50,27 @@ export function registerDailyTasksRoutes(app: Hono<AppBindings>, db: Database): 
   app.patch("/api/daily-tasks/:id/text", requireSameOrigin(), requireUser(db), zValidator("param", idParam), zValidator("json", updateTextBody), async (c) => {
     const { id } = c.req.valid("param");
     const { text } = c.req.valid("json");
-    const user = c.get("user");
-    const updated = await updateDailyTaskText(db, { id, userId: user.userId, text, now: new Date() });
+    const updated = await updateDailyTaskText(db, { id, text, now: new Date() });
     return c.json({ ok: true as const, updated });
   });
 
   app.patch("/api/daily-tasks/:id/emoji", requireSameOrigin(), requireUser(db), zValidator("param", idParam), zValidator("json", updateEmojiBody), async (c) => {
     const { id } = c.req.valid("param");
     const { emoji } = c.req.valid("json");
-    const user = c.get("user");
-    const updated = await updateDailyTaskEmoji(db, { id, userId: user.userId, emoji: emoji === "" ? null : emoji, now: new Date() });
+    const updated = await updateDailyTaskEmoji(db, { id, emoji: emoji === "" ? null : emoji, now: new Date() });
     return c.json({ ok: true as const, updated });
   });
 
   app.post("/api/daily-tasks/:id/done", requireSameOrigin(), requireUser(db), zValidator("param", idParam), zValidator("json", doneBody), async (c) => {
     const { id } = c.req.valid("param");
     const { done } = c.req.valid("json");
-    const user = c.get("user");
-    const updated = await setDailyTaskDone(db, { id, userId: user.userId, done, now: new Date() });
+    const updated = await setDailyTaskDone(db, { id, done, now: new Date() });
     return c.json({ ok: true as const, updated });
   });
 
   app.delete("/api/daily-tasks/:id", requireSameOrigin(), requireUser(db), zValidator("param", idParam), async (c) => {
     const { id } = c.req.valid("param");
-    const user = c.get("user");
-    const removed = await deleteDailyTask(db, { id, userId: user.userId });
+    const removed = await deleteDailyTask(db, { id });
     return c.json({ ok: true as const, removed });
   });
 }

--- a/apps/api/src/modules/daily-tasks/queries.ts
+++ b/apps/api/src/modules/daily-tasks/queries.ts
@@ -1,44 +1,52 @@
-import { and, count, desc, eq, isNull } from "drizzle-orm";
+import { count, desc, eq, isNull } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { dailyTask } from "../../db/schema.js";
+import { users } from "../../db/schema-users.js";
 
 export interface DailyTaskRow {
   readonly id: string;
   readonly text: string;
   readonly emoji: string | null;
+  readonly authorUserId: string;
+  readonly authorName: string;
   readonly doneAt: Date | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
 
-// Vždy filtrované na JEDNÉHO používateľa (nikdy zdieľané, viď design komentár
-// na issue 342) a zoradené "najnovšie hore" — jediná os triedenia, vybavené
-// úlohy ostávajú na svojom mieste (frontend ich len vizuálne stlmí).
-export async function listDailyTasks(db: Database, userId: string): Promise<readonly DailyTaskRow[]> {
+// issue 487: ZDIEĽANÝ zoznam — žiadny per-user filter (na rozdiel od pôvodnej
+// súkromnej sémantiky z #342). Presne ako `note` (Poznámky, #437): INNER JOIN na
+// `users` pripojí meno AUTORA, aby ho appka mohla zobraziť pri každej úlohe
+// (ticket: „autor sa pri riadku zobrazí, aby bolo jasné, čia úloha je"). `user_id`
+// stĺpec OSTÁVA ako autor (zapisuje sa zo session pri create, `service.ts`).
+// Zoradené „najnovšie hore" — jediná os triedenia, vybavené úlohy ostávajú na
+// svojom mieste (frontend ich len vizuálne stlmí).
+export async function listDailyTasks(db: Database): Promise<readonly DailyTaskRow[]> {
   return db
     .select({
       id: dailyTask.id,
       text: dailyTask.text,
       emoji: dailyTask.emoji,
+      authorUserId: dailyTask.userId,
+      authorName: users.displayName,
       doneAt: dailyTask.doneAt,
       createdAt: dailyTask.createdAt,
       updatedAt: dailyTask.updatedAt,
     })
     .from(dailyTask)
-    .where(eq(dailyTask.userId, userId))
+    .innerJoin(users, eq(users.id, dailyTask.userId))
     .orderBy(desc(dailyTask.createdAt));
 }
 
-// issue 473: odznak počtu v ľavom menu — počet OTVORENÝCH (bez fajky) úloh
-// PRIHLÁSENÉHO používateľa. `COUNT(*) WHERE ...` priamo v SQL (rovnaký vzor ako
+// issue 473 + 487: odznak počtu v ľavom menu — počet OTVORENÝCH (bez fajky) úloh
+// VŠETKÝCH účtov (zdieľaný zoznam, #487, nie už len prihláseného používateľa).
+// `COUNT(*) WHERE done_at IS NULL` priamo v SQL (rovnaký vzor ako
 // `countActionableUpozornenia`, nie natiahnutie všetkých riadkov a `.length` v
-// JS). Úlohy sú SÚKROMNÉ — `user_id` filter na KAŽDOM dopyte, presne ako
-// `listDailyTasks` vyššie (viď design komentár na issue 342/473), takže odznak
-// nikdy nezapočíta cudzie úlohy. `done_at IS NULL` = ešte nevybavená.
-export async function countOpenDailyTasks(db: Database, userId: string): Promise<number> {
+// JS). Žiadny per-user filter — badge ukazuje rovnaký počet pre každý účet.
+export async function countOpenDailyTasks(db: Database): Promise<number> {
   const [row] = await db
     .select({ total: count() })
     .from(dailyTask)
-    .where(and(eq(dailyTask.userId, userId), isNull(dailyTask.doneAt)));
+    .where(isNull(dailyTask.doneAt));
   return row?.total ?? 0;
 }

--- a/apps/api/src/modules/daily-tasks/service.ts
+++ b/apps/api/src/modules/daily-tasks/service.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { dailyTask } from "../../db/schema.js";
 
@@ -13,7 +13,10 @@ export interface DailyTaskWriteResult {
 }
 
 // Jediná zapisovacia cesta pre NOVÚ úlohu — rovnaký princíp ako
-// `.claude/rules/mail-log.md`/`upozornenia`'s "jediná zapisovacia cesta".
+// `.claude/rules/mail-log.md`/`upozornenia`'s "jediná zapisovacia cesta". Autor
+// (`userId`) prichádza zo session (nikdy z tela requestu) a ukladá sa aj v
+// ZDIEĽANOM režime (#487) — pri riadku sa zobrazuje ako autor, presne ako pri
+// Poznámkach (`note`, #437).
 export async function createDailyTask(db: Database, input: CreateDailyTaskInput): Promise<DailyTaskWriteResult> {
   const [row] = await db
     .insert(dailyTask)
@@ -25,17 +28,18 @@ export async function createDailyTask(db: Database, input: CreateDailyTaskInput)
 
 export interface UpdateDailyTaskTextInput {
   readonly id: string;
-  readonly userId: string;
   readonly text: string;
   readonly now: Date;
 }
 
-// Vlastníctvo (`user_id`) sa vynucuje TU, nie len vo frontende — rovnaká
-// disciplína ako `upozornenia/service.ts`'s `updateOwnNote` (`source ===
-// "vlastne"`). Cudziu/neznámu/už zmazanú úlohu vráti ako `false`, nikdy 4xx
-// (rovnaký "neškodné no-op" princíp ako zvyšok appky).
+// issue 487: ZDIEĽANÝ zoznam — upraviť/odfajknúť/zmazať smie KTOKOĽVEK
+// prihlásený, NIE len autor (rovnako ako `note`/Poznámky, #437). Preto sa tu —
+// na rozdiel od pôvodnej súkromnej sémantiky (#342, `and(eq(id), eq(user_id))`) —
+// vlastníctvo ZÁMERNE nevynucuje; zápisy kľúčujú len `eq(id)`. Neznámu/už
+// zmazanú úlohu vrátia ako `false`, nikdy 4xx (rovnaký "neškodné no-op" princíp
+// ako zvyšok appky).
 //
-// Text a emoji sú ZÁMERNE dve samostatné funkcie/endpointy, nie jeden
+// Text a emoji ostávajú ZÁMERNE dve samostatné funkcie/endpointy, nie jeden
 // partial-update — zrkadlí to dve samostatné akcie v UI ("upraviť text" /
 // "pridať emoji", design komentár na tickete) a vyhýba sa dvojznačnosti
 // "kľúč nezadaný vs. zadaný ako null" (`.claude/rules/testing.md`'s vlastná
@@ -45,14 +49,13 @@ export async function updateDailyTaskText(db: Database, input: UpdateDailyTaskTe
   const result = await db
     .update(dailyTask)
     .set({ text: input.text, updatedAt: input.now })
-    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .where(eq(dailyTask.id, input.id))
     .returning({ id: dailyTask.id });
   return result.length > 0;
 }
 
 export interface UpdateDailyTaskEmojiInput {
   readonly id: string;
-  readonly userId: string;
   // `null` = zmazať emoji (späť na "žiadne").
   readonly emoji: string | null;
   readonly now: Date;
@@ -62,14 +65,13 @@ export async function updateDailyTaskEmoji(db: Database, input: UpdateDailyTaskE
   const result = await db
     .update(dailyTask)
     .set({ emoji: input.emoji, updatedAt: input.now })
-    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .where(eq(dailyTask.id, input.id))
     .returning({ id: dailyTask.id });
   return result.length > 0;
 }
 
 export interface SetDailyTaskDoneInput {
   readonly id: string;
-  readonly userId: string;
   readonly done: boolean;
   readonly now: Date;
 }
@@ -78,20 +80,19 @@ export async function setDailyTaskDone(db: Database, input: SetDailyTaskDoneInpu
   const result = await db
     .update(dailyTask)
     .set({ doneAt: input.done ? input.now : null, updatedAt: input.now })
-    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .where(eq(dailyTask.id, input.id))
     .returning({ id: dailyTask.id });
   return result.length > 0;
 }
 
 export interface DeleteDailyTaskInput {
   readonly id: string;
-  readonly userId: string;
 }
 
 export async function deleteDailyTask(db: Database, input: DeleteDailyTaskInput): Promise<boolean> {
   const result = await db
     .delete(dailyTask)
-    .where(and(eq(dailyTask.id, input.id), eq(dailyTask.userId, input.userId)))
+    .where(eq(dailyTask.id, input.id))
     .returning({ id: dailyTask.id });
   return result.length > 0;
 }

--- a/apps/api/tests/daily-tasks-http.integration.test.ts
+++ b/apps/api/tests/daily-tasks-http.integration.test.ts
@@ -6,7 +6,13 @@ import { hashPassword } from "../src/modules/auth/passwords.js";
 import type { UserRole } from "../src/modules/auth/service.js";
 import { withCleanDb } from "./helpers/db.js";
 
-// issue 342: "Dôležité → Úlohy na dnes" — súkromný, per-používateľský zoznam.
+// issue 342 + 487: "Dôležité → Úlohy na dnes". PÔVODNE súkromný per-používateľský
+// zoznam (#342); od #487 ZDIEĽANÝ — každý prihlásený účet vidí a smie odfajknúť/
+// upraviť/zmazať VŠETKY úlohy (presne ako `note`/Poznámky, #437), autor sa
+// zobrazuje pri riadku. Tieto testy boli PREPÍSANÉ z pôvodnej per-user (IDOR)
+// sémantiky na zdieľanú: kde predtým „cudzí účet nič nezmení / nevidí", teraz
+// „iný účet vidí a smie meniť" — server vlastníctvo pri čítaní/zápise už
+// nevynucuje (`modules/daily-tasks/service.ts`/`queries.ts`).
 const HESLO = "test-heslo-abc";
 
 let close: (() => Promise<void>) | undefined;
@@ -60,6 +66,11 @@ async function setDone(app: ReturnType<typeof createApp>, cookie: string, id: st
   await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ done }) });
 }
 
+async function listRows(app: ReturnType<typeof createApp>, cookie: string) {
+  const res = await app.request("/api/daily-tasks", { headers: { cookie } });
+  return ((await res.json()) as { rows: readonly { id: string; text: string; emoji: string | null; authorUserId: string; authorName: string; doneAt: string | null }[] }).rows;
+}
+
 describe("GET /api/daily-tasks", () => {
   it("bez prihlásenia vráti 401", async () => {
     const { app } = await bootUser("sef@forestshop.sk", "admin");
@@ -67,7 +78,7 @@ describe("GET /api/daily-tasks", () => {
     expect(res.status).toBe(401);
   });
 
-  it("čerstvý používateľ má prázdny zoznam", async () => {
+  it("prázdna DB → prázdny zoznam", async () => {
     const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
     const res = await app.request("/api/daily-tasks", { headers: { cookie } });
     expect(res.status).toBe(200);
@@ -80,34 +91,39 @@ describe("GET /api/daily-tasks", () => {
     await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "poslať DPD" }) });
     await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Nemáme sáčky" }) });
 
-    const res = await app.request("/api/daily-tasks", { headers: { cookie } });
-    const body = (await res.json()) as { rows: readonly { text: string }[] };
-    expect(body.rows.map((r) => r.text)).toEqual(["Nemáme sáčky", "poslať DPD"]);
+    const rows = await listRows(app, cookie);
+    expect(rows.map((r) => r.text)).toEqual(["Nemáme sáčky", "poslať DPD"]);
   });
 
-  it("úlohy sú OSOBNÉ — druhý používateľ ich v zozname nevidí", async () => {
+  // issue 487: prepísané z pôvodného "úlohy sú OSOBNÉ — druhý používateľ ich
+  // nevidí". Teraz ZDIEĽANÉ: iný účet vidí úlohu prvého účtu a riadok nesie
+  // autora (JOIN na `users` — `authorUserId` + `authorName`).
+  it("ZDIEĽANÉ — iný účet vidí úlohu prvého účtu; riadok nesie autora", async () => {
     const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
-    await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "šéfova súkromná úloha" }) });
+    await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "šéfova úloha" }) });
 
     const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
-    const res = await app.request("/api/daily-tasks", { headers: { cookie: other.cookie } });
-    const body = (await res.json()) as { rows: readonly unknown[] };
-    expect(body.rows).toEqual([]);
+    const rows = await listRows(app, other.cookie);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.text).toBe("šéfova úloha");
+    // Autor = pôvodný účet (`displayName` = email v `bootUser`), NIE prihlásený B.
+    expect(rows[0]?.authorName).toBe("sef@forestshop.sk");
+    expect(typeof rows[0]?.authorUserId).toBe("string");
+    expect(rows[0]?.authorUserId).not.toBe("");
   });
 });
 
 describe("POST /api/daily-tasks", () => {
-  it("vytvorí úlohu len s textom, žiadne ďalšie pole nie je povinné", async () => {
+  it("vytvorí úlohu len s textom, autor sa uloží zo session", async () => {
     const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
     const res = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Záhorecký volať" }) });
     expect(res.status).toBe(200);
     const created = (await res.json()) as { ok: boolean; id: string };
     expect(created.ok).toBe(true);
 
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    const body = (await list.json()) as { rows: readonly { id: string; text: string; emoji: string | null; doneAt: string | null }[] };
-    expect(body.rows).toHaveLength(1);
-    expect(body.rows[0]).toMatchObject({ id: created.id, text: "Záhorecký volať", emoji: null, doneAt: null });
+    const rows = await listRows(app, cookie);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: created.id, text: "Záhorecký volať", emoji: null, doneAt: null, authorName: "sef@forestshop.sk" });
   });
 
   it("prázdny text je odmietnutý (400)", async () => {
@@ -116,7 +132,7 @@ describe("POST /api/daily-tasks", () => {
     expect(res.status).toBe(400);
   });
 
-  it("rola 'citanie' SMIE vytvoriť vlastnú úlohu — je to jej vlastný súkromný zoznam", async () => {
+  it("rola 'citanie' SMIE vytvoriť úlohu — zdieľaný tímový nástroj bez role-obmedzenia", async () => {
     const { app, cookie } = await bootUser("zamestnanec@forestshop.sk", "citanie");
     const res = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "moja poznámka" }) });
     expect(res.status).toBe(200);
@@ -124,7 +140,7 @@ describe("POST /api/daily-tasks", () => {
 });
 
 describe("PATCH /api/daily-tasks/:id/text", () => {
-  it("upraví text vlastnej úlohy", async () => {
+  it("upraví text úlohy", async () => {
     const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
     const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Pôvodná" }) });
     const { id } = (await create.json()) as { id: string };
@@ -132,23 +148,22 @@ describe("PATCH /api/daily-tasks/:id/text", () => {
     const patch = await app.request(`/api/daily-tasks/${id}/text`, { method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Upravená" }) });
     expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: true });
 
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    const body = (await list.json()) as { rows: readonly { text: string }[] };
-    expect(body.rows[0]?.text).toBe("Upravená");
+    const rows = await listRows(app, cookie);
+    expect(rows[0]?.text).toBe("Upravená");
   });
 
-  it("CUDZIU úlohu neupraví (updated:false), text ostane pôvodný", async () => {
+  // issue 487: prepísané z IDOR testu — zdieľaný zoznam, iný účet MÔŽE upraviť.
+  it("ZDIEĽANÉ — iný účet MÔŽE upraviť text úlohy prvého účtu (updated:true)", async () => {
     const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
     const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
     const { id } = (await create.json()) as { id: string };
 
     const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
-    const patch = await app.request(`/api/daily-tasks/${id}/text`, { method: "PATCH", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Prepísané cudzím" }) });
-    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: false });
+    const patch = await app.request(`/api/daily-tasks/${id}/text`, { method: "PATCH", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Upravené kolegom" }) });
+    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: true });
 
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    const body = (await list.json()) as { rows: readonly { text: string }[] };
-    expect(body.rows[0]?.text).toBe("Šéfova úloha");
+    const rows = await listRows(app, cookie);
+    expect(rows[0]?.text).toBe("Upravené kolegom");
   });
 });
 
@@ -160,31 +175,24 @@ describe("PATCH /api/daily-tasks/:id/emoji", () => {
 
     const setEmoji = await app.request(`/api/daily-tasks/${id}/emoji`, { method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ emoji: "🚚" }) });
     expect((await setEmoji.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
-    const afterSet = await app.request("/api/daily-tasks", { headers: { cookie } });
-    expect(((await afterSet.json()) as { rows: readonly { emoji: string | null }[] }).rows[0]?.emoji).toBe("🚚");
+    expect((await listRows(app, cookie))[0]?.emoji).toBe("🚚");
 
     const clearEmoji = await app.request(`/api/daily-tasks/${id}/emoji`, { method: "PATCH", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ emoji: null }) });
     expect((await clearEmoji.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
-    const afterClear = await app.request("/api/daily-tasks", { headers: { cookie } });
-    expect(((await afterClear.json()) as { rows: readonly { emoji: string | null }[] }).rows[0]?.emoji).toBeNull();
+    expect((await listRows(app, cookie))[0]?.emoji).toBeNull();
   });
 
-  // Code review: symetrické pokrytie s "PATCH .../text"'s a "DELETE"'s
-  // rovnaké IDOR testy nižšie — implementácia je identická (`and(eq(id),
-  // eq(userId))`), ale bez PRIAMEHO testu by táto cesta ostala pokrytá len
-  // nepriamo.
-  it("CUDZIU úlohu neupraví emoji (updated:false), emoji ostane pôvodné", async () => {
+  // issue 487: prepísané z IDOR testu — zdieľaný zoznam, iný účet MÔŽE upraviť emoji.
+  it("ZDIEĽANÉ — iný účet MÔŽE upraviť emoji úlohy prvého účtu (updated:true)", async () => {
     const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
     const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
     const { id } = (await create.json()) as { id: string };
 
     const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
     const patch = await app.request(`/api/daily-tasks/${id}/emoji`, { method: "PATCH", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ emoji: "🚚" }) });
-    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: false });
+    expect((await patch.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: true });
 
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    const body = (await list.json()) as { rows: readonly { emoji: string | null }[] };
-    expect(body.rows[0]?.emoji).toBeNull();
+    expect((await listRows(app, cookie))[0]?.emoji).toBe("🚚");
   });
 });
 
@@ -196,33 +204,34 @@ describe("POST /api/daily-tasks/:id/done", () => {
 
     const markDone = await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ done: true }) });
     expect((await markDone.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
-    const afterDone = await app.request("/api/daily-tasks", { headers: { cookie } });
-    expect(((await afterDone.json()) as { rows: readonly { doneAt: string | null }[] }).rows[0]?.doneAt).not.toBeNull();
+    expect((await listRows(app, cookie))[0]?.doneAt).not.toBeNull();
 
     const markUndone = await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ done: false }) });
     expect((await markUndone.json()) as { updated: boolean }).toEqual({ ok: true, updated: true });
-    const afterUndone = await app.request("/api/daily-tasks", { headers: { cookie } });
-    expect(((await afterUndone.json()) as { rows: readonly { doneAt: string | null }[] }).rows[0]?.doneAt).toBeNull();
+    expect((await listRows(app, cookie))[0]?.doneAt).toBeNull();
   });
 
-  // Code review: rovnaké symetrické IDOR pokrytie ako "PATCH .../emoji" vyššie.
-  it("CUDZIU úlohu neoznačí ako vybavenú (updated:false), doneAt ostane null", async () => {
+  // issue 487 — HLAVNÝ akceptačný test: účet B vidí a ODFAJKNE úlohu účtu A.
+  it("účet B vidí a odfajkne úlohu účtu A (zdieľané), zmena je viditeľná aj účtu A", async () => {
     const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
-    const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
-    const { id } = (await create.json()) as { id: string };
+    const id = await createTask(app, cookie, "šéfova úloha na odfajknutie");
 
     const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
+    // B vidí úlohu A (autor A)
+    const bRows = await listRows(app, other.cookie);
+    expect(bRows.map((r) => r.text)).toEqual(["šéfova úloha na odfajknutie"]);
+    expect(bRows[0]?.authorName).toBe("sef@forestshop.sk");
+    // B ju odfajkne
     const markDone = await app.request(`/api/daily-tasks/${id}/done`, { method: "POST", headers: { cookie: other.cookie, "content-type": "application/json" }, body: JSON.stringify({ done: true }) });
-    expect((await markDone.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: false });
-
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    const body = (await list.json()) as { rows: readonly { doneAt: string | null }[] };
-    expect(body.rows[0]?.doneAt).toBeNull();
+    expect((await markDone.json()) as { ok: boolean; updated: boolean }).toEqual({ ok: true, updated: true });
+    // A vidí, že je vybavená
+    const aRows = await listRows(app, cookie);
+    expect(aRows[0]?.doneAt).not.toBeNull();
   });
 });
 
 describe("DELETE /api/daily-tasks/:id", () => {
-  it("okamžite odstráni vlastnú úlohu", async () => {
+  it("okamžite odstráni úlohu", async () => {
     const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
     const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Na zmazanie" }) });
     const { id } = (await create.json()) as { id: string };
@@ -230,8 +239,7 @@ describe("DELETE /api/daily-tasks/:id", () => {
     const del = await app.request(`/api/daily-tasks/${id}`, { method: "DELETE", headers: { cookie } });
     expect((await del.json()) as { removed: boolean }).toEqual({ ok: true, removed: true });
 
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    expect(((await list.json()) as { rows: readonly unknown[] }).rows).toEqual([]);
+    expect(await listRows(app, cookie)).toEqual([]);
   });
 
   it("neznáme id vráti 200 {removed:false}, nikdy chybu", async () => {
@@ -241,21 +249,21 @@ describe("DELETE /api/daily-tasks/:id", () => {
     expect((await res.json()) as { ok: boolean; removed: boolean }).toEqual({ ok: true, removed: false });
   });
 
-  it("CUDZIU úlohu nezmaže (removed:false), ostáva v zozname vlastníka", async () => {
+  // issue 487: prepísané z IDOR testu — zdieľaný zoznam, iný účet MÔŽE zmazať.
+  it("ZDIEĽANÉ — iný účet MÔŽE zmazať úlohu prvého účtu (removed:true)", async () => {
     const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
     const create = await app.request("/api/daily-tasks", { method: "POST", headers: { cookie, "content-type": "application/json" }, body: JSON.stringify({ text: "Šéfova úloha" }) });
     const { id } = (await create.json()) as { id: string };
 
     const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
     const del = await app.request(`/api/daily-tasks/${id}`, { method: "DELETE", headers: { cookie: other.cookie } });
-    expect((await del.json()) as { removed: boolean }).toEqual({ ok: true, removed: false });
+    expect((await del.json()) as { removed: boolean }).toEqual({ ok: true, removed: true });
 
-    const list = await app.request("/api/daily-tasks", { headers: { cookie } });
-    expect(((await list.json()) as { rows: readonly { id: string }[] }).rows.map((r) => r.id)).toEqual([id]);
+    expect(await listRows(app, cookie)).toEqual([]);
   });
 });
 
-// issue 473: odznak počtu v ľavom menu — počet MOJICH otvorených (bez fajky) úloh.
+// issue 473 + 487: odznak počtu v ľavom menu — počet otvorených úloh VŠETKÝCH účtov.
 describe("GET /api/daily-tasks/count", () => {
   it("bez prihlásenia vráti 401", async () => {
     const { app } = await bootUser("sef@forestshop.sk", "admin");
@@ -263,7 +271,7 @@ describe("GET /api/daily-tasks/count", () => {
     expect(res.status).toBe(401);
   });
 
-  it("čerstvý používateľ má count 0", async () => {
+  it("prázdna DB → count 0", async () => {
     const { app, cookie } = await bootUser("sef@forestshop.sk", "admin");
     const res = await app.request("/api/daily-tasks/count", { headers: { cookie } });
     expect(res.status).toBe(200);
@@ -292,15 +300,18 @@ describe("GET /api/daily-tasks/count", () => {
     expect(await readCount(app, cookie)).toBe(1);
   });
 
-  it("count je PER-POUŽÍVATEĽ — cudzie otvorené úlohy sa nerátajú", async () => {
+  // issue 487: prepísané z "count je PER-POUŽÍVATEĽ" — teraz ZDIEĽANÝ.
+  it("count je ZDIEĽANÝ — počíta otvorené úlohy VŠETKÝCH účtov; oba účty vidia rovnaké číslo", async () => {
     const { app, cookie, db } = await bootUser("sef@forestshop.sk", "admin");
     await createTask(app, cookie, "šéfova 1");
     await createTask(app, cookie, "šéfova 2");
 
     const other = await secondLogin(app, db, "zamestnanec@forestshop.sk", "manazer");
-    // druhý používateľ vidí LEN svoje (0), nie šéfove dve
-    expect(await readCount(app, other.cookie)).toBe(0);
-    // vlastník vidí svoje dve
+    // Druhý účet vidí ROVNAKÝ počet (zdieľané), nie 0 ako pri per-user.
+    expect(await readCount(app, other.cookie)).toBe(2);
     expect(await readCount(app, cookie)).toBe(2);
+    // A keď B pridá vlastnú úlohu, A vidí zvýšený počet.
+    await createTask(app, other.cookie, "kolegova 1");
+    expect(await readCount(app, cookie)).toBe(3);
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -185,8 +185,9 @@ export function App(): JSX.Element {
 
   // issue 473: odznak "Úlohy na dnes" — presná kópia `upozorneniaCount` vzoru
   // vyššie (App.tsx vlastní count, fetchuje ho pri prihlásení/zmene záložky/
-  // refresh-nonce, žiaden polling). Číslo je PER-POUŽÍVATEĽ (úlohy sú súkromné),
-  // musí byť známe HNEĎ po prihlásení, nie až po prvom otvorení záložky.
+  // refresh-nonce, žiaden polling). Číslo je ZDIEĽANÉ (od #487 počíta otvorené
+  // úlohy VŠETKÝCH účtov), musí byť známe HNEĎ po prihlásení, nie až po prvom
+  // otvorení záložky.
   // `DailyTasksSection` po každej úspešnej count-meniacej mutácii (pridať/
   // zmazať/odfajknúť) zavolá `refresh()` cez `DailyTasksBadgeRefreshContext`.
   const [dailyTasksCount, setDailyTasksCount] = useState<number | null>(null);

--- a/apps/web/src/components/DailyTasksSection.badgeRefresh.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.badgeRefresh.test.tsx
@@ -28,6 +28,8 @@ const ULOHA = {
   id: "task-1",
   text: "poslať DPD",
   emoji: null,
+  authorUserId: "user-1",
+  authorName: "Šéf",
   doneAt: null,
   createdAt: "2026-08-23T08:00:00.000Z",
   updatedAt: "2026-08-23T08:00:00.000Z",

--- a/apps/web/src/components/DailyTasksSection.test.tsx
+++ b/apps/web/src/components/DailyTasksSection.test.tsx
@@ -19,9 +19,9 @@ vi.mock("../dailyTasksApi.js", async (importOriginal) => {
   return { ...actual, fetchDailyTasks, createDailyTask, updateDailyTaskText, updateDailyTaskEmoji, setDailyTaskDone, deleteDailyTask };
 });
 
-const ROW_A = { id: "task-a", text: "poslať DPD", emoji: null, doneAt: null, createdAt: "2026-08-11T08:00:00.000Z", updatedAt: "2026-08-11T08:00:00.000Z" };
-const ROW_B = { id: "task-b", text: "Nemáme sáčky", emoji: "🛍️", doneAt: null, createdAt: "2026-08-11T09:00:00.000Z", updatedAt: "2026-08-11T09:00:00.000Z" };
-const ROW_DONE = { id: "task-done", text: "Vybavená úloha", emoji: null, doneAt: "2026-08-11T10:00:00.000Z", createdAt: "2026-08-11T07:00:00.000Z", updatedAt: "2026-08-11T10:00:00.000Z" };
+const ROW_A = { id: "task-a", text: "poslať DPD", emoji: null, authorUserId: "user-1", authorName: "Šéf", doneAt: null, createdAt: "2026-08-11T08:00:00.000Z", updatedAt: "2026-08-11T08:00:00.000Z" };
+const ROW_B = { id: "task-b", text: "Nemáme sáčky", emoji: "🛍️", authorUserId: "user-2", authorName: "Kolega", doneAt: null, createdAt: "2026-08-11T09:00:00.000Z", updatedAt: "2026-08-11T09:00:00.000Z" };
+const ROW_DONE = { id: "task-done", text: "Vybavená úloha", emoji: null, authorUserId: "user-1", authorName: "Šéf", doneAt: "2026-08-11T10:00:00.000Z", createdAt: "2026-08-11T07:00:00.000Z", updatedAt: "2026-08-11T10:00:00.000Z" };
 
 afterEach(() => {
   cleanup();
@@ -35,6 +35,16 @@ it("zobrazí zoznam úloh z fetchDailyTasks", async () => {
   await screen.findByTestId("uloha-row-task-a");
   expect(screen.getByTestId("uloha-text-task-a").textContent).toBe("poslať DPD");
   expect(screen.getByTestId("uloha-text-task-b").textContent).toBe("Nemáme sáčky");
+});
+
+// issue 487: zdieľaný zoznam — autor sa zobrazuje pri každom riadku (ako pri Poznámkach).
+it("zobrazí autora pri každom riadku (zdieľaný zoznam)", async () => {
+  fetchDailyTasks.mockResolvedValueOnce([ROW_B, ROW_A]);
+  render(<DailyTasksSection onSessionExpired={vi.fn()} />);
+
+  await screen.findByTestId("uloha-row-task-a");
+  expect(screen.getByTestId("uloha-author-task-a").textContent).toBe("Šéf");
+  expect(screen.getByTestId("uloha-author-task-b").textContent).toBe("Kolega");
 });
 
 it("prázdny zoznam ukáže výzvu, nie chybu", async () => {

--- a/apps/web/src/components/DailyTasksSection.tsx
+++ b/apps/web/src/components/DailyTasksSection.tsx
@@ -12,16 +12,17 @@ import {
 import { DailyTasksBadgeRefreshContext } from "../dailyTasksBadgeContext.js";
 import { EmojiPickerButton } from "./EmojiPickerButton.js";
 
-// issue 342: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané do
-// Discord kanála #úlohy-na-dnes. Na rozdiel od zvyšku appky (viď
-// `UpozorneniaSection.tsx`'s `CONTROL_ROLES`) tu NIE JE žiadne
-// role-podmienené ovládanie — úlohy sú súkromné pre KAŽDÉHO prihláseného
-// používateľa nezávisle od role (server to vynucuje cez `user_id`,
-// `daily-tasks-routes.ts`), takže neexistuje dôvod niekomu brániť mať
-// vlastný súkromný zoznam. Preto komponent prijíma len `onSessionExpired`,
-// nie celý `SectionProps` — TypeScript-ovo je to stále kompatibilné s
-// `ComponentType<SectionProps>` (`nav.ts`), lebo objekt s VIAC poľami (role
-// navyše) sa dá vždy odovzdať tam, kde sa čaká len podmnožina.
+// issue 342 + 487: "Dôležité → Úlohy na dnes" — nahrádza šéfove poznámky písané
+// do Discord kanála #úlohy-na-dnes. PÔVODNE súkromný per-používateľský zoznam
+// (#342); od #487 ZDIEĽANÝ — každý prihlásený účet vidí a smie odfajknúť/upraviť/
+// zmazať VŠETKY úlohy, autor sa zobrazuje pri riadku (presne ako `NotesSection`/
+// Poznámky, #437). Na rozdiel od zvyšku appky (viď `UpozorneniaSection.tsx`'s
+// `CONTROL_ROLES`) tu NIE JE žiadne role-podmienené ovládanie — server na každú
+// akciu vyžaduje len `requireUser` (`daily-tasks-routes.ts`), takže aj rola
+// "citanie" smie pridávať/spracúvať. Preto komponent prijíma len
+// `onSessionExpired`, nie celý `SectionProps` — TypeScript-ovo je to stále
+// kompatibilné s `ComponentType<SectionProps>` (`nav.ts`), lebo objekt s VIAC
+// poľami (role navyše) sa dá vždy odovzdať tam, kde sa čaká len podmnožina.
 
 // Issue 403 (majiteľ: "stale to je otras" — naživo pomenované na tickete):
 // tri štrukturálne opravy, žiadna zmena funkčnosti/testid.
@@ -220,7 +221,7 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
     [load, handleActionError, badgeRefresh],
   );
 
-  const intro = <p>Osobný zoznam úloh — nahrádza poznámky písané do Discordu. Vidíš len svoje vlastné úlohy.</p>;
+  const intro = <p>Zdieľaný zoznam úloh — nahrádza poznámky písané do Discordu. Vidia ho všetky prihlásené účty; pri každej úlohe je jej autor.</p>;
 
   const addRow = (
     <div className="ulohy-add-row">
@@ -356,9 +357,16 @@ export function DailyTasksSection({ onSessionExpired }: { readonly onSessionExpi
                       </button>
                     </>
                   ) : (
-                    <span className="uloha-text" data-testid={`uloha-text-${row.id}`}>
-                      {row.text}
-                    </span>
+                    <>
+                      <span className="uloha-text" data-testid={`uloha-text-${row.id}`}>
+                        {row.text}
+                      </span>
+                      {/* issue 487: zdieľaný zoznam — autor úlohy pri riadku (ako
+                          pri Poznámkach), aby bolo jasné, čí je záznam. */}
+                      <span className="uloha-author" data-testid={`uloha-author-${row.id}`}>
+                        {row.authorName}
+                      </span>
+                    </>
                   )}
 
                   {editingTextId !== row.id && (

--- a/apps/web/src/components/NotesSection.tsx
+++ b/apps/web/src/components/NotesSection.tsx
@@ -3,8 +3,8 @@ import { createNote, deleteNote, fetchNotes, NotesUnauthorizedError, setNoteReso
 import { EmojiPickerButton } from "./EmojiPickerButton.js";
 
 // issue 437: "Poznámky" — ZDIEĽANÁ nástenka rýchlych poznámok (mobilný zápis +
-// PWA). Na rozdiel od `DailyTasksSection.tsx` (súkromný per-používateľský
-// zoznam) sú poznámky zdieľané: každý prihlásený ich vidí, autor je
+// PWA). Rovnako ako `DailyTasksSection.tsx` (od #487 tiež zdieľaný) sú
+// poznámky zdieľané: každý prihlásený ich vidí, autor je
 // zobrazený, a ktokoľvek prihlásený môže vybaviť/zmazať (server to tak
 // vynucuje — `note-routes.ts`). Preto tu NIE JE žiadne role-podmienené
 // ovládanie (Štěpán = rola `sef` musí vedieť pridávať aj spracúvať).

--- a/apps/web/src/dailyTasksApi.ts
+++ b/apps/web/src/dailyTasksApi.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
-// issue 342: "Dôležité → Úlohy na dnes" — zrkadlí `DailyTaskRow`
-// (`apps/api/src/modules/daily-tasks/queries.ts`).
+// issue 342 + 487: "Dôležité → Úlohy na dnes" — zrkadlí `DailyTaskRow`
+// (`apps/api/src/modules/daily-tasks/queries.ts`). Od #487 je zoznam ZDIEĽANÝ,
+// takže riadok nesie aj `authorUserId`/`authorName` (JOIN na `users`) — autor sa
+// zobrazuje pri každej úlohe (ako pri Poznámkach).
 
 const rowSchema = z.object({
   id: z.string(),
   text: z.string(),
   emoji: z.string().nullable(),
+  authorUserId: z.string(),
+  authorName: z.string(),
   doneAt: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),

--- a/apps/web/src/dailyTasksApi.ts
+++ b/apps/web/src/dailyTasksApi.ts
@@ -49,7 +49,8 @@ export async function fetchDailyTasks(): Promise<readonly DailyTaskRow[]> {
   return listSchema.parse(await readJson(response, "Úlohy sa nepodarilo načítať")).rows;
 }
 
-// issue 473: odznak počtu v ľavom menu — počet mojich otvorených úloh. Rovnaký
+// issue 473 + 487: odznak počtu v ľavom menu — počet otvorených úloh VŠETKÝCH
+// účtov (zdieľané, #487). Rovnaký
 // vzor ako `fetchUpozorneniaCount` (`upozorneniaApi.ts`): odznak nie je
 // kritický, takže pri 401/chybe vráti 0 namiesto vyhodenia (App.tsx nechá
 // odznak na poslednej známej hodnote).

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2626,6 +2626,17 @@ a.upozornenie-title:hover {
   overflow-wrap: break-word;
   min-width: 0;
 }
+/* issue 487: zdieľaný zoznam — meno autora pri riadku (rovnaký stlmený štýl ako
+   `.poznamka-meta`). Nekonkuruje textu o priestor (`flex:0 0 auto`), gap riadku
+   (`.uloha-row`'s `--fs-space-2`) ho oddelí; `align-self:center` ho opticky
+   zarovná na výšku jednoriadkového textu. */
+.uloha-author {
+  flex: 0 0 auto;
+  align-self: center;
+  font-size: var(--fs-text-xs);
+  color: var(--fs-ink-faint);
+  white-space: nowrap;
+}
 .uloha-edit-input {
   flex: 1 1 0%;
   min-width: 6rem;

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -9,7 +9,8 @@ const E2E_ULOHY_EMAIL = "e2e-ulohy@forestshop.sk"; // musí sa zhodovať s hodno
 // textového poľa + Uložiť), zmeniť/odstrániť emoji, upraviť text, vybaviť
 // (ostáva v zozname, len stlmené), odstrániť. Konzola musí zostať čistá
 // (`.claude/rules/testing.md`). Účet má rolu "citanie" — server (a teda aj
-// appka) nemá pre tento súkromný zoznam žiadne role-podmienené obmedzenie.
+// appka) nemá pre tento ZDIEĽANÝ zoznam (#487) žiadne role-podmienené
+// obmedzenie; autor sa zobrazuje pri riadku.
 test("emoji picker do textu úlohy + jednoklikové označenie riadku, upraviť, vybaviť, odstrániť — konzola je čistá", async ({ page }) => {
   const chyby: string[] = [];
   page.on("console", (m) => {

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -46,6 +46,11 @@ test("emoji picker do textu úlohy + jednoklikové označenie riadku, upraviť, 
   await expect(riadky.nth(0)).toContainText("Záhorecký volať");
   await expect(riadky.nth(1)).toContainText("Nemáme sáčky 👍");
 
+  // issue 487: zdieľaný zoznam — pri každom riadku je jeho autor (seedovaný
+  // účet `e2e-ulohy@forestshop.sk` má displayName "E2E Čitateľ").
+  await expect(riadky.nth(0).locator(".uloha-author")).toHaveText("E2E Čitateľ");
+  await expect(riadky.nth(1).locator(".uloha-author")).toHaveText("E2E Čitateľ");
+
   // Nájsť konkrétny riadok podľa aktuálneho textu (rovnaký vzor ako
   // `upozornenia.spec.ts`'s `kartaSNadpisom`, len cez `.uloha-row`).
   const sackyRiadok = page.locator(".uloha-row").filter({ hasText: "Nemáme sáčky" });

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4414,3 +4414,28 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
 - Playbook: `.claude/rules/orders.md` — sekcia „Riešiť" ZJEDNODUŠENÁ (plochý
   zoznam objednávok, `groupRiesitLinesByOrder`, `countOpenOrdersByState` distinct,
   `OrderLinesTableHead` zdieľaný). Doplnené v tomto docs follow-upe.
+
+## 2026-08-24 — issues 487 + 488 (Úlohy na dnes zdieľané pre všetky účty; monitor bez forestshop-novy)
+
+- Batch (worktree isolation, #317), version bump 0.3.0-dev.285 → .286.
+- Design komentáre PRED prvým commitom kódu (root cause / prístup / zamietnutá
+  alternatíva) + STEP 0 overenie (naživo + prod DB) na oboch tiketoch:
+  https://github.com/zbynekdrlik/forestshop-app/issues/487#issuecomment-5395672519
+  (a #488).
+- **#487 (majiteľ: „prečo ja nevidím úlohy na dnes … nechaj to viditeľné pre
+  všetky účty, opatrne aby si niečo nevymazal"):** modul „Úlohy na dnes"
+  (`daily_task`, #342) prešiel zo SÚKROMNÉHO per-user zoznamu na ZDIEĽANÝ —
+  presne ako Poznámky (`note`, #437). Odstránený per-user filter z čítania aj
+  zápisu (`modules/daily-tasks/queries.ts` + `service.ts` + `daily-tasks-routes.ts`);
+  `listDailyTasks` má JOIN na `users` pre `authorUserId`/`authorName` (autor sa
+  zobrazí pri riadku), `countOpenDailyTasks` počíta otvorené úlohy VŠETKÝCH účtov.
+  `user_id` stĺpec OSTÁVA (autor zo session pri create); ŽIADNA migrácia, ŽIADNE
+  mazanie — 22 existujúcich prod úloh (všetky účtu `info`) nedotknutých, len
+  viditeľné pre všetkých. Web: `dailyTasksApi.ts` (+autor), `DailyTasksSection.tsx`
+  (autor pri riadku, zdieľaný úvodný text), `app.css` (`.uloha-author`). Existujúce
+  per-user testy prepísané na zdieľanú sémantiku + nový „účet B vidí a odfajkne
+  úlohu účtu A".
+- **#488 (majiteľ: „vypni tú doménu forestshop-novy nech to beží iba na
+  normálnej"), LEN repo časť:** `scripts/uptime-check.sh` default (riadok 60) už
+  nekontroluje `forestshop-novy.newlevel.media`, ostáva len hlavná doména; HELP
+  hlavička zosúladená. Cloudflare/DNS/dev1 rieši supervisor — #488 ostáva OTVORENÝ.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.285",
+  "version": "0.3.0-dev.286",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/uptime-check.sh
+++ b/scripts/uptime-check.sh
@@ -6,8 +6,8 @@
 # scripts/uptime-check.sh — issue 357, external public-URL availability monitor.
 #
 # HELP-BEGIN
-# WHY: nič doteraz z VONKU nekontrolovalo, či `forestshop.newlevel.media` /
-# `forestshop-novy.newlevel.media` žijú — 12. 8. 2026 objavil výpadok (Cloudflare
+# WHY: nič doteraz z VONKU nekontrolovalo, či `forestshop.newlevel.media` žije
+# — 12. 8. 2026 objavil výpadok (Cloudflare
 # Error 1033, pozri .claude/rules/deploy.md) majiteľ, nie automatika. Beží NA
 # DEV1, zámerne NIE na dev2 (kde bežia appka aj tunel) — monitor na tom istom
 # stroji, čo sleduje, by zomrel presne v momente výpadku, ktorý má hlásiť.
@@ -57,7 +57,10 @@ esac
 # Pole, nie reťazec + `for url in $URLS` — review finding, issue 357: neúvodzovkovaná
 # expanzia reťazca sa spolieha na delenie slov (funguje, ale je krehké); pole je
 # odolnejšie a jasnejšie vyjadruje zámer (viacero nezávislých URL).
-read -ra URLS <<< "${UPTIME_CHECK_URLS:-https://forestshop.newlevel.media https://forestshop-novy.newlevel.media}"
+# issue 488: `forestshop-novy.newlevel.media` sa vypína (majiteľ, appka beží len
+# na hlavnej doméne), takže default kontroluje UŽ LEN hlavnú adresu; env override
+# `UPTIME_CHECK_URLS` ostáva, keby bolo treba sledovať aj ďalšie adresy.
+read -ra URLS <<< "${UPTIME_CHECK_URLS:-https://forestshop.newlevel.media}"
 CONFIRM_THRESHOLD="${UPTIME_CHECK_CONFIRM_THRESHOLD:-2}"
 ALERT_THROTTLE_PASSES="${UPTIME_CHECK_ALERT_THROTTLE_PASSES:-12}"   # ~1h at the 5-min cadence
 CURL_TIMEOUT="${UPTIME_CHECK_CURL_TIMEOUT:-10}"


### PR DESCRIPTION
Dve bundle-safe zmeny (worktree dispatch, verzia 0.3.0-dev.286). ŽIADNE zatváracie kľúčové slovo — obidva tikety ostávajú OTVORENÉ, zatvorí ich supervisor po naživo overení.

## issue 487 — „Úlohy na dnes" viditeľné pre všetky účty (zdieľané)

Modul daily_task prešiel zo súkromného per-user zoznamu na ZDIEĽANÝ (rovnako ako Poznámky/note). Každý prihlásený účet vidí a smie odfajknúť/upraviť/zmazať všetky úlohy; autor sa ukladá zo session pri create a zobrazuje sa pri riadku; nav badge počíta otvorené úlohy všetkých účtov. ŽIADNA migrácia, ŽIADNE mazanie — 22 existujúcich prod úloh ostáva nedotknutých, len viditeľné pre všetkých. Design + validácia + review komentáre na tikete 487.

## issue 488 — externý monitor bez forestshop-novy (LEN repo časť)

scripts/uptime-check.sh default (riadok 60) už nekontroluje forestshop-novy.newlevel.media, ostáva len hlavná doména forestshop.newlevel.media; HELP hlavička zosúladená. Cloudflare/DNS/dev1 rieši supervisor mimo repa — tiket 488 ostáva otvorený.

## Testy

- API integ (daily-tasks-http): per-user testy prepísané na zdieľanú sémantiku + hlavný akceptačný test „účet B vidí a odfajkne úlohu účtu A".
- Web unit + e2e: autor sa zobrazuje pri riadku.
- Review 0 🔴 0 🟡 (4 zastarané komentáre opravené), gates:local + CI (check / integration / e2e / docker-build / version-check) zelené.
