### PR TITLE
issue 501 — menu sekcie Vyšívanie + Slavosport (v0.3.0-dev.293); recovery main behu po Actions outage

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -28,6 +28,23 @@ paths:
   to visible = move its entry from `HIDDEN_TABS` to a `NAV` folder — the
   component itself needs no change (`findTab`/`isVisibleTabId` already
   handle both).
+- **A PRÁZDNY priečinok (`NavFolder` s `tabs: []`) je platný placeholder —
+  `Sidebar.tsx` ho vykreslí ako obyčajnú zbaliteľnú hlavičku bez obsahu,
+  žiadny viditeľný prázdny box** (`.folder-head` sa renderuje vždy, telo
+  `.folder-body`/`.tabs` ostane prázdne a nemá rám ani pozadie). Issue 501
+  (nové sekcie „Vyšívanie"/„Slavosport" HNEĎ POD „Eshop", zatiaľ bez funkcií)
+  ich pridalo presne takto — jeden `{ id, label, tabs: [] }` záznam v `NAV`,
+  žiadna zmena `Sidebar.tsx`/`App.tsx`/CSS. `defaultCollapsed` sa NENASTAVILO
+  (štartujú rozbalené ako Dôležité/Eshop), `label` je v prirodzenom tvare
+  (CSS `text-transform: uppercase` na `.folder-head` ho zobrazí veľkými
+  písmenami — do registra sa píše prirodzený tvar). Keď sa neskôr doplní
+  funkcia, stačí pridať záložky do `tabs` toho istého priečinka. **E2E
+  overenie PORADIA priečinkov** (nielen prítomnosti jednotlivých hlavičiek):
+  `page.locator(".side-nav .folder-head .ftitle").allTextContents()` vráti
+  SUROVÝ text priečinkov z registra (CSS `uppercase` neovplyvňuje
+  `textContent`), takže sa porovná `toEqual([...])` s očakávaným poradím —
+  pozri `nav.spec.ts`. Prázdny priečinok nemá žiadny `.tab`, takže počet
+  `.side-nav .tab` sa pridaním prázdnej sekcie NEMENÍ.
 - **A VISIBLE tab (in `NAV`, not `HIDDEN_TABS`) must NEVER render its own
   `<h1>`/`<h2>` matching the tab's `label` — `App.tsx` renders that title
   itself via `Topbar` for any `isVisibleTabId(activeTabId)` tab, so a

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -154,6 +154,36 @@ it("klik na hlavičku priečinka ho zbalí (folder-chev sa otočí cez triedu 'c
   expect(folderBtn.getAttribute("aria-expanded")).toBe("false");
 });
 
+// issue 501: nové sekcie "Vyšívanie"/"Slavosport" sú zatiaľ PRÁZDNE priečinky
+// (`tabs: []`, žiadna funkcia). Musia sa vykresliť ako obyčajná zbaliteľná
+// hlavička bez obsahu — konzistentne s naplnenými priečinkami — a nesmú
+// vykresliť žiadne `.tab` tlačidlo.
+const FOLDERS_WITH_EMPTY = [
+  {
+    id: "eshop",
+    label: "Eshop",
+    tabs: [{ id: "orders", label: "Na objednanie", icon: "📦", Component: () => null }],
+  },
+  { id: "vysivanie", label: "Vyšívanie", tabs: [] },
+];
+
+it("prázdny priečinok (tabs: []) vykreslí zbaliteľnú hlavičku bez záložiek", () => {
+  render(<Sidebar folders={FOLDERS_WITH_EMPTY} activeTabId="orders" onSelectTab={() => {}} />);
+
+  // Hlavička sa vykreslí a štartuje rozbalená (žiadny defaultCollapsed).
+  const hlavicka = screen.getByRole("button", { name: "Vyšívanie" });
+  expect(hlavicka.getAttribute("aria-expanded")).toBe("true");
+
+  // Priečinok nemá žiadnu záložku (žiadne `.tab` tlačidlo v jeho `.nav-folder`).
+  const priecinok = hlavicka.closest(".nav-folder");
+  expect(priecinok).not.toBeNull();
+  expect(priecinok?.querySelectorAll(".tab").length).toBe(0);
+
+  // Klik hlavičku zbalí — rovnaké zbaliteľné správanie ako naplnené priečinky.
+  fireEvent.click(hlavicka);
+  expect(hlavicka.getAttribute("aria-expanded")).toBe("false");
+});
+
 // issue 147: `badgeCounts` je generický (kľúčovaný `tab.id`), nielen pre
 // "Na objednanie" — test preto overuje aj že tab BEZ kľúča v `badgeCounts`
 // odznak nedostane vôbec (nie odznak s "0").

