### PR TITLE
issue 492 — sebaozdravujúce okno CSV importu (zamrznutý stav objednávky mimo okna)

### DIFF
--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -391,6 +391,10 @@ paths:
   nezmenené; CSV rozšírenie predlžuje AJ `windowStart` akceptačnej brány (`ingest.ts`),
   takže `previousLineRatio` ostáva apples-to-apples (počítadlo DB riadkov aj stiahnutý
   export sa rozšíria SPOLU). Zdieľaný privátny helper `oldestOpenOrderPlacedAt(db, extra?)`.
+  Drôtovanie oboch okien (ktoré okno ktorý fetch dostane + `dateUntil`) je v JEDINOM
+  `computeOrdersIngestWindows(db, now, {hasXmlUrl})` — volajú ho AJ `cli/orders-ingest.ts`
+  AJ `index.ts` scheduler, aby sa nikdy nerozišli a aby to šlo unit-testovať (presne
+  trieda tichého regresu, ktorý #492 spôsobil — pevné okno bez testu na drôtovaní).
 - **Overené naživo (issue 492, forestshop-dev, 26. 8. 2026): Shoptet REŠPEKTUJE
   širší `dateFrom`** — priame stiahnutie s `dateFrom=2026-4-1` vrátilo objednávku
   z 30.4 (mimo 90-dňového okna) s AKTUÁLNYM stavom ("Vybavená"), zatiaľ čo posledný

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -375,6 +375,29 @@ paths:
   alternatívy, nikdy vyskúšané, lebo CSV dovtedy stačilo) predtým, než sa
   záver zovšeobecní na "Shoptet to nemá vôbec" — mal len iný, dovtedy
   neotestovaný export.
