### PR TITLE
docs: finalizácia autopilot-log + playbook (issues 487, 488), bump .287

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1197,8 +1197,10 @@ paths:
   onSessionExpired={reload} />`), and excess-property checking only
   fires on object LITERALS, never on a wider-typed value flowing into a
   narrower parameter.** Issue 342's `DailyTasksSection` takes only
-  `{onSessionExpired}` (its data is scoped by `user_id` server-side, so no
-  `CONTROL_ROLES`-style role check exists anywhere in the component) — no
+  `{onSessionExpired}` (since #487 it is a SHARED list — `requireUser` on
+  every endpoint, so no `CONTROL_ROLES`-style role check exists in the
+  component; it was a private per-`user_id` list at #342, the justification
+  changed but the narrow-props shape stayed the same) — no
   cast, no `as SectionProps`, `pnpm typecheck` passes clean. Reach for this
   ONLY when the screen genuinely has no role distinction (server enforces
   ownership/permission some OTHER way); if any role check exists, take the

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -858,3 +858,15 @@ paths:
   PRÁVE svojho `noteId` (`floor-note-row-${noteId}` `toHaveCount(0)`), nikdy
   globálny stav. Lokálne (`workers: 1`) sa táto kolízia NEPREJAVÍ — chytí ju až
   paralelné CI.
+- **`daily_task` je od #487 tiež GLOBÁLNa (zdieľaná) tabuľka — modul „Úlohy na
+  dnes" prešiel z per-`user_id` na zdieľaný (ako `note`/#437: bez per-user
+  filtra, JOIN na `users` pre autora, zápisy kľúčujú len `eq(id)`).**
+  `daily-tasks.spec.ts` NAPRIEK TOMU stále používa globálnu prázdnotu
+  (`ulohy-empty`) aj presné počty (`toHaveCount(2)`/`toHaveCount(1)`) — je to
+  bezpečné LEN preto, že tento spec je JEDINÝ e2e zapisovateľ do `daily_task`
+  (over `grep -rln "api/daily-tasks\|uloha-new" apps/web/tests/e2e/`). Prvý
+  ĎALŠÍ spec, ktorý zapíše `daily_task`, spustí presne kolíznu triedu issue 480
+  vyššie — vtedy treba OBA prerobiť na „filtruj podľa VLASTNÉHO fixture" (a nav
+  badge `nav-badge-ulohy` už dnes správne overuje len `/^\d+$/`, nie presné
+  číslo — zdieľaný počet naprieč účtami). Pri prevode akéhokoľvek ďalšieho
+  per-user zoznamu na zdieľaný over toto ako prvé.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4439,3 +4439,26 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   normálnej"), LEN repo časť:** `scripts/uptime-check.sh` default (riadok 60) už
   nekontroluje `forestshop-novy.newlevel.media`, ostáva len hlavná doména; HELP
   hlavička zosúladená. Cloudflare/DNS/dev1 rieši supervisor — #488 ostáva OTVORENÝ.
+- Testy: web unit 742 + api unit 1010 (`pnpm gates:local` zelené); CI (dev aj
+  main) check/integration/e2e/docker-build/version-check zelené. Review cez
+  fresh-context reviewera: 0 🔴 0 🟡 4 🔵 (len zastarané komentáre, opravené).
+- Commity: `51eb19c` (bump .286 + log hlavička), `4d60bc7` (feat #487),
+  `a11b6bc` (uptime #488), `44bbc63` (oprava komentárov po review). PR #489
+  (merge `eab1f87`). Nasadené `v0.3.0-dev.286` na main. **Obidva tikety 487 aj
+  488 ostávajú OTVORENÉ** (telo PR aj commit správy plain „issue N" bez
+  zatváracieho slova) — zatvorí ich supervisor po naživo overení / doriešení
+  infra časti #488.
+- Post-deploy naživo overené na forestshop.newlevel.media (verzia z DOM
+  `v0.3.0-dev.286`, aj `/api/version`): prihlásený INÝ účet než autor
+  (`vychod@varos.sk` / Zbyněk, admin) vidí VŠETKÝCH 22 existujúcich úloh účtu
+  `info`, pri každej je autor „info"; nav odznak „Úlohy na dnes: 22"
+  (zdieľaný počet). Cross-account odfajknutie: Zbyněk odfajkol úlohu `info`
+  → odznak 22→21, riadok `done`; VRÁTENÉ presne späť → odznak 22, riadok
+  otvorený (dáta majiteľa nedotknuté). Konzola 0 chýb na obrazovke úloh.
+- Playbook: `frontend-design.md` (DailyTasksSection úzke props — zdôvodnenie
+  aktualizované na zdieľané #487), `testing.md` (nová poznámka: `daily_task`
+  je od #487 GLOBÁLna tabuľka, `daily-tasks.spec.ts` globálne asercie sú
+  bezpečné len ako jediný zapisovateľ — issue 480 trieda).
+- Táto log+playbook finalizácia jazdí na samostatnom docs bump-e
+  `0.3.0-dev.287` (rovnaký vzor ako .285 pri issue 484) — ŽIADNA funkčná
+  zmena, len dokumentácia; #487/#488 sú funkčne nasadené už na `.286`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.286",
+  "version": "0.3.0-dev.287",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Docs-only finalizácia (bump 0.3.0-dev.287) k funkčnej práci nasadenej na .286.

Autopilot-log doplnený o SHA/PR/deploy/naživo overenie; playbook: frontend-design.md (DailyTasksSection úzke props — zdôvodnenie na zdieľané) + testing.md (daily_task je od issue 487 GLOBÁLna tabuľka, e2e globálne asercie bezpečné len ako jediný zapisovateľ).

ŽIADNE zatváracie kľúčové slovo — tikety 487 aj 488 ostávajú OTVORENÉ.
