### PR TITLE
DPD zvoz na deň: čakať #button-save review krok, zúžiť info toasty (issue 491)

### DIFF
--- a/.claude/rules/dpd.md
+++ b/.claude/rules/dpd.md
@@ -112,7 +112,10 @@ paths:
     mechanizmus (ten istý, aký appka videla vypisovať systémové správy na
     `/pickup-orders`), aj bežné hádané CSS triedy ako zálohu — kým sa
     skutočný tvar chyby/úspechu neoverí prvým reálnym zvozom, KAŽDÉ
-    `ok:true` tu je optimistické, nie potvrdené.
+    `ok:true` tu je optimistické, nie potvrdené. **VYRIEŠENÉ issue 491
+    (26.8.2026): pozitívny signál = review krok zmizne (`#button-save`
+    detached) po Uložení, inak chybový toast → fail-loud; pozri bullet
+    „PRVÝ REÁLNY ZVOZ" nižšie.**
   - **Testy** (`tests/helpers/dpd-portal-fixture.ts`) imitujú LEN tvar,
     ktorý appka skutočne ovláda (ID/vnorenie/atribúty naživo domapovaných
     prvkov) — NIKDY sa nedotknú `dpdshipper.sk`. **Fixture login formulár
@@ -239,7 +242,12 @@ paths:
   zoznam; scope-nuté selektory (`[class*="banner"] [class*="close"]` …) bežia
   PRVÉ, holé `button:has-text("✕"/"×")` až posledné ako záloha — pri prvom
   reálnom zvoze ich ZÚŽ podľa skutočného DOM (nikdy naslepo, zúženie teraz by
-  mohlo scope-núť VON aj skutočný zatvárací prvok). Volá sa LEN v pickup
+  mohlo scope-núť VON aj skutočný zatvárací prvok). **ZÚŽENÉ issue 491
+  (26.8.2026): reálne hlášky sú `shp-newsfeed-toast`, zatvárané
+  `.newsfeed-toast__button` „Zatvoriť" (staré hádané selektory nezavreli NIČ);
+  `dismissInfoBanners` teraz mieri LEN na `shp-newsfeed-toast
+  button:has-text("Zatvoriť")` — pozri bullet „PRVÝ REÁLNY ZVOZ" nižšie.**
+  Volá sa LEN v pickup
   vetve — shipment vetva (#292) ostáva nedotknutá. Test: fixtúra
   `dpd-portal-fixture.ts`'s `showInfoBanner` prekryje formulár celoobrazovkovým
   `z-index` overlayom, ktorý zachytí pointer eventy (Playwright „intercepts
@@ -257,3 +265,49 @@ paths:
   > 0`). Badge/per-zásielková logika #445 nedotknuté. Kontakt (Štěpánov krok
   5) sa NEVYBERÁ — účet má jediný predvyplnený kontakt + fail-loud poistka;
   ak by prvý reálny zvoz ukázal, že kontakt treba aktívne vybrať, TU je delta.
+- **PRVÝ REÁLNY ZVOZ (issue 491, 26.8.2026) — objednávka zvozu `/pickup-orders/0`
+  NAŽIVO domapovaná, a predošlé HÁDANÉ `#step1`/`#step2` boli NESPRÁVNE.**
+  Skutočný DOM (read-only remap app credentials z kontajnera, žiadny zápis):
+  - Formulár je JEDEN Angular `<form class="data">` (`shp-app ng-version=5.1.3`)
+    — zvozová adresa readonly (`#customer-name`/`-street`/`-zip`/`-city`),
+    kontakt (`#contact-person` ng2-completer, `#email`, `#phone`), `#note`,
+    a **`#pickup-date` = `wj-input-date`** s vnútorným `input[wj-part="input"]`
+    (type=tel) — selektor `#pickup-date input[wj-part="input"]` je SPRÁVNY.
+    Jediné editovateľné pole, ktoré appka mení, je dátum. Krok 1 má JEDNO
+    tlačidlo `#button-confirmation` „Pokračovať".
+  - **`#step1`/`#step2` v reálnom DOM NEEXISTUJÚ.** Klik „Pokračovať"
+    NEnaviguje (URL ostáva `/pickup-orders/0`) — Angular RE-RENDERuje NA
+    MIESTE na REVIEW krok: zmizne `#button-confirmation`, `<form>` sa zmení na
+    `<div class="data">`, objaví sa `<div class="panel wide warning">` („Po jej
+    uložení bude objednávka odoslaná do DPD…"), polia sú readonly, a pribudnú
+    **`#button-save` („Uložiť") + `#button-back` („Späť")** v `.commands.toolbar`.
+    Skutočné odoslanie = klik `#button-save`. Starý kód čakal `#step1` hidden
+    (prejde triviálne — prvok chýba = hidden) + `#step2` visible (timeout
+    8000 ms — nikdy neexistoval) → nahlásená chyba; finálne uloženie sa NIKDY
+    nedosiahlo, teda žiadny zvoz sa nevytvoril (sedí s tým, čo videl Štěpán).
+    **Fix (`fillPickupForm`):** čakať `#button-save` visible (review marker),
+    klik `#button-save`, potom FAIL-LOUD pozitívne overenie — race medzi
+    „`#button-save` detached" (navigácia na zoznam / re-render = ÚSPECH) a
+    chybovým toastom (ZLYHANIE), nikdy tiché optimistické „ok" (uzatvára
+    UNVERIFIED poznámku vyššie o „úspech = absencia chyby").
+  - **Info hlášky (Štěpánov krok „zavrieť všetky hlášky") sú
+    `shp-newsfeed-toast` toasty v `#toast-container` („Aktuálne obmedzenia a
+    možné oneskorenia…", „Nové pravidlá v doručovaní…"), zatvárané tlačidlom
+    `.newsfeed-toast__button` s textom „Zatvoriť"** (druhé tlačidlo toastu
+    „Obsah správy" je DECOY — otvorilo by správu). Staré hádané selektory
+    (`[aria-label=Zavrieť]`/`✕`/`[class*=close]`) nezavreli NIČ. Naživo
+    overené: klik `shp-newsfeed-toast button:has-text("Zatvoriť")` zavrel OBA
+    toasty (2 → 0). `dismissInfoBanners` ZÚŽENÉ presne na tento selektor
+    (loop-close-first, bounded, fail-soft) — pozri `portal-fill.ts`.
+  - **Zoznam `/pickup-orders`:** „Jednorazové zvozy" je
+    `shp-one-time-pickup-orders-list` (`.one-time-pickups`), tlačidlo „Nová
+    objednávka zvozu" = `#add-pickup-order` (naviguje na `/pickup-orders/0`,
+    appka's priama navigácia stále platí). Úspešný zvoz = riadok s dátumom
+    (`Dátum vyzdvihnutia`) + stav **„Objednávka odoslaná"** (`td.col-date`).
+    Zvozová adresa účtu: „Slavosport s.r.o., Brokoffova 1654/8, 05801 Poprad".
+  - **Fixtúra `dpd-portal-fixture.ts`'s `pickupFormPage` prerobená na tento
+    reálny tvar** (single `<form>` → „Pokračovať" → review s `#button-save`;
+    `shp-newsfeed-toast` overlay so „Zatvoriť" + „Obsah správy" DECOY) —
+    empiricky RED na starom kóde (5/5 testov padlo, `#step2` timeout / decoy),
+    GREEN na novom (5/5). Kontakt sa STÁLE nevyberá (jediný predvyplnený,
+    fungovalo naživo).

--- a/apps/api/src/modules/dpd/pickup-playwright.ts
+++ b/apps/api/src/modules/dpd/pickup-playwright.ts
@@ -4,17 +4,27 @@ import { runInChildProcess } from "../shoptet-writeback/child-runner.js";
 import type { DpdPortalConfig } from "./config.js";
 import { dismissInfoBanners, runOnDpdPortalPage, typeInto } from "./portal-fill.js";
 
-// issue 292: "Objednávky zvozu" (`/pickup-orders`) — naživo overené
-// (7.8.2026 menu, 9.8.2026 formulár): klik "+" pri "Jednorazové zvozy"
-// navigoval na `/pickup-orders/0` (`config.ts`'s `newPickupOrderUrl`), teda
-// priama navigácia je spoľahlivejšia než hľadanie tlačidla. Formulár je
-// DVOJKROKOVÝ — krok 1 (zvozová adresa/kontakt/dátum, predvyplnené z účtu,
-// appka mení LEN dátum) → "Pokračovať" → krok 2 (rovnaká URL, appka's
-// vlastný SPA prechod) → skutočné "Uložiť".
+// issue 292/491: "Objednávky zvozu" (`/pickup-orders`) — naživo overené
+// (7.8.2026 menu, 9.8.2026 + 26.8.2026 formulár): klik "+" pri "Jednorazové
+// zvozy" navigoval na `/pickup-orders/0` (`config.ts`'s `newPickupOrderUrl`),
+// teda priama navigácia je spoľahlivejšia než hľadanie tlačidla. Formulár je
+// JEDEN Angular `<form class="data">` (zvozová adresa/kontakt/dátum, predvyplnené
+// z účtu, appka mení LEN `#pickup-date`) s tlačidlom `#button-confirmation`
+// "Pokračovať". Klik "Pokračovať" NEnaviguje (URL ostáva `/pickup-orders/0`) —
+// Angular RE-RENDERuje NA MIESTE na REVIEW krok: zmizne `#button-confirmation`,
+// objaví sa `.panel.warning` + readonly polia + `#button-save` "Uložiť". Skutočné
+// odoslanie = klik `#button-save`. (Predtým sa hádali `#step1`/`#step2` step-
+// container ID, ktoré v reálnom DOM NEEXISTUJÚ — `#step2` waitFor timeoutoval
+// 8000 ms; issue 491.)
 const PICKUP_DATE_SELECTOR = '#pickup-date input[wj-part="input"]';
 const CONTINUE_BUTTON_SELECTOR = "#button-confirmation";
-const STEP1_SELECTOR = "#step1";
-const STEP2_SELECTOR = "#step2";
+const SAVE_BUTTON_SELECTOR = "#button-save";
+// Chybové hlásenie portálu — scoped na toast/alert kontajnery s chybovým textom
+// (NIE bežné validačné `[class*=error]` triedy, aby po úspešnej navigácii na
+// zoznam nevznikol falošný pozitív). Reálne info toasty (`shp-newsfeed-toast`,
+// text "obmedzenia"/"pravidlá") tento vzor NEmatchujú.
+const PORTAL_ERROR_SELECTOR =
+  '.alert-danger, .toast-error, [id*="toast"] :text-matches("chyb|zlyha|nepodarilo|error", "i")';
 
 /** DPD portál čaká slovenský tvar dátumu bez vedúcich núl ("10. 8. 2026"),
  * naživo overené (9.8.2026) — appka dostáva ISO `YYYY-MM-DD`
@@ -28,20 +38,9 @@ function toDpdDateFormat(isoDate: string): string {
   return `${String(Number(day))}. ${String(Number(month))}. ${year}`;
 }
 
-/**
- * Code review (issue 292, PR 324): "úspech" tu ostáva NEPRIAMY dôkaz
- * (absencia chyby), lebo skutočný pozitívny signál sa nedal naživo overiť
- * (rovnaké bezpečnostné pravidlo ako pri zásielke — prvý reálny klik patrí
- * majiteľovi, `.claude/rules/dpd.md`). Kontrola je preto zámerne ŠIROKÁ:
- * najprv overený `#toast-container`/`[id*="toast"]` mechanizmus (rovnaký,
- * aký appka už naživo videla vypisovať systémové správy PO prihlásení na
- * `/pickup-orders`), potom aj bežné chybové CSS triedy ako záloha. Kým sa
- * toto neoverí prvým skutočným zvozom, každé "ok:true" tu je optimistické,
- * NIE potvrdené — pozri `.claude/rules/dpd.md`'s UNVERIFIED poznámku.
- */
 async function checkForPortalError(page: Page): Promise<string | null> {
   const errorText = await page
-    .locator('[id*="toast"] :text-matches("chyb|zlyha|nepodarilo|error", "i"), .toast-error, .alert-danger, [class*="error"]:visible')
+    .locator(PORTAL_ERROR_SELECTOR)
     .first()
     .textContent({ timeout: 3000 })
     .catch(() => null);
@@ -51,19 +50,47 @@ async function checkForPortalError(page: Page): Promise<string | null> {
 async function fillPickupForm(page: Page, pickupDate: string): Promise<void> {
   await typeInto(page, PICKUP_DATE_SELECTOR, toDpdDateFormat(pickupDate));
   await page.locator(CONTINUE_BUTTON_SELECTOR).click();
-  // Deterministické čakanie namiesto pevného spánku (code review, issue
-  // 292, PR 324) — krok 1 sa naozaj skryje AŽ keď Angular prekreslí, na
-  // reálnom (ťažšom) portáli to môže trvať dlhšie než pevná pauza.
-  await page.locator(STEP1_SELECTOR).waitFor({ state: "hidden", timeout: 8000 });
-  await page.locator(STEP2_SELECTOR).waitFor({ state: "visible", timeout: 8000 });
 
-  const saveButton = page.getByRole("button", { name: "Uložiť", exact: true });
+  // Klik "Pokračovať" re-renderuje formulár NA MIESTE na REVIEW krok — objaví sa
+  // `#button-save` ("Uložiť") a zmizne `#button-confirmation` (naživo overené
+  // issue 491). Čakáme na skutočný marker review kroku namiesto neexistujúceho
+  // `#step1`/`#step2` (to timeoutovalo). Angular prekreslenie môže na reálnom
+  // (ťažšom) portáli trvať dlhšie než pevná pauza — deterministické čakanie.
+  await page.locator(SAVE_BUTTON_SELECTOR).waitFor({ state: "visible", timeout: 10_000 });
+
+  // Poistka: ak sa medzitým znovu objavil prekrývajúci info toast, zavri ho,
+  // inak by zachytil klik na "Uložiť" (fail-soft, no-op keď žiadny nie je).
+  await dismissInfoBanners(page);
+
+  const saveButton = page.locator(SAVE_BUTTON_SELECTOR);
   await saveButton.click();
+
+  // Fail-loud POZITÍVNE overenie výsledku (issue 491, uzatvára dpd.md UNVERIFIED
+  // poznámku): po Uložení sa objednávka odošle do DPD a portál buď opustí review
+  // krok (`#button-save` sa odpojí — navigácia na zoznam / re-render = ÚSPECH),
+  // alebo zobrazí chybový toast (ZLYHANIE). Nikdy tiché optimistické "ok".
+  const outcome = await Promise.race([
+    saveButton
+      .waitFor({ state: "detached", timeout: 20_000 })
+      .then(() => "saved" as const)
+      .catch(() => "timeout" as const),
+    page
+      .locator(PORTAL_ERROR_SELECTOR)
+      .first()
+      .waitFor({ state: "visible", timeout: 20_000 })
+      .then(() => "error" as const)
+      .catch(() => "timeout" as const),
+  ]);
   await page.waitForLoadState("networkidle").catch(() => {});
 
   const errorText = await checkForPortalError(page);
   if (errorText !== null) {
     throw new Error(`DPD portál nahlásil chybu pri objednaní zvozu: ${errorText}`);
+  }
+  if (outcome !== "saved") {
+    throw new Error(
+      "DPD zvoz: po kliknutí Uložiť sa objednávka nepotvrdila (review krok nezmizol ani sa nezobrazila chyba) — over stav ručne v portáli",
+    );
   }
 }
 

--- a/apps/api/src/modules/dpd/portal-fill.ts
+++ b/apps/api/src/modules/dpd/portal-fill.ts
@@ -105,48 +105,40 @@ export function assertSlovakDeliveryCountry(countryName: string): void {
   }
 }
 
-// issue 451 (Štěpánov krok 2): po prihlásení portál môže ukázať info banner
-// („Aktuálne obmedzenia…") so zatváracím ✕, ktorý — ak prekryje formulár —
-// zachytí klik na „Pokračovať"/„Uložiť". Zámerne ŠIROKÝ, tolerantný výber
-// zatváracích prvkov v banner/alert/notification kontajneroch. Presný
-// selektor reálneho bannera je UNVERIFIED (mapovanie 9.8.2026 bolo
-// read-only, a z lane sa robot NESMIE spustiť naživo) — preto tolerantný
-// zoznam; over/zúž ho pri prvom reálnom zvoze.
-const INFO_BANNER_CLOSE_SELECTORS: readonly string[] = [
-  '[aria-label="Zavrieť" i]',
-  '[aria-label="Zavriet" i]',
-  '[aria-label="Close" i]',
-  '[class*="banner"] [class*="close"]',
-  '[class*="notification"] [class*="close"]',
-  '[class*="alert"] [class*="close"]',
-  "button.close",
-  'button:has-text("✕")',
-  'button:has-text("×")',
-];
+// issue 451/491 (Štěpánov krok 2 „zavrieť všetky hlášky"): reálne info hlášky
+// DPD portálu sú `shp-newsfeed-toast` toasty v `#toast-container`
+// („Aktuálne obmedzenia a možné oneskorenia…", „Nové pravidlá v doručovaní…"),
+// zatvárané tlačidlom `.newsfeed-toast__button` s textom „Zatvoriť". Naživo
+// overené (issue 491, prvý reálny remap `/pickup-orders/0`): klik
+// `shp-newsfeed-toast button:has-text("Zatvoriť")` zavrel OBA toasty (2 → 0).
+// ZÚŽENÉ podľa skutočného DOM (predtým hádaný ŠIROKÝ zoznam aria-label/✕/close
+// nezavrel NIČ) — druhé tlačidlo toastu „Obsah správy" je DECOY, ktoré
+// `:has-text("Zatvoriť")` NIKDY netrafí (otvorilo by správu namiesto zatvorenia).
+const NEWSFEED_CLOSE_SELECTOR = 'shp-newsfeed-toast button:has-text("Zatvoriť")';
 
 /**
- * Štěpánov krok 2 (issue 451): zatvorí prekrývajúce info bannery/hlášky PRED
+ * Štěpánov krok 2 (issue 451/491): zatvorí prekrývajúce info toasty PRED
  * vyplnením formulára. Zámerne BEST-EFFORT a fail-SOFT, NIE fail-loud —
- * chýbajúci banner je NORMÁLNY stav (na rozdiel od povinného poľa, ktoré
+ * chýbajúci toast je NORMÁLNY stav (na rozdiel od povinného poľa, ktoré
  * appka MUSÍ vyplniť), takže absencia = no-op, nikdy throw. Ak by prekrytie
- * predsa zostalo, `checkForPortalError` po Uložení aj tak zlyhá nahlas —
- * táto pomôcka teda nič nezhoršuje, len odstráni bežnú prekážku. Volá sa
- * LEN z pickup vetvy (`pickup-playwright.ts`), shipment vetva ostáva
+ * predsa zostalo, klik na formulár/`checkForPortalError` po Uložení aj tak
+ * zlyhá nahlas — táto pomôcka teda nič nezhoršuje, len odstráni bežnú prekážku.
+ * Volá sa LEN z pickup vetvy (`pickup-playwright.ts`), shipment vetva ostáva
  * nedotknutá.
+ *
+ * Loop-close-first (bounded): klik na PRVÝ viditeľný „Zatvoriť", počkaj, znovu
+ * vyhľadaj — bezpečne zavrie VIACERO toastov bez index-shift problému `.all()`
+ * (po odstránení prvého toastu by sa handle druhého rozpadol).
  */
 export async function dismissInfoBanners(page: Page): Promise<void> {
-  for (const selector of INFO_BANNER_CLOSE_SELECTORS) {
-    const closers = await page
-      .locator(selector)
-      .all()
-      .catch(() => [] as Locator[]);
-    for (const closer of closers) {
-      const visible = await closer.isVisible().catch(() => false);
-      if (!visible) continue;
-      await closer.click({ timeout: 1500 }).catch(() => {
-        // best-effort: tento prvok nemusí byť skutočný zatvárací ovládač
-      });
-    }
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const closer = page.locator(NEWSFEED_CLOSE_SELECTOR).first();
+    const visible = await closer.isVisible().catch(() => false);
+    if (!visible) return;
+    await closer.click({ timeout: 1500 }).catch(() => {
+      // best-effort: tento toast sa medzitým mohol sám zavrieť/odísť
+    });
+    await page.waitForTimeout(200);
   }
 }
 

--- a/apps/api/tests/dpd-pickup-playwright.integration.test.ts
+++ b/apps/api/tests/dpd-pickup-playwright.integration.test.ts
@@ -18,7 +18,7 @@ describe("runOrderDpdPickup (proti fixture, nikdy proti reálnemu DPD)", () => {
   });
 
   it(
-    "prejde oboma krokmi wizardu, nastaví dátum v slovenskom tvare bez vedúcich núl a uloží",
+    "vyplní dátum (slovenský tvar bez vedúcich núl), prejde cez Pokračovať do review kroku a uloží cez #button-save",
     async () => {
       fixture = await startDpdFixture({ user: USER, password: PASSWORD });
       const outcome = await runOrderDpdPickup({
@@ -76,6 +76,21 @@ describe("runOrderDpdPickup (proti fixture, nikdy proti reálnemu DPD)", () => {
 
       expect(outcome.ok).toBe(false);
       expect(outcome.errorDetail).toMatch(/nepodarilo/i);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "vráti ok:false s 'nepotvrdila', keď po Uložení review krok NEZMIZNE ani sa nezobrazí chyba (tichý/zaseknutý portál) — nikdy tiché ok:true",
+    async () => {
+      fixture = await startDpdFixture({ user: USER, password: PASSWORD, pickupSaveHangs: true });
+      const outcome = await runOrderDpdPickup({
+        config: dpdPortalConfigFromBaseUrl(fixture.baseUrl, USER, PASSWORD),
+        pickupDate: "2026-08-10",
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.errorDetail).toMatch(/nepotvrdila/i);
     },
     TEST_TIMEOUT_MS,
   );

--- a/apps/api/tests/helpers/dpd-portal-fixture.ts
+++ b/apps/api/tests/helpers/dpd-portal-fixture.ts
@@ -156,39 +156,84 @@ function shipmentsListPage(reference: string | null): string {
 }
 
 function pickupFormPage(showInfoBanner: boolean): string {
-  // issue 451: celoobrazovkový prekrývací info banner s ✕ — vysoký z-index
-  // (zachytáva pointer eventy nad formulárom), zatvárateľný `aria-label
-  // "Zavrieť"`/text ✕. Kým sa nezavrie, `Pokračovať`/`Uložiť` klik zachytí
-  // tento banner a zlyhá — presne ten stav, ktorý `dismissInfoBanners`
-  // (Štěpánov krok 2) rieši.
+  // issue 491 (reálny tvar, naživo domapované 26.8.2026): `/pickup-orders/0` je
+  // JEDEN `<form class="data">` s `#pickup-date` (wj-input-date, vnútorný
+  // `input[wj-part="input"]`) a `#button-confirmation` „Pokračovať". Klik
+  // „Pokračovať" re-renderuje NA MIESTE na REVIEW krok — zmizne
+  // `#button-confirmation`, objaví sa `#button-save` „Uložiť" (+ `.panel.warning`).
+  // Skutočné odoslanie = klik `#button-save`. (Predtým fixtúra modelovala
+  // hádané `#step1`/`#step2` step-container ID, ktoré v reálnom DOM NEEXISTUJÚ.)
+  //
+  // issue 451/491 info toasty (Štěpánov krok „zavrieť všetky hlášky"):
+  // `shp-newsfeed-toast` v celoobrazovkovom `#toast-container` overlaye
+  // (zachytáva pointer eventy nad formulárom), zatvárané tlačidlom „Zatvoriť"
+  // (`.newsfeed-toast__button`). Druhé tlačidlo „Obsah správy" je DECOY — klik
+  // naň overlay NEODstráni; implementácia, čo klikne na VŠETKY
+  // `.newsfeed-toast__button` (alebo hádaný ✕/aria-label/close), by decoy
+  // klikla / netrafila „Zatvoriť" → overlay zostane → klik na formulár zlyhá.
   const infoBanner = showInfoBanner
-    ? `<div id="dpd-info-banner" style="position:fixed;top:0;left:0;right:0;bottom:0;z-index:2147483647;background:rgba(0,0,0,0.4)">
-        <div class="alert-info" style="padding:1rem">Aktuálne obmedzenia v doručovaní.
-          <button type="button" id="info-banner-close" class="banner-close" aria-label="Zavrieť">✕</button>
-        </div>
+    ? `<div id="toast-container" class="toast-center-center toast-container" style="position:fixed;top:0;left:0;right:0;bottom:0;z-index:2147483647;background:rgba(0,0,0,0.4)">
+        <shp-newsfeed-toast class="toast-info toast newsfeed-toast">
+          <div class="toast-title">Nové pravidlá v doručovaní do Holandska</div>
+          <div class="newsfeed-toast__buttons">
+            <button type="button" class="newsfeed-toast__button" data-role="close"><span class="newsfeed-toast__label">Zatvoriť</span></button>
+            <button type="button" class="newsfeed-toast__button" data-role="content"><span class="newsfeed-toast__label">Obsah správy</span></button>
+          </div>
+        </shp-newsfeed-toast>
+        <shp-newsfeed-toast class="toast-info toast newsfeed-toast">
+          <div class="toast-title">Aktuálne obmedzenia a možné oneskorenia pri doručovaní zásielok</div>
+          <div class="newsfeed-toast__buttons">
+            <button type="button" class="newsfeed-toast__button" data-role="close"><span class="newsfeed-toast__label">Zatvoriť</span></button>
+            <button type="button" class="newsfeed-toast__button" data-role="content"><span class="newsfeed-toast__label">Obsah správy</span></button>
+          </div>
+        </shp-newsfeed-toast>
       </div>
       <script>
-        document.getElementById('info-banner-close').addEventListener('click', function () {
-          var b = document.getElementById('dpd-info-banner'); if (b) b.remove();
+        Array.prototype.forEach.call(document.querySelectorAll('shp-newsfeed-toast'), function (t) {
+          t.querySelector('[data-role=close]').addEventListener('click', function () {
+            t.remove();
+            var c = document.getElementById('toast-container');
+            if (c && c.querySelectorAll('shp-newsfeed-toast').length === 0) c.remove();
+          });
+          // "Obsah správy" (data-role=content) = DECOY: overlay zámerne NEODstráni
         });
       </script>`
     : "";
   return `<!doctype html><html><body>
+    <div class="content-panel pickup-order-editor">
+      <form id="pickup-step1" class="data ng-untouched ng-pristine ng-valid" novalidate="">
+        <div class="panel"><h2>Podrobnosti</h2>
+          <div class="ctl">
+            <label for="pickup-date_input">Dátum vyzdvihnutia</label>
+            <div id="pickup-date" class="wj-control wj-inputdate"><input wj-part="input" type="tel" class="wj-form-control" id="pickup-date_input" /></div>
+          </div>
+          <div class="ctl"><label for="note">Poznámka</label><textarea id="note"></textarea></div>
+        </div>
+        <div class="commands toolbar"><button type="button" id="button-confirmation">Pokračovať</button></div>
+      </form>
+      <div id="pickup-step2" class="data" style="display:none">
+        <div class="panel wide warning">Prosím, skontrolujte údaje objednávky. Po jej uložení bude objednávka odoslaná do DPD.</div>
+        <div class="commands toolbar">
+          <button id="button-save"><span class="ic-floppydisk"></span><span class="label">Uložiť</span></button>
+          <button id="button-back"><span class="ic-arrow-left-1"></span><span class="label">Späť</span></button>
+        </div>
+      </div>
+    </div>
     ${infoBanner}
-    <div id="pickup-date"><input wj-part="input" id="pickup-date-input" /></div>
-    <div id="step1"><button type="button" id="button-confirmation">Pokračovať</button></div>
-    <div id="step2" style="display:none"><button type="button" id="save-btn2">Uložiť</button></div>
     <script>
       document.getElementById('button-confirmation').addEventListener('click', function () {
-        document.getElementById('step1').style.display = 'none';
-        document.getElementById('step2').style.display = 'block';
+        window.__pickupDate = document.getElementById('pickup-date_input').value;
+        document.getElementById('pickup-step1').style.display = 'none';
+        document.getElementById('pickup-step2').style.display = 'block';
       });
-      document.getElementById('save-btn2').addEventListener('click', function () {
-        var date = document.getElementById('pickup-date-input').value;
-        fetch('/test/pickup-submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ date: date }) })
+      document.getElementById('button-save').addEventListener('click', function () {
+        fetch('/test/pickup-submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ date: window.__pickupDate }) })
           .then(function (r) { return r.json(); })
           .then(function (r) {
-            if (!r.ok) {
+            if (r.ok) {
+              // úspech: review krok sa odpojí — appka deteguje detach #button-save
+              var s = document.getElementById('pickup-step2'); if (s) s.remove();
+            } else {
               document.body.insertAdjacentHTML('beforeend', '<div class="alert-danger">Zvoz sa nepodarilo objednať (test)</div>');
             }
           });

--- a/apps/api/tests/helpers/dpd-portal-fixture.ts
+++ b/apps/api/tests/helpers/dpd-portal-fixture.ts
@@ -25,6 +25,11 @@ export interface DpdFixtureOptions {
   readonly stuckDisabled?: boolean;
   /** Krok 2 objednávky zvozu po Uložení ukáže chybu namiesto úspechu. */
   readonly pickupSaveFails?: boolean;
+  /** issue 491: klik „Uložiť" v review kroku NIČ nespraví — review krok
+   * NEZMIZNE ani sa NEZOBRAZÍ chyba (simuluje tichý/zaseknutý portál). Overuje
+   * fail-loud „nepotvrdila" vetvu (`outcome !== "saved"`), aby appka nikdy
+   * tiché ok:true pri nepotvrdenom odoslaní. */
+  readonly pickupSaveHangs?: boolean;
   /** issue 451 (Štěpánov krok 2): formulár zvozu prekryje celoobrazovkový
    * info banner („Aktuálne obmedzenia…") so zatváracím ✕ — kým sa nezavrie,
    * zachytáva kliky na polia/tlačidlá formulára (na overenie, že robot
@@ -155,7 +160,7 @@ function shipmentsListPage(reference: string | null): string {
   return `<!doctype html><html><body><table>${row}</table></body></html>`;
 }
 
-function pickupFormPage(showInfoBanner: boolean): string {
+function pickupFormPage(showInfoBanner: boolean, pickupSaveHangs: boolean): string {
   // issue 491 (reálny tvar, naživo domapované 26.8.2026): `/pickup-orders/0` je
   // JEDEN `<form class="data">` s `#pickup-date` (wj-input-date, vnútorný
   // `input[wj-part="input"]`) a `#button-confirmation` „Pokračovať". Klik
@@ -226,7 +231,9 @@ function pickupFormPage(showInfoBanner: boolean): string {
         document.getElementById('pickup-step1').style.display = 'none';
         document.getElementById('pickup-step2').style.display = 'block';
       });
-      document.getElementById('button-save').addEventListener('click', function () {
+      ${pickupSaveHangs
+        ? "/* issue 491 pickupSaveHangs: žiadny listener na #button-save — klik je no-op (tichý portál). Review krok NEZMIZNE ani sa NEZOBRAZÍ chyba → appka musí fail-loud 'nepotvrdila'. */"
+        : `document.getElementById('button-save').addEventListener('click', function () {
         fetch('/test/pickup-submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ date: window.__pickupDate }) })
           .then(function (r) { return r.json(); })
           .then(function (r) {
@@ -237,7 +244,7 @@ function pickupFormPage(showInfoBanner: boolean): string {
               document.body.insertAdjacentHTML('beforeend', '<div class="alert-danger">Zvoz sa nepodarilo objednať (test)</div>');
             }
           });
-      });
+      });`}
     </script>
   </body></html>`;
 }
@@ -272,7 +279,9 @@ export async function startDpdFixture(options: DpdFixtureOptions): Promise<DpdFi
   });
 
   app.get("/pickup-orders/0", (c) =>
-    getCookie(c, COOKIE_NAME) === "ok" ? c.html(pickupFormPage(options.showInfoBanner ?? false)) : c.html(loginPage()),
+    getCookie(c, COOKIE_NAME) === "ok"
+      ? c.html(pickupFormPage(options.showInfoBanner ?? false, options.pickupSaveHangs ?? false))
+      : c.html(loginPage()),
   );
 
   app.post("/test/pickup-submit", async (c) => {

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4455,6 +4455,23 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   (zdieľaný počet). Cross-account odfajknutie: Zbyněk odfajkol úlohu `info`
   → odznak 22→21, riadok `done`; VRÁTENÉ presne späť → odznak 22, riadok
   otvorený (dáta majiteľa nedotknuté). Konzola 0 chýb na obrazovke úloh.
+
+## 2026-08-26 — issue 491 (DPD „Objednať zvoz na deň" zlyháva — #step2 timeout, klient-urgent)
+
+- Version bump 0.3.0-dev.287 → .288 (worktree agent-a226518e).
+- Root cause (naživo read-only remap `/pickup-orders/0` na dpdshipper.sk, žiadny
+  zápis): formulár NIE JE dvojkrokový wizard s `#step1`/`#step2` — je to JEDEN
+  Angular `<form class="data">` s `#button-confirmation` „Pokračovať". Klik
+  „Pokračovať" re-renderuje NA MIESTE (URL ostáva) na REVIEW krok: `.panel.warning`
+  + readonly polia + `#button-save` „Uložiť" (+ `#button-back`). `pickup-playwright.ts`
+  čakal `#step1` hidden (prejde triviálne, prvok chýba) + `#step2` visible (timeout
+  8000 ms — prvok nikdy neexistoval) → nahlásená chyba; finálne uloženie sa
+  nedosiahlo (žiadny zvoz sa nevytvoril). Info hlášky (Štěpánov krok „zavrieť")
+  sú `shp-newsfeed-toast` zatvárané `.newsfeed-toast__button` „Zatvoriť" — staré
+  `dismissInfoBanners` selektory (aria-label/✕/close) nezavreli nič.
+- Design komentár PRED prvým commitom kódu (root cause / prístup / zamietnutá
+  alternatíva) + STEP 0 overenie:
+  https://github.com/zbynekdrlik/forestshop-app/issues/491
 - Playbook: `frontend-design.md` (DailyTasksSection úzke props — zdôvodnenie
   aktualizované na zdieľané #487), `testing.md` (nová poznámka: `daily_task`
   je od #487 GLOBÁLna tabuľka, `daily-tasks.spec.ts` globálne asercie sú

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.287",
+  "version": "0.3.0-dev.288",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
DPD „Objednať zvoz na deň" — klient-urgent oprava zlyhania na dpdshipper.sk (issue 491).

**Root cause** (naživo read-only remap `/pickup-orders/0`, 26.8.2026): reálny formulár je JEDEN Angular `<form class="data">`; klik „Pokračovať" (`#button-confirmation`) re-renderuje NA MIESTE na REVIEW krok s `#button-save` („Uložiť"). `#step1`/`#step2` v DOM NEEXISTUJÚ — preto `#step2` waitFor timeoutoval 8000 ms (nahlásená chyba), finálne uloženie sa nikdy nedosiahlo. Info hlášky (Štěpánov krok „zavrieť") sú `shp-newsfeed-toast` zatvárané „Zatvoriť" — staré `dismissInfoBanners` selektory nezavreli nič.

**Zmeny:**
- `pickup-playwright.ts`: `fillPickupForm` čaká `#button-save` (review marker) namiesto neexistujúceho `#step2`, klik `#button-save`, fail-loud pozitívne overenie (review krok zmizne = úspech, chybový toast = zlyhanie, inak „nepotvrdila").
- `portal-fill.ts`: `dismissInfoBanners` zúžené na reálny `shp-newsfeed-toast button:has-text("Zatvoriť")` (loop-close-first, fail-soft).
- Fixtúra `dpd-portal-fixture.ts` prerobená na reálny tvar (single form → review → `#button-save`; newsfeed-toast overlay so „Zatvoriť" + „Obsah správy" decoy) — empiricky RED na starom kóde (5/5), GREEN na novom (6/6, vrátane fail-loud „nepotvrdila" vetvy).
- Playbook `.claude/rules/dpd.md` doplnený o reálny DOM.

Ticket ostáva OTVORENÝ — má post-deploy akceptačnú podmienku (naživo reálny zvoz), zatvorí ho supervisor po overení. Preto BEZ zatváracieho slova (plain „issue 491").