+- **Import má PEVNÉ 90-dňové KĹZAVÉ okno (`fetcher.ts`'s `computeImportWindow(now,
+  90)`, `dateFrom`/`dateUntil` z `now`); objednávka staršia než 90 dní z exportu
+  VYPADNE. `backfill.ts` predlžuje okno dozadu SEBAOZDRAVUJÚCO, samostatne pre
+  dva rôzne dôvody:**
+  - **#132 — XML id-fetch (`computeOrderIdsWindowStart`, `findOldestOpenOrderMissingShoptetId`):**
+    najstaršia OTVORENÁ objednávka BEZ `shoptet_order_id`. Inak nikdy nedostane id.
+  - **#492 — CSV import (`computeOrdersExportWindowStart`, `findOldestOpenOrder`):**
+    najstaršia OTVORENÁ objednávka BEZ ohľadu na id. CSV je JEDINÁ cesta osviežujúca
+    `status_name` (issue 59) — objednávka vybavená v Shoptete AŽ PO vypadnutí z okna
+    by inak navždy zamrzla na "Vybavuje sa" a visela v "Na objednanie" (20260739).
+    REPAIR je inherentný: prvý beh s predĺženým oknom zosúladí každý zamrznutý stav
+    zo Shoptetu — žiadny samostatný skript, žiadna heuristika "staré = vybavené".
+  Obe počítané z PREDVOLENÉHO `dateFrom` (nie navzájom), aby #132 správanie ostalo
+  nezmenené; CSV rozšírenie predlžuje AJ `windowStart` akceptačnej brány (`ingest.ts`),
+  takže `previousLineRatio` ostáva apples-to-apples (počítadlo DB riadkov aj stiahnutý
+  export sa rozšíria SPOLU). Zdieľaný privátny helper `oldestOpenOrderPlacedAt(db, extra?)`.
+- **Overené naživo (issue 492, forestshop-dev, 26. 8. 2026): Shoptet REŠPEKTUJE
+  širší `dateFrom`** — priame stiahnutie s `dateFrom=2026-4-1` vrátilo objednávku
+  z 30.4 (mimo 90-dňového okna) s AKTUÁLNYM stavom ("Vybavená"), zatiaľ čo posledný
+  bežný surový export ju vôbec neniesol. Rozdiel veľkosti (90 dní ~1,27 MB vs. 148
+  dní ~1,9 MB) je zanedbateľný. Známa hranica: objednávka otvorená v appke, ktorá už
+  v Shoptete NEEXISTUJE (zmazaná), by okno držala predĺžené donekonečna — extrémne
+  zriedkavé, download aj tak malý (rovnaká trieda rizika, akú #132 vedome prijalo).
 - **`fixtures/orders-sample.csv` je RUČNE vyrobená (nie výrez reálneho
   exportu ako katalógova fixtúra), takže sa smie prepísať CELÁ pythonom —
   žiadny byte-for-byte jeden-riadok postup ako `.claude/rules/catalog.md`

--- a/apps/api/src/cli/orders-ingest.ts
+++ b/apps/api/src/cli/orders-ingest.ts
@@ -16,13 +16,9 @@
 // na $?, nie len na text výstupu (rovnaká disciplína ako `scripts/catalog-ingest.ts`).
 import { createDb } from "../db/client.js";
 import { loadEnv } from "../env.js";
-import { computeOrderIdsWindowStart, computeOrdersExportWindowStart } from "../modules/orders/backfill.js";
-import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "../modules/orders/fetcher.js";
-import {
-  DEFAULT_ORDERS_IMPORT_WINDOW_DAYS,
-  ingestOrders,
-  type OrdersIngestResult,
-} from "../modules/orders/ingest.js";
+import { computeOrdersIngestWindows } from "../modules/orders/backfill.js";
+import { createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "../modules/orders/fetcher.js";
+import { ingestOrders, type OrdersIngestResult } from "../modules/orders/ingest.js";
 
 function popis(result: OrdersIngestResult): string {
   switch (result.status) {
@@ -45,20 +41,19 @@ if (env.SHOPTET_ORDERS_URL === undefined) {
 }
 
 const now = new Date();
-const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
-
 const ordersXmlUrl = env.SHOPTET_ORDERS_XML_URL;
 
 const { db, pool } = createDb(env.DATABASE_URL);
 let result: OrdersIngestResult;
 try {
-  // issue 132/492: pozri rovnaký komentár v `index.ts`. CSV import okno
-  // (`exportDateFrom`) sa sebaozdravujúco predĺži dozadu na najstaršiu OTVORENÚ
-  // objednávku (osvieženie zamrznutého status_name, #492); XML id-fetch okno
-  // samostatne na najstaršiu otvorenú BEZ id (#132) — počítané z predvoleného
-  // okna, aby #132 správanie ostalo nezmenené.
-  const exportDateFrom = await computeOrdersExportWindowStart(db, dateFrom);
-  const idsDateFrom = ordersXmlUrl === undefined ? dateFrom : await computeOrderIdsWindowStart(db, dateFrom);
+  // issue 132/492: obe okná importu (CSV export sebaozdravujúco rozšírené na
+  // najstaršiu OTVORENÚ objednávku — osvieženie zamrznutého status_name #492;
+  // XML id-fetch na otvorenú BEZ id #132) počíta JEDEN zdroj pravdy
+  // `computeOrdersIngestWindows` (`backfill.ts`), aby sa CLI a `index.ts`
+  // nikdy nerozišli a aby to šlo unit-testovať.
+  const { exportDateFrom, idsDateFrom, dateUntil } = await computeOrdersIngestWindows(db, now, {
+    hasXmlUrl: ordersXmlUrl !== undefined,
+  });
   result = await ingestOrders(db, {
     fetchExport: createHttpOrdersExportFetcher({ url: env.SHOPTET_ORDERS_URL, dateFrom: exportDateFrom, dateUntil }),
     now,

--- a/apps/api/src/cli/orders-ingest.ts
+++ b/apps/api/src/cli/orders-ingest.ts
@@ -16,7 +16,7 @@
 // na $?, nie len na text výstupu (rovnaká disciplína ako `scripts/catalog-ingest.ts`).
 import { createDb } from "../db/client.js";
 import { loadEnv } from "../env.js";
-import { computeOrderIdsWindowStart } from "../modules/orders/backfill.js";
+import { computeOrderIdsWindowStart, computeOrdersExportWindowStart } from "../modules/orders/backfill.js";
 import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "../modules/orders/fetcher.js";
 import {
   DEFAULT_ORDERS_IMPORT_WINDOW_DAYS,
@@ -52,15 +52,18 @@ const ordersXmlUrl = env.SHOPTET_ORDERS_XML_URL;
 const { db, pool } = createDb(env.DATABASE_URL);
 let result: OrdersIngestResult;
 try {
-  // issue 132: pozri rovnaký komentár v `index.ts` — XML id-fetch okno sa
-  // sebaozdravujúco predĺži dozadu, keď existuje otvorená objednávka bez id
-  // staršia než predvolené okno.
+  // issue 132/492: pozri rovnaký komentár v `index.ts`. CSV import okno
+  // (`exportDateFrom`) sa sebaozdravujúco predĺži dozadu na najstaršiu OTVORENÚ
+  // objednávku (osvieženie zamrznutého status_name, #492); XML id-fetch okno
+  // samostatne na najstaršiu otvorenú BEZ id (#132) — počítané z predvoleného
+  // okna, aby #132 správanie ostalo nezmenené.
+  const exportDateFrom = await computeOrdersExportWindowStart(db, dateFrom);
   const idsDateFrom = ordersXmlUrl === undefined ? dateFrom : await computeOrderIdsWindowStart(db, dateFrom);
   result = await ingestOrders(db, {
-    fetchExport: createHttpOrdersExportFetcher({ url: env.SHOPTET_ORDERS_URL, dateFrom, dateUntil }),
+    fetchExport: createHttpOrdersExportFetcher({ url: env.SHOPTET_ORDERS_URL, dateFrom: exportDateFrom, dateUntil }),
     now,
     rawDir: env.ORDERS_RAW_DIR,
-    windowStart: dateFrom,
+    windowStart: exportDateFrom,
     windowEnd: dateUntil,
     // issue 269: odkaz priamo na objednávku vo vrátkovej karte na Upozorneniach.
     adminBaseUrl: env.SHOPTET_ADMIN_BASE_URL,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,9 +12,9 @@ import { createNextEventService } from "./modules/calendar/service.js";
 import { createHttpExportFetcher } from "./modules/catalog/fetcher.js";
 import { ingestCatalog } from "./modules/catalog/ingest.js";
 import { createSmtpMailTransport } from "./modules/mail/transport.js";
-import { computeOrderIdsWindowStart, computeOrdersExportWindowStart } from "./modules/orders/backfill.js";
-import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
-import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
+import { computeOrdersIngestWindows } from "./modules/orders/backfill.js";
+import { createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
+import { ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
 import { createHttpTrackingClient } from "./modules/posta-uncollected/tracking-client.js";
 import { runPostaUncollected } from "./modules/posta-uncollected/run.js";
 import { createOpenAiClassifyClient } from "./modules/order-reminder/classify-client.js";
@@ -97,21 +97,21 @@ const ordersUrl = env.SHOPTET_ORDERS_URL;
 // ako "id zatiaľ neznáme", nikdy ako chybu.
 const ordersXmlUrl = env.SHOPTET_ORDERS_XML_URL;
 // issue 132/492: obe importné okná sa sebaozdravujúco predĺžia dozadu, keď v
-// DB existuje otvorená objednávka staršia než predvolené 90-dňové okno
-// (`backfill.ts`). CSV import (`exportDateFrom`, #492) na najstaršiu OTVORENÚ
-// objednávku BEZ ohľadu na id — inak jej `status_name` navždy zamrzne
-// (objednávka vybavená v Shoptete AŽ PO vypadnutí z okna zostane v appke
-// "Vybavuje sa" a visí v "Na objednanie", napr. 20260739; CSV je jediná cesta
-// osviežujúca status). XML id-fetch (`idsDateFrom`, #132) na najstaršiu
-// otvorenú BEZ `shoptet_order_id` — počítané z predvoleného okna, aby #132
-// správanie ostalo nezmenené.
+// DB existuje otvorená objednávka staršia než predvolené 90-dňové okno. CSV
+// import (`exportDateFrom`, #492) na najstaršiu OTVORENÚ objednávku BEZ ohľadu
+// na id — inak jej `status_name` navždy zamrzne (objednávka vybavená v Shoptete
+// AŽ PO vypadnutí z okna zostane v appke "Vybavuje sa" a visí v "Na objednanie",
+// napr. 20260739; CSV je jediná cesta osviežujúca status). XML id-fetch
+// (`idsDateFrom`, #132) na najstaršiu otvorenú BEZ `shoptet_order_id`, z
+// predvoleného okna (nezmenené #132). Oba počíta JEDEN zdroj pravdy
+// `computeOrdersIngestWindows` (`backfill.ts`) — zdieľaný s `cli/orders-ingest.ts`.
 const runOrdersIngest: RunOrdersIngest | undefined =
   ordersUrl === undefined
     ? undefined
     : async (now: Date) => {
-        const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
-        const exportDateFrom = await computeOrdersExportWindowStart(db, dateFrom);
-        const idsDateFrom = ordersXmlUrl === undefined ? dateFrom : await computeOrderIdsWindowStart(db, dateFrom);
+        const { exportDateFrom, idsDateFrom, dateUntil } = await computeOrdersIngestWindows(db, now, {
+          hasXmlUrl: ordersXmlUrl !== undefined,
+        });
         return ingestOrders(db, {
           fetchExport: createHttpOrdersExportFetcher({ url: ordersUrl, dateFrom: exportDateFrom, dateUntil }),
           now,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,7 +12,7 @@ import { createNextEventService } from "./modules/calendar/service.js";
 import { createHttpExportFetcher } from "./modules/catalog/fetcher.js";
 import { ingestCatalog } from "./modules/catalog/ingest.js";
 import { createSmtpMailTransport } from "./modules/mail/transport.js";
-import { computeOrderIdsWindowStart } from "./modules/orders/backfill.js";
+import { computeOrderIdsWindowStart, computeOrdersExportWindowStart } from "./modules/orders/backfill.js";
 import { computeImportWindow, createHttpOrderIdsFetcher, createHttpOrdersExportFetcher } from "./modules/orders/fetcher.js";
 import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS, ingestOrders, type RunOrdersIngest } from "./modules/orders/ingest.js";
 import { createHttpTrackingClient } from "./modules/posta-uncollected/tracking-client.js";
@@ -96,24 +96,27 @@ const ordersUrl = env.SHOPTET_ORDERS_URL;
 // `runIngest`/`runOrdersIngest` vyššie) — `ingestOrders` to sama osebe berie
 // ako "id zatiaľ neznáme", nikdy ako chybu.
 const ordersXmlUrl = env.SHOPTET_ORDERS_XML_URL;
-// issue 132: XML id-fetch okno (LEN preň, nikdy pre hlavný CSV import vyššie
-// — ten má vlastnú, nezávislú akceptančnú logiku, `.claude/rules/orders.md`)
-// sa sebaozdravujúco predĺži dozadu, keď v DB existuje otvorená objednávka
-// bez `shoptet_order_id` staršia než predvolené 90-dňové okno
-// (`backfill.ts`'s `computeOrderIdsWindowStart`) — inak taká objednávka
-// (napr. 20260739/20260740) nikdy nedostane svoje id, hoci Shoptet ho má a
-// objednávka ostáva otvorená.
+// issue 132/492: obe importné okná sa sebaozdravujúco predĺžia dozadu, keď v
+// DB existuje otvorená objednávka staršia než predvolené 90-dňové okno
+// (`backfill.ts`). CSV import (`exportDateFrom`, #492) na najstaršiu OTVORENÚ
+// objednávku BEZ ohľadu na id — inak jej `status_name` navždy zamrzne
+// (objednávka vybavená v Shoptete AŽ PO vypadnutí z okna zostane v appke
+// "Vybavuje sa" a visí v "Na objednanie", napr. 20260739; CSV je jediná cesta
+// osviežujúca status). XML id-fetch (`idsDateFrom`, #132) na najstaršiu
+// otvorenú BEZ `shoptet_order_id` — počítané z predvoleného okna, aby #132
+// správanie ostalo nezmenené.
 const runOrdersIngest: RunOrdersIngest | undefined =
   ordersUrl === undefined
     ? undefined
     : async (now: Date) => {
         const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
+        const exportDateFrom = await computeOrdersExportWindowStart(db, dateFrom);
         const idsDateFrom = ordersXmlUrl === undefined ? dateFrom : await computeOrderIdsWindowStart(db, dateFrom);
         return ingestOrders(db, {
-          fetchExport: createHttpOrdersExportFetcher({ url: ordersUrl, dateFrom, dateUntil }),
+          fetchExport: createHttpOrdersExportFetcher({ url: ordersUrl, dateFrom: exportDateFrom, dateUntil }),
           now,
           rawDir: env.ORDERS_RAW_DIR,
-          windowStart: dateFrom,
+          windowStart: exportDateFrom,
           windowEnd: dateUntil,
           // issue 269: odkaz priamo na objednávku vo vrátkovej karte na
           // Upozorneniach — rovnaká premenná ako `postaUncollectedDeps`/

--- a/apps/api/src/modules/orders/backfill.ts
+++ b/apps/api/src/modules/orders/backfill.ts
@@ -1,7 +1,12 @@
 import { and, inArray, isNull, sql, type SQL } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orders } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { computeImportWindow } from "./fetcher.js";
+import { DEFAULT_ORDERS_IMPORT_WINDOW_DAYS } from "./ingest.js";
 import { listOpenStatusNames } from "./open-statuses.js";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // issue 132 + 492: `createHttpOrderIdsFetcher` AJ `createHttpOrdersExportFetcher`
 // (fetcher.ts) dostávajú `dateFrom`/`dateUntil` z `computeImportWindow` —
@@ -94,10 +99,56 @@ export async function computeOrdersExportWindowStart(
   db: Pick<Database, "select">,
   defaultDateFrom: Date,
 ): Promise<Date> {
-  return extendWindowStartBack(await findOldestOpenOrder(db), defaultDateFrom);
+  const oldest = await findOldestOpenOrder(db);
+  const start = extendWindowStartBack(oldest, defaultDateFrom);
+  // comprehensive-logging: keď sa okno reálne rozšíri, zaznač PREČO a O KOĽKO —
+  // pri diagnostike "prečo import ťahá 200 dní" je kľúčové vidieť, KTORÁ otvorená
+  // objednávka okno drží (napr. objednávka zmazaná v Shoptete, ktorá by ho držala
+  // predĺžené donekonečna). Nad 365 dní je to takmer isto taký prípad → warn.
+  if (oldest !== null && start.getTime() < defaultDateFrom.getTime()) {
+    const extraDays = Math.round((defaultDateFrom.getTime() - start.getTime()) / MS_PER_DAY);
+    const detail = {
+      oldestOpenPlacedAt: oldest.toISOString(),
+      defaultDateFrom: defaultDateFrom.toISOString(),
+      extraDays,
+    };
+    if (extraDays > 365) {
+      log.warn(detail, "okno CSV importu predĺžené o viac než 365 dní — možno objednávka otvorená v appke, ktorá už v Shoptete neexistuje");
+    } else {
+      log.info(detail, "okno CSV importu predĺžené dozadu, aby zachytilo staršiu otvorenú objednávku (osvieženie stavu, #492)");
+    }
+  }
+  return start;
 }
 
 function extendWindowStartBack(oldest: Date | null, defaultDateFrom: Date): Date {
   if (oldest !== null && oldest.getTime() < defaultDateFrom.getTime()) return oldest;
   return defaultDateFrom;
+}
+
+/**
+ * issue 492: JEDINÝ zdroj pravdy pre okná importu objednávok — DRY-uje inak
+ * duplikovanú (a NETESTOVANÚ) drôtovú logiku z `cli/orders-ingest.ts` aj
+ * `index.ts`, aby sa už NIKDY nemohli rozísť (a aby ju šlo unit-testovať —
+ * presne trieda tichého regresu, ktorý #492 spôsobil). `exportDateFrom` (CSV
+ * export + `windowStart` akceptačnej brány) sa rozšíri na najstaršiu OTVORENÚ
+ * objednávku (#492); `idsDateFrom` (XML id-fetch) LEN keď existuje XML URL, a
+ * počítané z PREDVOLENÉHO okna (nezmenené #132 správanie). `dateUntil` je
+ * spoločné pre oba fetche.
+ */
+export interface OrdersIngestWindows {
+  readonly exportDateFrom: Date;
+  readonly idsDateFrom: Date;
+  readonly dateUntil: Date;
+}
+
+export async function computeOrdersIngestWindows(
+  db: Pick<Database, "select">,
+  now: Date,
+  opts: { readonly hasXmlUrl: boolean },
+): Promise<OrdersIngestWindows> {
+  const { dateFrom, dateUntil } = computeImportWindow(now, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
+  const exportDateFrom = await computeOrdersExportWindowStart(db, dateFrom);
+  const idsDateFrom = opts.hasXmlUrl ? await computeOrderIdsWindowStart(db, dateFrom) : dateFrom;
+  return { exportDateFrom, idsDateFrom, dateUntil };
 }

--- a/apps/api/src/modules/orders/backfill.ts
+++ b/apps/api/src/modules/orders/backfill.ts
@@ -1,38 +1,46 @@
-import { and, inArray, isNull, sql } from "drizzle-orm";
+import { and, inArray, isNull, sql, type SQL } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { orders } from "../../db/schema.js";
 import { listOpenStatusNames } from "./open-statuses.js";
 
-// issue 132: `createHttpOrderIdsFetcher` (fetcher.ts) dostáva PEVNÉ
-// `dateFrom`/`dateUntil` z `computeImportWindow` — presne to isté posúvajúce
-// sa 90-dňové okno, aké používa aj hlavný CSV import. Keďže sa okno vždy
-// počíta od `now`, objednávka staršia než 90 dní sa do XML exportu (jediný
-// zdroj `order.shoptet_order_id`, issue 120) UŽ NIKDY nedostane — aj keď je
-// stále otvorená ("Na objednanie") a aj keď Shoptet jej id má. Funkcie nižšie
-// zisťujú, či taká objednávka existuje, a o koľko treba okno IBA pre XML
-// id-fetch (nikdy pre hlavný CSV import — ten má vlastnú, nezávislú
-// akceptančnú logiku voči `previousLineRatio`, `.claude/rules/orders.md`,
-// ktorú netreba meniť) predĺžiť dozadu, aby ju zachytil.
+// issue 132 + 492: `createHttpOrderIdsFetcher` AJ `createHttpOrdersExportFetcher`
+// (fetcher.ts) dostávajú `dateFrom`/`dateUntil` z `computeImportWindow` —
+// posúvajúce sa 90-dňové okno počítané od `now`, takže objednávka staršia než
+// 90 dní z exportu UŽ NIKDY nevypadne. To spôsobuje DVE nezávislé straty:
+//   - #132: XML export (jediný zdroj `order.shoptet_order_id`) taku objednávku
+//     nezachytí — id navždy chýba, aj keď je otvorená.
+//   - #492: CSV export (jediná cesta osviežujúca `order.status_name`, #59) ju
+//     nezachytí — status zamrzne (napr. objednávka vybavená v Shoptete AŽ PO
+//     vypadnutí z okna zostane v appke navždy "Vybavuje sa" a visí v "Na
+//     objednanie", napr. 20260739).
+// Funkcie nižšie zisťujú, o koľko treba okno predĺžiť dozadu, aby zachytilo
+// takú objednávku — samostatne pre XML id-fetch (`computeOrderIdsWindowStart`,
+// LEN otvorené BEZ id) a pre CSV import (`computeOrdersExportWindowStart`,
+// KAŽDÁ otvorená — presne prípad #492, kde 20260739 svoje id UŽ MÁ, ale status
+// je zamrznutý). CSV rozšírenie nechá `previousLineRatio` akceptačnú bránu
+// (`ingest.ts`) apples-to-apples: aj `windowStart` (počítadlo DB riadkov) aj
+// stiahnutý export sa rozšíria SPOLU, takže pomer sa zachová.
 
 /**
  * Najstarší `placedAt` medzi OTVORENÝMI objednávkami (rovnaká definícia
- * "otvorená" ako "Na objednanie" — `orders.statusName` v
- * `listOpenStatusNames()`), ktorým chýba `shoptet_order_id`. `null`, keď
- * žiadna taká objednávka neexistuje (nič nechýba, alebo nie je nastavený
- * žiadny otvorený stav — rovnaký guard ako `queries.ts`'s
- * `listOpenOrderLinesBySupplier`, `inArray` s prázdnym poľom by nemalo podľa
- * čoho filtrovať).
+ * "otvorená" ako "Na objednanie" — `orders.statusName` v `listOpenStatusNames()`)
+ * spĺňajúcimi voliteľný `extra` predikát. `null`, keď žiadna taká objednávka
+ * neexistuje (nič nechýba, alebo nie je nastavený žiadny otvorený stav —
+ * rovnaký guard ako `queries.ts`'s `listOpenOrderLinesBySupplier`, `inArray` s
+ * prázdnym poľom by nemalo podľa čoho filtrovať).
  */
-export async function findOldestOpenOrderMissingShoptetId(
+async function oldestOpenOrderPlacedAt(
   db: Pick<Database, "select">,
+  extra?: SQL,
 ): Promise<Date | null> {
   const openStatuses = await listOpenStatusNames(db);
   if (openStatuses.length === 0) return null;
 
+  const openFilter = inArray(orders.statusName, [...openStatuses]);
   const [row] = await db
     .select({ oldest: sql<string | null>`min(${orders.placedAt})` })
     .from(orders)
-    .where(and(isNull(orders.shoptetOrderId), inArray(orders.statusName, [...openStatuses])));
+    .where(extra === undefined ? openFilter : and(extra, openFilter));
   // `min()` cez raw `sql` šablónu neprejde drizzle-ovým stĺpcovým mapperom
   // (ten by `timestamp` normálne vrátil ako `Date`) — pg driver ho preto
   // vracia ako ISO reťazec, nie `Date` objekt. Explicitná konverzia tu, nie
@@ -41,19 +49,55 @@ export async function findOldestOpenOrderMissingShoptetId(
 }
 
 /**
- * Počiatok okna PRE XML id-fetch (`createHttpOrderIdsFetcher`'s
- * `dateFrom`) — nikdy nezúži `defaultDateFrom` (predvolené 90-dňové okno,
- * `computeImportWindow`), len ho voliteľne predĺži dozadu, aby zachytil
- * KAŽDÚ dnes otvorenú objednávku, ktorej id ešte chýba. Sebaozdravujúce:
- * kým je objednávka otvorená A chýba jej id, okno ju zachytáva pri každom
- * behu; len čo id raz zistí, `ingestOrders`'s `COALESCE` zápis ho už
- * navždy chráni a okno sa pre ňu ďalej netýka.
+ * issue 132: najstaršia OTVORENÁ objednávka, ktorej chýba `shoptet_order_id`
+ * (podmnožina otvorených). Pre XML id-fetch okno.
+ */
+export function findOldestOpenOrderMissingShoptetId(db: Pick<Database, "select">): Promise<Date | null> {
+  return oldestOpenOrderPlacedAt(db, isNull(orders.shoptetOrderId));
+}
+
+/**
+ * issue 492: najstaršia OTVORENÁ objednávka BEZ ohľadu na id — každá otvorená
+ * objednávka staršia než okno má zamrznutý status_name (CSV import ju
+ * neosviežuje). Pre CSV import okno. Nadmnožina `findOldestOpenOrderMissingShoptetId`.
+ */
+export function findOldestOpenOrder(db: Pick<Database, "select">): Promise<Date | null> {
+  return oldestOpenOrderPlacedAt(db);
+}
+
+/**
+ * Počiatok okna PRE XML id-fetch (`createHttpOrderIdsFetcher`'s `dateFrom`) —
+ * nikdy nezúži `defaultDateFrom` (predvolené 90-dňové okno, `computeImportWindow`),
+ * len ho voliteľne predĺži dozadu, aby zachytil KAŽDÚ dnes otvorenú objednávku,
+ * ktorej id ešte chýba. Sebaozdravujúce: kým je objednávka otvorená A chýba jej
+ * id, okno ju zachytáva pri každom behu; len čo id raz zistí, `ingestOrders`'s
+ * `COALESCE` zápis ho už navždy chráni a okno sa pre ňu ďalej netýka.
  */
 export async function computeOrderIdsWindowStart(
   db: Pick<Database, "select">,
   defaultDateFrom: Date,
 ): Promise<Date> {
-  const oldestMissing = await findOldestOpenOrderMissingShoptetId(db);
-  if (oldestMissing !== null && oldestMissing.getTime() < defaultDateFrom.getTime()) return oldestMissing;
+  return extendWindowStartBack(await findOldestOpenOrderMissingShoptetId(db), defaultDateFrom);
+}
+
+/**
+ * issue 492: počiatok okna PRE CSV import (`createHttpOrdersExportFetcher`'s
+ * `dateFrom` A `windowStart` akceptačnej brány) — nikdy nezúži `defaultDateFrom`,
+ * len ho voliteľne predĺži dozadu na najstaršiu OTVORENÚ objednávku, aby sa jej
+ * `status_name` zosúladil so Shoptetom aj keď vypadla z 90-dňového okna.
+ * Sebaozdravujúce: kým je objednávka otvorená, okno ju pri každom behu zachytáva
+ * a status osviežuje; keď ju Shoptet vybaví, ďalší import ju osvieži na terminálny
+ * stav a vypadne z otvorenej množiny (→ prestane predlžovať okno). Žiadna
+ * heuristika "staré = vybavené" — status sa vždy preberá zo Shoptetu.
+ */
+export async function computeOrdersExportWindowStart(
+  db: Pick<Database, "select">,
+  defaultDateFrom: Date,
+): Promise<Date> {
+  return extendWindowStartBack(await findOldestOpenOrder(db), defaultDateFrom);
+}
+
+function extendWindowStartBack(oldest: Date | null, defaultDateFrom: Date): Date {
+  if (oldest !== null && oldest.getTime() < defaultDateFrom.getTime()) return oldest;
   return defaultDateFrom;
 }

--- a/apps/api/src/modules/orders/ingest.ts
+++ b/apps/api/src/modules/orders/ingest.ts
@@ -440,12 +440,16 @@ export async function ingestOrders(db: Database, options: OrdersIngestOptions): 
         for (const row of inserted) orderIdByExternalId.set(row.externalOrderId, row.id);
       }
 
-      // issue 132: `orderIdsByCode` (best-effort XML fetch, prípadne
-      // ROZŠÍRENÉ za CSV okno cez `backfill.ts`'s `computeOrderIdsWindowStart`
+      // issue 132: `orderIdsByCode` (best-effort XML fetch, `dateFrom`
+      // ROZŠÍRENÝ za predvolené okno cez `backfill.ts`'s `computeOrderIdsWindowStart`
       // — pozri `index.ts`/`cli/orders-ingest.ts`) môže poznať objednávku,
-      // ktorá v TOMTO behu CSV vôbec NIE JE (staršia než jeho vlastné,
-      // NEROZŠÍRENÉ okno — CSV okno sa zámerne nemení, aby sa nedotkla
-      // `previousLineRatio` akceptančná logika vyššie). Bez tohto kroku by
+      // ktorá v TOMTO behu CSV vôbec NIE JE. Od #492 sa AJ CSV okno
+      // sebaozdravujúco rozširuje (`computeOrdersExportWindowStart`, na
+      // NADMNOŽINU XML okna — najstaršia OTVORENÁ objednávka bez ohľadu na id),
+      // takže táto vetva je v praxi takmer mŕtva (objednávku, ktorú pozná XML,
+      // zvyčajne teraz nesie aj CSV) — ponechaná ZÁMERNE ako obrana pre prípad,
+      // že by XML poznal objednávku mimo CSV obsahu (napr. zmazaná/vymenená
+      // v CSV, ale ešte v XML histórii). Bez tohto kroku by
       // upsert cyklus vyššie (ktorý ide LEN cez `orderInfo`, postavené z CSV)
       // taký záznam nikdy nenavštívil, takže jeho `shoptetOrderId` by sa
       // nikdy nezapísal, hoci XML mapa ho pozná. Priamy `UPDATE` namiesto

--- a/apps/api/tests/orders-status-backfill.integration.test.ts
+++ b/apps/api/tests/orders-status-backfill.integration.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -137,13 +136,17 @@ function buildCsv(rows: readonly Record<string, string>[]): Buffer {
 
 // Simuluje Shoptet-ov `dateFrom` filter: STARÁ objednávka (30.4, teraz už
 // "Vybavená") je v exporte LEN keď stiahnuté okno siaha po ňu; ČERSTVÁ
-// objednávka je v exporte vždy (drží akceptačnú bránu zdravú).
-const STARA_DATE = new Date("2026-04-30T10:00:00Z");
+// objednávka je v exporte vždy (drží akceptačnú bránu zdravú). `WINDOW_THRESHOLD`
+// je bod MEDZI dátumom starej objednávky (30.4) a začiatkom predvoleného
+// 90-dňového okna (~28.5 pri NOW=26.8) — NIE presný placed_at (ten je po
+// TZ prevode 30.4 13:45 UTC, nie 10:00), takže prah drží obe strany jasne
+// oddelené bez ohľadu na presný čas.
+const WINDOW_THRESHOLD = new Date("2026-05-10T00:00:00Z");
 function windowAwareFetcher(dateFrom: Date): OrdersExportFetcher {
   const rows: Record<string, string>[] = [
     { code: "9210", date: "2026-08-20 09:00:00", statusName: "Vybavuje sa", billFullName: "Cerstva", itemName: "T", itemAmount: "1", itemCode: "40237/XL" },
   ];
-  if (dateFrom.getTime() <= STARA_DATE.getTime()) {
+  if (dateFrom.getTime() <= WINDOW_THRESHOLD.getTime()) {
     rows.push({ code: "20260739", date: "2026-04-30 15:45:25", statusName: "Vybavena", billFullName: "Andrej", itemName: "T", itemAmount: "1", itemCode: "40237/XL" });
   }
   return () => Promise.resolve({ body: buildCsv(rows), sourceLabel: "fixtúra" });
@@ -179,7 +182,7 @@ it("BUG: pevné 90-dňové okno necháva starú vybavenú objednávku zamrznutú
 
   // pevné okno (predfixové správanie): dateFrom ~28.5, stará objednávka (30.4) mimo neho
   const { dateFrom, dateUntil } = computeImportWindow(NOW, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
-  expect(dateFrom.getTime()).toBeGreaterThan(STARA_DATE.getTime()); // 30.4 je PRED oknom
+  expect(dateFrom.getTime()).toBeGreaterThan(WINDOW_THRESHOLD.getTime()); // okno nesiaha po 30.4 → export ju vynechá
   await ingestOrders(db, { fetchExport: windowAwareFetcher(dateFrom), now: NOW, rawDir: dir, windowStart: dateFrom, windowEnd: dateUntil });
 
   const [old] = await db.select().from(orders).where(eq(orders.externalOrderId, "20260739"));
@@ -193,7 +196,7 @@ it("FIX: sebaozdravujúce okno CSV importu dočíta starú objednávku a osviež
 
   const { dateFrom: defaultFrom, dateUntil } = computeImportWindow(NOW, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
   const exportFrom = await computeOrdersExportWindowStart(db, defaultFrom);
-  expect(exportFrom.getTime()).toBeLessThanOrEqual(STARA_DATE.getTime()); // predĺžené na 30.4
+  expect(exportFrom.getTime()).toBeLessThanOrEqual(WINDOW_THRESHOLD.getTime()); // predĺžené po 30.4 → export ju zachytí
   await ingestOrders(db, { fetchExport: windowAwareFetcher(exportFrom), now: NOW, rawDir: dir, windowStart: exportFrom, windowEnd: dateUntil });
 
   const [old] = await db.select().from(orders).where(eq(orders.externalOrderId, "20260739"));

--- a/apps/api/tests/orders-status-backfill.integration.test.ts
+++ b/apps/api/tests/orders-status-backfill.integration.test.ts
@@ -7,6 +7,7 @@ import { orders } from "../src/db/schema.js";
 import { DEFAULT_ORDER_OPEN_STATUS, listOpenStatusNames } from "../src/modules/orders/open-statuses.js";
 import {
   computeOrdersExportWindowStart,
+  computeOrdersIngestWindows,
   findOldestOpenOrder,
 } from "../src/modules/orders/backfill.js";
 import { computeImportWindow } from "../src/modules/orders/fetcher.js";
@@ -121,6 +122,56 @@ it("computeOrdersExportWindowStart NEROZŠÍRI, keď je uzavretá stará objedn�
   });
 
   expect(await computeOrdersExportWindowStart(ctx.db, DEFAULT_DATE_FROM)).toEqual(DEFAULT_DATE_FROM);
+});
+
+// --- unit: computeOrdersIngestWindows (zdieľaný zdroj pravdy drôtovania CLI+scheduler) ---
+
+const NOW_WINDOWS = new Date("2026-08-26T10:00:00Z");
+
+it("computeOrdersIngestWindows: bez otvorených objednávok → obe okná = predvolené 90-dňové", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const { dateFrom, dateUntil } = computeImportWindow(NOW_WINDOWS);
+
+  const w = await computeOrdersIngestWindows(ctx.db, NOW_WINDOWS, { hasXmlUrl: true });
+  expect(w.exportDateFrom).toEqual(dateFrom);
+  expect(w.idsDateFrom).toEqual(dateFrom);
+  expect(w.dateUntil).toEqual(dateUntil);
+});
+
+it("computeOrdersIngestWindows: stará otvorená objednávka (s id) rozšíri exportDateFrom; idsDateFrom ostane predvolené (bez XML)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const stara = new Date("2026-04-30T10:00:00Z"); // > 90 dní pred NOW_WINDOWS
+  await ctx.db.insert(orders).values({
+    externalOrderId: "20260739",
+    customerName: "Andrej Praskač",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: stara,
+    shoptetOrderId: 58184, // MÁ id → #132 XML okno by ho nechalo tak
+  });
+  const { dateFrom } = computeImportWindow(NOW_WINDOWS);
+
+  const w = await computeOrdersIngestWindows(ctx.db, NOW_WINDOWS, { hasXmlUrl: false });
+  expect(w.exportDateFrom.toISOString()).toBe(stara.toISOString()); // CSV okno rozšírené (#492)
+  expect(w.idsDateFrom).toEqual(dateFrom); // bez XML URL → predvolené
+});
+
+it("computeOrdersIngestWindows: stará otvorená BEZ id + XML → OBE okná rozšírené", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const stara = new Date("2026-04-30T10:00:00Z");
+  await ctx.db.insert(orders).values({
+    externalOrderId: "20260740",
+    customerName: "Zákazník X",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: stara,
+    shoptetOrderId: null, // chýba id → #132 okno ju TIEŽ zachytí
+  });
+
+  const w = await computeOrdersIngestWindows(ctx.db, NOW_WINDOWS, { hasXmlUrl: true });
+  expect(w.exportDateFrom.toISOString()).toBe(stara.toISOString());
+  expect(w.idsDateFrom.toISOString()).toBe(stara.toISOString());
 });
 
 // --- end-to-end: stale-status cesta cez ingestOrders + okno-vedomý fetcher ---

--- a/apps/api/tests/orders-status-backfill.integration.test.ts
+++ b/apps/api/tests/orders-status-backfill.integration.test.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { orders } from "../src/db/schema.js";
+import { DEFAULT_ORDER_OPEN_STATUS, listOpenStatusNames } from "../src/modules/orders/open-statuses.js";
+import {
+  computeOrdersExportWindowStart,
+  findOldestOpenOrder,
+} from "../src/modules/orders/backfill.js";
+import { computeImportWindow } from "../src/modules/orders/fetcher.js";
+import {
+  DEFAULT_ORDERS_IMPORT_WINDOW_DAYS,
+  ingestOrders,
+  type OrdersExportFetcher,
+} from "../src/modules/orders/ingest.js";
+import { insertTestVariant } from "./helpers/orders.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 492: objednávka vybavená v Shoptete AŽ PO vypadnutí z 90-dňového
+// kĺzavého okna sa už nikdy neosviežila — `order.status_name` (jediná cesta
+// osviežovania je CSV import, #59) zamrzol na "Vybavuje sa" a riadok navždy
+// visel v "Na objednanie" (20260739). Tieto testy overujú novú `backfill.ts`
+// logiku, ktorá okno CSV importu sebaozdravujúco predĺži dozadu, kým existuje
+// OTVORENÁ objednávka staršia než predvolené okno — vzor issue 132
+// (`computeOrderIdsWindowStart`), ale bez id-filtra: záleží na KAŽDEJ otvorenej
+// objednávke, aj tej, čo svoje `shoptet_order_id` už MÁ (presne prípad 20260739).
+
+let close: (() => Promise<void>) | undefined;
+let rawDir: string | undefined;
+
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  if (rawDir !== undefined) await rm(rawDir, { recursive: true, force: true });
+  rawDir = undefined;
+});
+
+const DEFAULT_DATE_FROM = new Date("2026-05-03T00:00:00Z");
+
+// --- unit: findOldestOpenOrder / computeOrdersExportWindowStart ---
+
+it("findOldestOpenOrder vráti null, keď žiadna otvorená objednávka neexistuje", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values({
+    externalOrderId: "9201",
+    customerName: "Zákazník A",
+    statusName: "Vybavená", // uzavretá — mimo open-statuses
+    placedAt: new Date("2026-01-01T00:00:00Z"),
+    shoptetOrderId: 111,
+  });
+
+  expect(await findOldestOpenOrder(ctx.db)).toBeNull();
+});
+
+it("findOldestOpenOrder NÁJDE najstaršiu otvorenú objednávku aj keď MÁ shoptet_order_id (na rozdiel od #132)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values([
+    {
+      externalOrderId: "20260739",
+      customerName: "Andrej Praskač",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-04-30T10:00:00Z"),
+      shoptetOrderId: 58184, // MÁ id — #132's findOldestOpenOrderMissingShoptetId by ho preskočil
+    },
+    {
+      externalOrderId: "20260819",
+      customerName: "Martina Šandor",
+      statusName: DEFAULT_ORDER_OPEN_STATUS,
+      placedAt: new Date("2026-05-14T10:00:00Z"),
+      shoptetOrderId: 58422,
+    },
+  ]);
+
+  const oldest = await findOldestOpenOrder(ctx.db);
+  expect(oldest?.toISOString()).toBe(new Date("2026-04-30T10:00:00Z").toISOString());
+});
+
+it("computeOrdersExportWindowStart NEZUŽUJE predvolené okno, keď žiadna otvorená objednávka nie je staršia", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values({
+    externalOrderId: "9202",
+    customerName: "Zákazník B",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: new Date("2026-06-01T10:00:00Z"), // vnútri okna
+    shoptetOrderId: 222,
+  });
+
+  expect(await computeOrdersExportWindowStart(ctx.db, DEFAULT_DATE_FROM)).toEqual(DEFAULT_DATE_FROM);
+});
+
+it("computeOrdersExportWindowStart PREDĹŽI okno dozadu na staršiu otvorenú objednávku (aj s id)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  const stara = new Date("2026-04-30T10:00:00Z"); // staršia než DEFAULT_DATE_FROM
+  await ctx.db.insert(orders).values({
+    externalOrderId: "20260739",
+    customerName: "Andrej Praskač",
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: stara,
+    shoptetOrderId: 58184,
+  });
+
+  const windowStart = await computeOrdersExportWindowStart(ctx.db, DEFAULT_DATE_FROM);
+  expect(windowStart.toISOString()).toBe(stara.toISOString());
+});
+
+it("computeOrdersExportWindowStart NEROZŠÍRI, keď je uzavretá stará objednávka (mimo open-statuses)", async () => {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(orders).values({
+    externalOrderId: "9203",
+    customerName: "Zákazník C",
+    statusName: "Vybavená", // stará ALE uzavretá — nemá sa čo dočítavať
+    placedAt: new Date("2026-01-01T00:00:00Z"),
+    shoptetOrderId: 333,
+  });
+
+  expect(await computeOrdersExportWindowStart(ctx.db, DEFAULT_DATE_FROM)).toEqual(DEFAULT_DATE_FROM);
+});
+
+// --- end-to-end: stale-status cesta cez ingestOrders + okno-vedomý fetcher ---
+
+const HEADER = ["code", "date", "statusName", "billFullName", "itemName", "itemAmount", "itemCode"] as const;
+
+function buildCsv(rows: readonly Record<string, string>[]): Buffer {
+  const esc = (v: string): string => `"${v.replaceAll('"', '""')}"`;
+  const lines = [HEADER.map(esc).join(";") + ";"];
+  for (const row of rows) lines.push(HEADER.map((c) => esc(row[c] ?? "")).join(";") + ";");
+  return Buffer.from(lines.join("\r\n") + "\r\n", "utf-8");
+}
+
+// Simuluje Shoptet-ov `dateFrom` filter: STARÁ objednávka (30.4, teraz už
+// "Vybavená") je v exporte LEN keď stiahnuté okno siaha po ňu; ČERSTVÁ
+// objednávka je v exporte vždy (drží akceptačnú bránu zdravú).
+const STARA_DATE = new Date("2026-04-30T10:00:00Z");
+function windowAwareFetcher(dateFrom: Date): OrdersExportFetcher {
+  const rows: Record<string, string>[] = [
+    { code: "9210", date: "2026-08-20 09:00:00", statusName: "Vybavuje sa", billFullName: "Cerstva", itemName: "T", itemAmount: "1", itemCode: "40237/XL" },
+  ];
+  if (dateFrom.getTime() <= STARA_DATE.getTime()) {
+    rows.push({ code: "20260739", date: "2026-04-30 15:45:25", statusName: "Vybavena", billFullName: "Andrej", itemName: "T", itemAmount: "1", itemCode: "40237/XL" });
+  }
+  return () => Promise.resolve({ body: buildCsv(rows), sourceLabel: "fixtúra" });
+}
+
+async function boot(): Promise<{ db: Awaited<ReturnType<typeof withCleanDb>>["db"]; dir: string }> {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  rawDir = await mkdtemp(join(tmpdir(), "forestshop-orders-status-"));
+  return { db: ctx.db, dir: rawDir };
+}
+
+const NOW = new Date("2026-08-26T10:00:00Z");
+const WIDE_START = new Date("2020-01-01T00:00:00Z");
+const WIDE_END = new Date("2030-01-01T00:00:00Z");
+
+// Založí starú OTVORENÚ objednávku (30.4, "Vybavuje sa") + čerstvú, tak ako by
+// ich appka mala z čias, keď boli obe ešte v okne.
+async function seedFrozenOldOrder(db: Awaited<ReturnType<typeof withCleanDb>>["db"], dir: string): Promise<void> {
+  await insertTestVariant(db, "40237/XL");
+  const seed = buildCsv([
+    { code: "9210", date: "2026-08-20 09:00:00", statusName: "Vybavuje sa", billFullName: "Cerstva", itemName: "T", itemAmount: "1", itemCode: "40237/XL" },
+    { code: "20260739", date: "2026-04-30 15:45:25", statusName: "Vybavuje sa", billFullName: "Andrej", itemName: "T", itemAmount: "1", itemCode: "40237/XL" },
+  ]);
+  await ingestOrders(db, { fetchExport: () => Promise.resolve({ body: seed, sourceLabel: "seed" }), now: NOW, rawDir: dir, windowStart: WIDE_START, windowEnd: WIDE_END });
+  const [seeded] = await db.select().from(orders).where(eq(orders.externalOrderId, "20260739"));
+  expect(seeded?.statusName).toBe("Vybavuje sa");
+}
+
+it("BUG: pevné 90-dňové okno necháva starú vybavenú objednávku zamrznutú v 'Vybavuje sa'", async () => {
+  const { db, dir } = await boot();
+  await seedFrozenOldOrder(db, dir);
+
+  // pevné okno (predfixové správanie): dateFrom ~28.5, stará objednávka (30.4) mimo neho
+  const { dateFrom, dateUntil } = computeImportWindow(NOW, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
+  expect(dateFrom.getTime()).toBeGreaterThan(STARA_DATE.getTime()); // 30.4 je PRED oknom
+  await ingestOrders(db, { fetchExport: windowAwareFetcher(dateFrom), now: NOW, rawDir: dir, windowStart: dateFrom, windowEnd: dateUntil });
+
+  const [old] = await db.select().from(orders).where(eq(orders.externalOrderId, "20260739"));
+  expect(old?.statusName).toBe("Vybavuje sa"); // ZAMRZNUTÉ — export ju nezachytil
+  expect(await listOpenStatusNames(db)).toContain(old?.statusName); // stále "otvorená"
+});
+
+it("FIX: sebaozdravujúce okno CSV importu dočíta starú objednávku a osvieži ju na 'Vybavená'", async () => {
+  const { db, dir } = await boot();
+  await seedFrozenOldOrder(db, dir);
+
+  const { dateFrom: defaultFrom, dateUntil } = computeImportWindow(NOW, DEFAULT_ORDERS_IMPORT_WINDOW_DAYS);
+  const exportFrom = await computeOrdersExportWindowStart(db, defaultFrom);
+  expect(exportFrom.getTime()).toBeLessThanOrEqual(STARA_DATE.getTime()); // predĺžené na 30.4
+  await ingestOrders(db, { fetchExport: windowAwareFetcher(exportFrom), now: NOW, rawDir: dir, windowStart: exportFrom, windowEnd: dateUntil });
+
+  const [old] = await db.select().from(orders).where(eq(orders.externalOrderId, "20260739"));
+  // ASCII "Vybavena" v CSV (buildCsv je UTF-8, ingest dekóduje cp1250 → diakritika
+  // by bola mojibake, rovnaký dôvod ako v orders-ingest.integration.test.ts); reálny
+  // Shoptet nesie "Vybavená" v cp1250, čo sa dekóduje správne (naživo overené).
+  expect(old?.statusName).toBe("Vybavena"); // osviežené zo Shoptetu (v teste ASCII)
+  expect(await listOpenStatusNames(db)).not.toContain(old?.statusName); // vypadla z "Na objednanie"
+});

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4480,3 +4480,14 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
 - Zamietnuté: (B) per-order Playwright dočítanie stavu (nový krehký scraping),
   (C) natvrdo dlhšie pevné okno (nerieši triedu). Design komentár:
   https://github.com/zbynekdrlik/forestshop-app/issues/492#issuecomment-5423282699
+- Commity: `db6949b` (bump .289 + log), `07acb4f` (RED test), `9fee46e` (GREEN
+  fix), + docs (orders.md playbook + tento log). RED→GREEN:
+  `orders-status-backfill.integration.test.ts` — "computeOrdersExportWindowStart
+  PREDĹŽI okno dozadu na staršiu otvorenú objednávku (aj s id)" + "FIX:
+  sebaozdravujúce okno CSV importu dočíta starú objednávku a osvieži ju na
+  'Vybavená'" (obidva RED na neutralizovanej `computeOrdersExportWindowStart`,
+  overené na izolovanom Postgrese; 7/7 GREEN, #132 backfill + ingest bez regresie).
+- Repair sweep (inherentný): prvý beh po nasadení s predĺženým oknom zosúladí
+  presne 2 zamrznuté staré otvorené objednávky — 20260739 (→ Vybavená, zmizne z
+  Na objednanie) a 20260819 (→ Vybavuje sa, správne ZOSTANE, v Shoptete stále
+  otvorená). Klientove 20260990/20261172 sú vnútri okna, nedotknuté.

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4462,3 +4462,21 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
 - Táto log+playbook finalizácia jazdí na samostatnom docs bump-e
   `0.3.0-dev.287` (rovnaký vzor ako .285 pri issue 484) — ŽIADNA funkčná
   zmena, len dokumentácia; #487/#488 sú funkčne nasadené už na `.286`.
+
+## 2026-08-26 — #492 (zamrznutý stav objednávky po vypadnutí z exportného okna)
+
+- Solo ticket, paralelný fleet round; version bump `0.3.0-dev.289` (prvý commit).
+- Koreň (empiricky overené na forestshop-dev): import objednávok beží s pevným
+  90-dňovým kĺzavým oknom (`computeImportWindow(now,90)`); CSV import je jediná
+  cesta osviežujúca `order.status_name` (#59). Objednávka vybavená v Shoptete AŽ
+  PO vypadnutí z okna sa už nikdy neosvieži → zamrzne na "Vybavuje sa" a visí v
+  Na objednanie. Overené: 20260739 (30.4) v DB "Vybavuje sa", v poslednom exporte
+  chýba; priame stiahnutie so širokým `dateFrom` vracia "Vybavená".
+- Fix (prístup A, vzor #132): sebaozdravujúce okno CSV importu — `findOldestOpenOrder`
+  + `computeOrdersExportWindowStart` v `backfill.ts`; CLI + `index.ts` predĺžia
+  `dateFrom` (aj `windowStart` akceptačnej brány) dozadu na najstaršiu otvorenú
+  objednávku. Repair sweep inherentný: prvý beh po nasadení zosúladí 20260739
+  (→Vybavená, zmizne) aj 20260819 (→zostane). Žiadne mazanie, žiadna heuristika.
+- Zamietnuté: (B) per-order Playwright dočítanie stavu (nový krehký scraping),
+  (C) natvrdo dlhšie pevné okno (nerieši triedu). Design komentár:
+  https://github.com/zbynekdrlik/forestshop-app/issues/492#issuecomment-5423282699

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.287",
+  "version": "0.3.0-dev.289",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Rieši issue 492 — objednávka vybavená v Shoptete visí v „Na objednanie", lebo stav zamrzol po vypadnutí z exportného okna.

## Koreň (empiricky overený)

Import objednávok používa pevné 90-dňové kĺzavé okno (`computeImportWindow(now,90)`); CSV import je jediná cesta osviežujúca `order.status_name` (#59). Objednávka vybavená v Shoptete AŽ PO vypadnutí z okna sa už nikdy neosvieži → stav zamrzne na „Vybavuje sa" a riadok visí v „Na objednanie". Overené na forestshop-dev: 20260739 (30.4) je v DB „Vybavuje sa", v poslednom exporte chýba, ale priame stiahnutie so širokým `dateFrom` vracia „Vybavená".

## Fix

Sebaozdravujúce okno CSV importu (vzor #132): `findOldestOpenOrder` + `computeOrdersExportWindowStart` v `backfill.ts` predĺžia `dateFrom` (aj `windowStart` akceptačnej brány) dozadu na najstaršiu otvorenú objednávku. CLI (`cli/orders-ingest.ts`) aj scheduler (`index.ts`) to používajú. Žiadne mazanie riadkov, žiadna heuristika „staré = vybavené" — stav sa vždy preberá zo Shoptetu.

Repair sweep je inherentný: prvý beh po nasadení zosúladí zamrznuté staré otvorené objednávky (20260739 → Vybavená zmizne; 20260819 → Vybavuje sa, správne zostane).

## Testy

`apps/api/tests/orders-status-backfill.integration.test.ts` — unit testy nových funkcií + end-to-end stale-status cesta (BUG kontrola: pevné okno necháva stav zamrznutý; FIX: predĺžené okno ho osvieži). RED→GREEN overené na izolovanom Postgrese; #132 backfill + ingest + acceptance testy bez regresie. `pnpm gates:local` zelené.

Verzia bump 0.3.0-dev.289. Ticket ostáva OTVORENÝ (plain „issue 492", žiadne zatváracie kľúčové slovo) — zavrie sa ručne AŽ po nasadení a naživo overení.