--- a/apps/web/src/nav.test.ts
+++ b/apps/web/src/nav.test.ts
@@ -34,9 +34,20 @@ import { DEFAULT_TAB_ID, HIDDEN_TABS, NAV, findTab, isVisibleTabId } from "./nav
 // Issue 387 E5 pridalo "Párovanie" — pôvodne hneď za "Párovanie produktov"
 // (#239), ktorú issue 400 (E9) odstránilo (majiteľ ju výslovne schválil).
 // Tento test je najbližšie k tomu, čo strojovo overiť dá (registrácia, nie DOM).
-it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 4/10/3/4 záložkami v poradí podľa dôležitosti", () => {
-  expect(NAV).toHaveLength(4);
-  expect(NAV.map((f) => f.label)).toEqual(["Dôležité", "Eshop", "Systém", "Automatizácie"]);
+// issue 501: dva nové PRÁZDNE priečinky "Vyšívanie"/"Slavosport" HNEĎ POD
+// "Eshop" (šéfov kolega Štěpán, Discord + nákres) — poradie priečinkov je teraz
+// Dôležité, Eshop, Vyšívanie, Slavosport, Systém, Automatizácie. Sú zatiaľ bez
+// záložiek (0/0), "Systém"/"Automatizácie" sa posunuli na indexy 4/5.
+it("NAV má šesť priečinkov (Dôležité/Eshop/Vyšívanie/Slavosport/Systém/Automatizácie), s 4/10/0/0/3/4 záložkami v poradí podľa dôležitosti", () => {
+  expect(NAV).toHaveLength(6);
+  expect(NAV.map((f) => f.label)).toEqual([
+    "Dôležité",
+    "Eshop",
+    "Vyšívanie",
+    "Slavosport",
+    "Systém",
+    "Automatizácie",
+  ]);
   // issue 437: "Poznámky" pribudlo do priečinka „Dôležité" (2 → 3 záložky).
   // issue 445: "Objednať DPD" presunuté z „Eshop" do „Dôležité" pod
   // „Poznámky" (Dôležité 3 → 4, Eshop 10 → 9).
@@ -44,8 +55,12 @@ it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 4/10
   // (Eshop 9 → 10).
   expect(NAV[0]?.tabs).toHaveLength(4);
   expect(NAV[1]?.tabs).toHaveLength(10);
-  expect(NAV[2]?.tabs).toHaveLength(3);
-  expect(NAV[3]?.tabs).toHaveLength(4);
+  // issue 501: dve nové PRÁZDNE sekcie (Vyšívanie/Slavosport) — zatiaľ 0/0
+  // záložiek; "Systém"/"Automatizácie" sa posunuli na indexy 4/5.
+  expect(NAV[2]?.tabs).toHaveLength(0);
+  expect(NAV[3]?.tabs).toHaveLength(0);
+  expect(NAV[4]?.tabs).toHaveLength(3);
+  expect(NAV[5]?.tabs).toHaveLength(4);
   expect(NAV[0]?.tabs.map((t) => t.label)).toEqual(["Upozornenia", "Úlohy na dnes", "Poznámky", "Objednať DPD"]);
   expect(NAV[1]?.tabs.map((t) => t.label)).toEqual([
     "Na objednanie",
@@ -61,9 +76,9 @@ it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 4/10
   ]);
   // issue 212: "Dodávateľský sklad" — scraper dostupnosti u dodávateľa;
   // patrí do Systému (zadanie majiteľa), nie medzi Automatizácie.
-  expect(NAV[2]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
+  expect(NAV[4]?.tabs.map((t) => t.label)).toEqual(["Sync zo Shoptetu", "Texty e-mailov", "Dodávateľský sklad"]);
   // issue 193: "Odoslané e-maily" — prehľad toho, čo automatizácie poslali.
-  expect(NAV[3]?.tabs.map((t) => t.label)).toEqual([
+  expect(NAV[5]?.tabs.map((t) => t.label)).toEqual([
     // issue 213: prepínanie vypredaných produktov späť na skladom.
     "Vypredané → Skladom",
     "Nevyzdvihnuté zásielky",
@@ -80,15 +95,21 @@ it("NAV má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie), s 4/10
 // jeho vlastný test). Issue 342: "Dôležité" (nový, PRVÝ priečinok) ostáva
 // tiež rozbalený — rovnaký dôvod ako "Eshop" (dennodenne používaná
 // obrazovka).
-it("Dôležité a Eshop nemajú defaultCollapsed nastavené, Systém a Automatizácie majú true", () => {
+it("Dôležité/Eshop/Vyšívanie/Slavosport nemajú defaultCollapsed nastavené, Systém a Automatizácie majú true", () => {
   expect(NAV[0]?.label).toBe("Dôležité");
   expect(NAV[0]?.defaultCollapsed).toBeUndefined();
   expect(NAV[1]?.label).toBe("Eshop");
   expect(NAV[1]?.defaultCollapsed).toBeUndefined();
-  expect(NAV[2]?.label).toBe("Systém");
-  expect(NAV[2]?.defaultCollapsed).toBe(true);
-  expect(NAV[3]?.label).toBe("Automatizácie");
-  expect(NAV[3]?.defaultCollapsed).toBe(true);
+  // issue 501: nové prázdne sekcie štartujú ROZBALENÉ (žiadny defaultCollapsed),
+  // rovnako ako Dôležité/Eshop — dizajnové rozhodnutie na tickete #501.
+  expect(NAV[2]?.label).toBe("Vyšívanie");
+  expect(NAV[2]?.defaultCollapsed).toBeUndefined();
+  expect(NAV[3]?.label).toBe("Slavosport");
+  expect(NAV[3]?.defaultCollapsed).toBeUndefined();
+  expect(NAV[4]?.label).toBe("Systém");
+  expect(NAV[4]?.defaultCollapsed).toBe(true);
+  expect(NAV[5]?.label).toBe("Automatizácie");
+  expect(NAV[5]?.defaultCollapsed).toBe(true);
 });
 
 // issue 287: DEFAULT_TAB_ID sa NEODVODZUJE od NAV[0] (to je "eshop", priečinok,

--- a/apps/web/src/nav.ts
+++ b/apps/web/src/nav.ts
@@ -172,6 +172,26 @@ export const NAV: readonly NavFolder[] = [
       // DPD" — pozri hore v priečinku „dolezite".
     ],
   },
+  // issue 501: šéfov kolega Štěpán (Discord, 26.8.2026 + nákres) — dva nové
+  // „adresáre" VYŠÍVANIE a SLAVOSPORT umiestnené HNEĎ POD „Eshop" (šípka v
+  // nákrese mieri presne pod Eshop), teda poradie priečinkov: Dôležité, Eshop,
+  // Vyšívanie, Slavosport, Systém, Automatizácie. Zatiaľ sú to PRÁZDNE sekcie
+  // (žiadne záložky, žiadna funkcia — tá príde neskôr samostatnými tiketmi):
+  // prázdny `tabs: []` sa v `Sidebar.tsx` vykreslí ako obyčajná zbaliteľná
+  // hlavička bez obsahu, konzistentne s ostatnými priečinkami. `defaultCollapsed`
+  // sa NENASTAVUJE (štartujú rozbalené ako Dôležité/Eshop) a `label` je v
+  // prirodzenom tvare — CSS ho zobrazí veľkými písmenami (`text-transform:
+  // uppercase` na `.folder-head`), rovnako ako pri ostatných priečinkoch.
+  {
+    id: "vysivanie",
+    label: "Vyšívanie",
+    tabs: [],
+  },
+  {
+    id: "slavosport",
+    label: "Slavosport",
+    tabs: [],
+  },
   {
     id: "system",
     label: "Systém",

--- a/apps/web/tests/e2e/nav.spec.ts
+++ b/apps/web/tests/e2e/nav.spec.ts
@@ -41,7 +41,11 @@ const E2E_NAV_EMAIL = "e2e-nav@forestshop.sk";
 // nahradilo jej Shoptet-viazaný obsah vlastnými zápismi z predajne
 // (`id`/`label`/miesto v menu nezmenené, funkčný test teraz v samostatnom
 // `floor-notes.spec.ts`, rovnaký vzor).
-test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizácie) s dvadsiatimi jednou záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
+// issue 501 (2026-08-26): dva nové PRÁZDNE priečinky "Vyšívanie"/"Slavosport"
+// HNEĎ POD "Eshop" (šéfov kolega Štěpán, Discord + nákres) — celkovo šesť
+// priečinkov, poradie Dôležité/Eshop/Vyšívanie/Slavosport/Systém/Automatizácie.
+// Počet ZÁLOŽIEK sa NEMENÍ (nové sekcie sú zatiaľ bez záložiek) — stále 21.
+test("ľavé menu má šesť priečinkov (Dôležité/Eshop/Vyšívanie/Slavosport/Systém/Automatizácie) s dvadsiatimi jednou záložkami, klik prepne obrazovku, panel sa zbalí do lišty a stav si pamätá, konzola je čistá", async ({
   page,
 }) => {
   const chyby: string[] = [];
@@ -57,11 +61,33 @@ test("ľavé menu má štyri priečinky (Dôležité/Eshop/Systém/Automatizáci
   await page.getByLabel("Heslo").fill(E2E_HESLO);
   await page.getByRole("button", { name: "Prihlásiť sa" }).click();
 
-  // Presne štyri priečinky.
+  // Presne šesť priečinkov (issue 501 pridalo Vyšívanie/Slavosport).
   await expect(page.getByRole("button", { name: "Dôležité" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Systém" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Eshop" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Automatizácie" })).toBeVisible();
+  // issue 501: dva nové PRÁZDNE priečinky HNEĎ POD "Eshop".
+  await expect(page.getByRole("button", { name: "Vyšívanie" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Slavosport" })).toBeVisible();
+
+  // issue 501: over presné PORADIE priečinkov podľa nákresu Štěpána (šípka
+  // mieri presne pod Eshop). `.ftitle` nesie SUROVÝ text priečinka —
+  // `text-transform: uppercase` je len CSS, takže `allTextContents()` vráti
+  // prirodzený tvar z registra (`nav.ts`), nie veľké písmená.
+  const poradiePriecinkov = await page.locator(".side-nav .folder-head .ftitle").allTextContents();
+  expect(poradiePriecinkov).toEqual([
+    "Dôležité",
+    "Eshop",
+    "Vyšívanie",
+    "Slavosport",
+    "Systém",
+    "Automatizácie",
+  ]);
+  // Nové prázdne sekcie štartujú ROZBALENÉ (žiadny defaultCollapsed, ako
+  // Dôležité/Eshop) — správanie prázdnej sekcie je konzistentné s ostatnými
+  // zbaliteľnými priečinkami (klik ich zbalí; overené unit testom Sidebaru).
+  await expect(page.getByRole("button", { name: "Vyšívanie" })).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByRole("button", { name: "Slavosport" })).toHaveAttribute("aria-expanded", "true");
 
   // issue 343: "Systém" a "Automatizácie" štartujú ZBALENÉ (menu by inak
   // presahovalo výšku obrazovky), "Eshop" ostáva rozbalený — over predvolený

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.291",
+  "version": "0.3.0-dev.293",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 501 — dve nové prázdne sekcie bočného menu VYŠÍVANIE a SLAVOSPORT medzi Eshop a Systém (zadanie Štěpána, funkcie prídu neskôr samostatne). Prázdny `NavFolder` (`tabs: []`) sa renderuje ako čistá zbaliteľná hlavička; poradie overené e2e testom.

v0.3.0-dev.293. Zároveň tento push nesie na main aj kód issue 492 (sebaozdravujúce importné okno, v0.3.0-dev.291) — jeho pôvodný main push `e378bfb` spadol do GitHub Actions outage (26. 8. popoludní): main CI beh sa nikdy nevytvoril a Deploy ostal zombie-queued s nula jobmi (zrušený). Tento beh spúšťa plné CI + Deploy nad celým aktuálnym stromom, presne podľa zdokumentovaného recovery postupu v `.claude/rules/ci.md`.

Tickety 492 aj 501 ostávajú otvorené — zavrú sa ručne po naživo overení.
