### PR TITLE
issue 500 + 502 — tlačidlo @ e-mail zákazníkovi v Na objednanie a Riešiť (v0.3.0-dev.294)

### DIFF
--- a/.claude/rules/mail-log.md
+++ b/.claude/rules/mail-log.md
@@ -91,3 +91,20 @@ paths:
   `/srv/forestshop/.env` a bude ho chcieť „napojiť": je to zámerné
   rozhodnutie (viď aj `.claude/rules/orders.md`), nie chýbajúce drôtovanie —
   BCC už funguje cez vyhradené premenné.
+- **issue 500: nová hodnota `mail_log_source` enumu sa musí pridať na TROCH
+  miestach, inak PRVÝ zapísaný riadok toho zdroja zhodí CELÚ obrazovku „Kniha
+  odoslaných e-mailov" (aj fail-closed `skipped` riadok stačí).** Fable review
+  na PR pre #500 chytil dva zabudnuté: (1) `apps/web/src/mailLogApi.ts`'s
+  `MAIL_LOG_SOURCES` pole + `MAIL_LOG_SOURCE_LABELS` (frontend zod
+  `rowSchema.source: z.enum(MAIL_LOG_SOURCES)` inak `listSchema.parse` vyhodí
+  pri PRVOM riadku a `MailLogSection` prestane vykresľovať pre VŠETKY zdroje),
+  a (2) `apps/api/src/http/mail-log-routes.ts`'s `listQuery.source` filter
+  enum. Plus samozrejme (3) `apps/api/src/db/schema-mail-log.ts`'s `pgEnum`
+  (+ samostatná `ALTER TYPE … ADD VALUE` migrácia, `.claude/rules/database.md`
+  issue 476 bezpečný vzor) a `mail-log/service.ts`'s `MailLogSource` únia.
+  Checklist pri KAŽDOM ďalšom (šiestom+) odosielateľovi: schema pgEnum +
+  MailLogSource únia + migrácia + `mailLogApi.ts` (SOURCES + LABELS) +
+  `mail-log-routes.ts` filter. `order_merge` (#257) to všetko urobilo správne
+  — porovnaj s ním. A nová `env.ts` `*_BCC_EMAIL` premenná potrebuje riadok v
+  `docker-compose.prod.yml` (`.claude/rules/deploy.md` issue 198/292), inak je
+  funkcia fail-closed mŕtva na prode.

--- a/apps/api/drizzle/0061_far_rawhide_kid.sql
+++ b/apps/api/drizzle/0061_far_rawhide_kid.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."mail_log_source" ADD VALUE 'order_customer_contact';

--- a/apps/api/drizzle/meta/0061_snapshot.json
+++ b/apps/api/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,3893 @@
+{
+  "id": "a369a0ec-6134-43cb-aba1-2c3976c9ae17",
+  "prevId": "af58cb7f-5632-4977-98da-e72c556d93e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_events_at_idx": {
+          "name": "audit_events_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_actor_user_id_users_id_fk": {
+          "name": "audit_events_actor_user_id_users_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'citanie'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_snapshot": {
+      "name": "catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confirmed_at": {
+          "name": "last_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_label": {
+          "name": "source_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "snapshot_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_path": {
+          "name": "raw_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_count": {
+          "name": "variant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "catalog_snapshot_fetched_at_idx": {
+          "name": "catalog_snapshot_fetched_at_idx",
+          "columns": [
+            {
+              "expression": "fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_snapshot_accepted_sha_uq": {
+          "name": "catalog_snapshot_accepted_sha_uq",
+          "columns": [
+            {
+              "expression": "content_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_snapshot\".\"verdict\" = 'accepted'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_snapshot_reason_ck": {
+          "name": "catalog_snapshot_reason_ck",
+          "value": "(\"catalog_snapshot\".\"verdict\" = 'rejected') = (\"catalog_snapshot\".\"rejection_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingest_issue": {
+      "name": "ingest_issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "ingest_issue_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ingest_issue_snapshot_idx": {
+          "name": "ingest_issue_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingest_issue_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "ingest_issue_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "ingest_issue",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product": {
+      "name": "product",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_note": {
+          "name": "internal_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "product_supplier_idx": {
+          "name": "product_supplier_idx",
+          "columns": [
+            {
+              "expression": "supplier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "product_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "product",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant": {
+      "name": "variant",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_code": {
+          "name": "external_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard_price": {
+          "name": "standard_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_price": {
+          "name": "action_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_from": {
+          "name": "action_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_until": {
+          "name": "action_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_vat": {
+          "name": "percent_vat",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "including_vat": {
+          "name": "including_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock": {
+          "name": "stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_in_stock_text": {
+          "name": "availability_in_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_out_of_stock_text": {
+          "name": "availability_out_of_stock_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_visibility": {
+          "name": "product_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "variant_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_snapshot_id": {
+          "name": "last_seen_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missing_since": {
+          "name": "missing_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "variant_product_idx": {
+          "name": "variant_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_guid_idx": {
+          "name": "variant_guid_idx",
+          "columns": [
+            {
+              "expression": "guid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_state_idx": {
+          "name": "variant_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "variant_name_idx": {
+          "name": "variant_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_product_key_product_key_fk": {
+          "name": "variant_product_key_product_key_fk",
+          "tableFrom": "variant",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_last_seen_snapshot_id_catalog_snapshot_id_fk": {
+          "name": "variant_last_seen_snapshot_id_catalog_snapshot_id_fk",
+          "tableFrom": "variant",
+          "tableTo": "catalog_snapshot",
+          "columnsFrom": [
+            "last_seen_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "variant_money_needs_currency_ck": {
+          "name": "variant_money_needs_currency_ck",
+          "value": "(\"variant\".\"currency\" IS NOT NULL AND \"variant\".\"currency\" != '') OR (\"variant\".\"price\" IS NULL AND \"variant\".\"standard_price\" IS NULL AND \"variant\".\"purchase_price\" IS NULL AND \"variant\".\"action_price\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_run_name_started_idx": {
+          "name": "job_run_name_started_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_line": {
+      "name": "order_line",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_line_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'objednane'"
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "order_line_order_idx": {
+          "name": "order_line_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_variant_idx": {
+          "name": "order_line_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_state_idx": {
+          "name": "order_line_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "order_line_order_variant_uq": {
+          "name": "order_line_order_variant_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_line_order_id_order_id_fk": {
+          "name": "order_line_order_id_order_id_fk",
+          "tableFrom": "order_line",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_line_variant_code_variant_code_fk": {
+          "name": "order_line_variant_code_variant_code_fk",
+          "tableFrom": "order_line",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_line_quantity_positive_ck": {
+          "name": "order_line_quantity_positive_ck",
+          "value": "\"order_line\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_open_status": {
+      "name": "order_open_status",
+      "schema": "",
+      "columns": {
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order": {
+      "name": "order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Vybavuje sa'"
+        },
+        "remark": {
+          "name": "remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_remark": {
+          "name": "shop_remark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shoptet_order_id": {
+          "name": "shoptet_order_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placed_at": {
+          "name": "placed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "comment_updated_at": {
+          "name": "comment_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_synced_at": {
+          "name": "comment_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_carrier_name": {
+          "name": "shipping_carrier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price_with_vat": {
+          "name": "total_price_with_vat",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_marked_at": {
+          "name": "claim_marked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_note": {
+          "name": "claim_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_full_name": {
+          "name": "delivery_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_company": {
+          "name": "delivery_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street": {
+          "name": "delivery_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_house_number": {
+          "name": "delivery_house_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_zip": {
+          "name": "delivery_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_name": {
+          "name": "delivery_country_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_name": {
+          "name": "payment_method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_to_pay": {
+          "name": "price_to_pay",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "order_placed_at_idx": {
+          "name": "order_placed_at_idx",
+          "columns": [
+            {
+              "expression": "placed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_external_order_id_unique": {
+          "name": "order_external_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_link_override": {
+      "name": "product_supplier_link_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_link_override_product_key_product_key_fk": {
+          "name": "product_supplier_link_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_link_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_supplier_override": {
+      "name": "product_supplier_override",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_supplier_override_product_key_product_key_fk": {
+          "name": "product_supplier_override_product_key_product_key_fk",
+          "tableFrom": "product_supplier_override",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_contact": {
+      "name": "supplier_contact",
+      "schema": "",
+      "columns": {
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing": {
+      "name": "pairing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_url": {
+          "name": "supplier_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "pairing_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'navrhnute'"
+        },
+        "confirmed_by": {
+          "name": "confirmed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pairing_state_idx": {
+          "name": "pairing_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_confirmed_by_idx": {
+          "name": "pairing_confirmed_by_idx",
+          "columns": [
+            {
+              "expression": "confirmed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_variant_code_variant_code_fk": {
+          "name": "pairing_variant_code_variant_code_fk",
+          "tableFrom": "pairing",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pairing_confirmed_by_users_id_fk": {
+          "name": "pairing_confirmed_by_users_id_fk",
+          "tableFrom": "pairing",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pairing_variant_code_unique": {
+          "name": "pairing_variant_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pairing_confirmation_ck": {
+          "name": "pairing_confirmation_ck",
+          "value": "(\"pairing\".\"state\" = 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NOT NULL AND \"pairing\".\"confirmed_at\" IS NOT NULL)\n        OR (\"pairing\".\"state\" != 'potvrdene' AND \"pairing\".\"confirmed_by\" IS NULL AND \"pairing\".\"confirmed_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier": {
+      "name": "supplier",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wholesale_base_url": {
+          "name": "wholesale_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_key": {
+          "name": "adapter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_settings": {
+      "name": "posta_uncollected_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posta_uncollected_state": {
+      "name": "posta_uncollected_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_state": {
+          "name": "terminal_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_settings": {
+      "name": "order_reminder_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_reminder_state": {
+      "name": "order_reminder_state",
+      "schema": "",
+      "columns": {
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_replacement_link": {
+      "name": "nedostupne_replacement_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nedostupne_replacement_link_variant_idx": {
+          "name": "nedostupne_replacement_link_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nedostupne_state": {
+      "name": "nedostupne_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "nedostupne_email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nedostupne_state_order_variant_type_uq": {
+          "name": "nedostupne_state_order_variant_type_uq",
+          "columns": [
+            {
+              "expression": "order_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template_history": {
+      "name": "mail_template_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "mail_template_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_template_history_key_idx": {
+          "name": "mail_template_history_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "changed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_template_history_changed_by_user_id_users_id_fk": {
+          "name": "mail_template_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "mail_template_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_template": {
+      "name": "mail_template",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_template_updated_by_user_id_users_id_fk": {
+          "name": "mail_template_updated_by_user_id_users_id_fk",
+          "tableFrom": "mail_template",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_log": {
+      "name": "mail_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "mail_log_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "mail_log_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "mail_log_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_code": {
+          "name": "order_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_number": {
+          "name": "package_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mail_log_created_idx": {
+          "name": "mail_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_log_source_created_idx": {
+          "name": "mail_log_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_log_actor_user_id_users_id_fk": {
+          "name": "mail_log_actor_user_id_users_id_fk",
+          "tableFrom": "mail_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_stock": {
+      "name": "supplier_stock",
+      "schema": "",
+      "columns": {
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_label": {
+          "name": "size_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "supplier_availability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability_text": {
+          "name": "availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "supplier_stock_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "supplier_stock_host_idx": {
+          "name": "supplier_stock_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "supplier_stock_avail_idx": {
+          "name": "supplier_stock_avail_idx",
+          "columns": [
+            {
+              "expression": "availability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "supplier_stock_link_size_label_pk": {
+          "name": "supplier_stock_link_size_label_pk",
+          "columns": [
+            "link",
+            "size_label"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_event": {
+      "name": "restock_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pair_code": {
+          "name": "pair_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier": {
+          "name": "supplier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_link": {
+          "name": "supplier_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_availability_text": {
+          "name": "supplier_availability_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "supplier_price": {
+          "name": "supplier_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "restock_event_at_idx": {
+          "name": "restock_event_at_idx",
+          "columns": [
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "restock_event_variant_idx": {
+          "name": "restock_event_variant_idx",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.restock_settings": {
+      "name": "restock_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_product_url": {
+      "name": "shop_product_url",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "shop_product_url_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "theme_color_updated_by_user_id_users_id_fk": {
+          "name": "theme_color_updated_by_user_id_users_id_fk",
+          "tableFrom": "theme_color",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upozornenie": {
+      "name": "upozornenie",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "upozornenie_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "upozornenie_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postponed_until": {
+          "name": "postponed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upozornenie_dedup_key_uq": {
+          "name": "upozornenie_dedup_key_uq",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "resolved_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_resolved_at_idx": {
+          "name": "upozornenie_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upozornenie_dedup_key_idx": {
+          "name": "upozornenie_dedup_key_idx",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upozornenie_resolved_by_user_id_users_id_fk": {
+          "name": "upozornenie_resolved_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "upozornenie_created_by_user_id_users_id_fk": {
+          "name": "upozornenie_created_by_user_id_users_id_fk",
+          "tableFrom": "upozornenie",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_pickup_request": {
+      "name": "dpd_pickup_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dpd_shipment": {
+      "name": "dpd_shipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dpd_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_number": {
+          "name": "parcel_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cod_amount": {
+          "name": "cod_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dpd_shipment_order_uq": {
+          "name": "dpd_shipment_order_uq",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dpd_shipment_order_id_order_id_fk": {
+          "name": "dpd_shipment_order_id_order_id_fk",
+          "tableFrom": "dpd_shipment",
+          "tableTo": "order",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_task": {
+      "name": "daily_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_task_user_id_created_at_idx": {
+          "name": "daily_task_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_task_user_id_users_id_fk": {
+          "name": "daily_task_user_id_users_id_fk",
+          "tableFrom": "daily_task",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate_set": {
+      "name": "pairing_candidate_set",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gathered_at": {
+          "name": "gathered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queries": {
+          "name": "queries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_url": {
+          "name": "chosen_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chosen_reason": {
+          "name": "chosen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "pairing_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "pairing_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_checked_at": {
+          "name": "verdict_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_candidate_set_product_key_product_key_fk": {
+          "name": "pairing_candidate_set_product_key_product_key_fk",
+          "tableFrom": "pairing_candidate_set",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_candidate": {
+      "name": "pairing_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_score": {
+          "name": "raw_score",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hit": {
+          "name": "code_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pairing_candidate_product_url_uq": {
+          "name": "pairing_candidate_product_url_uq",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pairing_candidate_product_idx": {
+          "name": "pairing_candidate_product_idx",
+          "columns": [
+            {
+              "expression": "product_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pairing_candidate_product_key_fk": {
+          "name": "pairing_candidate_product_key_fk",
+          "tableFrom": "pairing_candidate",
+          "tableTo": "pairing_candidate_set",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "product_key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_decision": {
+      "name": "pairing_decision",
+      "schema": "",
+      "columns": {
+        "product_key": {
+          "name": "product_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pairing_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_synced_at": {
+          "name": "state_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_decision_product_key_product_key_fk": {
+          "name": "pairing_decision_product_key_product_key_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "product",
+          "columnsFrom": [
+            "product_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pairing_decision_decided_by_users_id_fk": {
+          "name": "pairing_decision_decided_by_users_id_fk",
+          "tableFrom": "pairing_decision",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pairing_decision_url_ck": {
+          "name": "pairing_decision_url_ck",
+          "value": "(\"pairing_decision\".\"status\"::text IN ('good','manual') AND \"pairing_decision\".\"url\" IS NOT NULL) OR (\"pairing_decision\".\"status\"::text IN ('unavailable','discontinued','split') AND \"pairing_decision\".\"url\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pairing_search_settings": {
+      "name": "pairing_search_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_state_writeback_settings": {
+      "name": "pairing_state_writeback_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pairing_variant_link": {
+      "name": "pairing_variant_link",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pairing_variant_link_code_variant_code_fk": {
+          "name": "pairing_variant_link_code_variant_code_fk",
+          "tableFrom": "pairing_variant_link",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.floor_note_product": {
+      "name": "floor_note_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "floor_note_id": {
+          "name": "floor_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "ordered_at": {
+          "name": "ordered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_product_note_idx": {
+          "name": "floor_note_product_note_idx",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "floor_note_product_note_variant_uq": {
+          "name": "floor_note_product_note_variant_uq",
+          "columns": [
+            {
+              "expression": "floor_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_product_floor_note_id_floor_note_id_fk": {
+          "name": "floor_note_product_floor_note_id_floor_note_id_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "floor_note",
+          "columnsFrom": [
+            "floor_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "floor_note_product_variant_code_variant_code_fk": {
+          "name": "floor_note_product_variant_code_variant_code_fk",
+          "tableFrom": "floor_note_product",
+          "tableTo": "variant",
+          "columnsFrom": [
+            "variant_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "floor_note_product_quantity_ck": {
+          "name": "floor_note_product_quantity_ck",
+          "value": "\"floor_note_product\".\"quantity\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.floor_note": {
+      "name": "floor_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ordered": {
+          "name": "ordered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "called": {
+          "name": "called",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "floor_note_created_at_idx": {
+          "name": "floor_note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "floor_note_created_by_user_id_users_id_fk": {
+          "name": "floor_note_created_by_user_id_users_id_fk",
+          "tableFrom": "floor_note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note": {
+      "name": "note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "note_created_at_idx": {
+          "name": "note_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "note_author_user_id_users_id_fk": {
+          "name": "note_author_user_id_users_id_fk",
+          "tableFrom": "note",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "manazer",
+        "sef",
+        "citanie"
+      ]
+    },
+    "public.ingest_issue_kind": {
+      "name": "ingest_issue_kind",
+      "schema": "public",
+      "values": [
+        "empty_code",
+        "empty_guid",
+        "duplicate_code",
+        "invalid_money",
+        "missing_currency",
+        "invalid_stock",
+        "product_name_conflict"
+      ]
+    },
+    "public.snapshot_verdict": {
+      "name": "snapshot_verdict",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.variant_state": {
+      "name": "variant_state",
+      "schema": "public",
+      "values": [
+        "sellable",
+        "out_of_stock",
+        "discontinued"
+      ]
+    },
+    "public.job_run_status": {
+      "name": "job_run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "failure"
+      ]
+    },
+    "public.order_line_state": {
+      "name": "order_line_state",
+      "schema": "public",
+      "values": [
+        "objednane",
+        "caka_sa",
+        "skladom",
+        "nedostupne",
+        "riesit",
+        "objednane_stav"
+      ]
+    },
+    "public.pairing_state": {
+      "name": "pairing_state",
+      "schema": "public",
+      "values": [
+        "navrhnute",
+        "potvrdene"
+      ]
+    },
+    "public.nedostupne_email_type": {
+      "name": "nedostupne_email_type",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "alternativa"
+      ]
+    },
+    "public.mail_template_action": {
+      "name": "mail_template_action",
+      "schema": "public",
+      "values": [
+        "save",
+        "reset"
+      ]
+    },
+    "public.mail_log_source": {
+      "name": "mail_log_source",
+      "schema": "public",
+      "values": [
+        "nedostupne",
+        "posta_uncollected",
+        "order_reminder",
+        "supplier_order",
+        "order_merge",
+        "order_customer_contact"
+      ]
+    },
+    "public.mail_log_status": {
+      "name": "mail_log_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.mail_log_trigger": {
+      "name": "mail_log_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.supplier_availability": {
+      "name": "supplier_availability",
+      "schema": "public",
+      "values": [
+        "available",
+        "unavailable",
+        "unknown"
+      ]
+    },
+    "public.supplier_stock_source": {
+      "name": "supplier_stock_source",
+      "schema": "public",
+      "values": [
+        "json_ld",
+        "meta",
+        "text",
+        "size_list",
+        "none"
+      ]
+    },
+    "public.shop_product_url_source": {
+      "name": "shop_product_url_source",
+      "schema": "public",
+      "values": [
+        "feed",
+        "sitemap",
+        "probe"
+      ]
+    },
+    "public.upozornenie_source": {
+      "name": "upozornenie_source",
+      "schema": "public",
+      "values": [
+        "vlastne",
+        "appka"
+      ]
+    },
+    "public.upozornenie_type": {
+      "name": "upozornenie_type",
+      "schema": "public",
+      "values": [
+        "vlastna_poznamka",
+        "nevyzdvihnuta_zasielka",
+        "vratenie",
+        "vratena_zasielka",
+        "objednavka_visi"
+      ]
+    },
+    "public.dpd_operation_status": {
+      "name": "dpd_operation_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "failed"
+      ]
+    },
+    "public.pairing_confidence": {
+      "name": "pairing_confidence",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "none"
+      ]
+    },
+    "public.pairing_decision_status": {
+      "name": "pairing_decision_status",
+      "schema": "public",
+      "values": [
+        "good",
+        "manual",
+        "unavailable",
+        "discontinued",
+        "split"
+      ]
+    },
+    "public.pairing_verdict": {
+      "name": "pairing_verdict",
+      "schema": "public",
+      "values": [
+        "ok",
+        "unsure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1787736233178,
       "tag": "0060_nifty_quentin_quire",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1787765018327,
+      "tag": "0061_far_rawhide_kid",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema-mail-log.ts
+++ b/apps/api/src/db/schema-mail-log.ts
@@ -11,12 +11,18 @@ import { users } from "./schema-users.js";
 // vedel, čo sa v jeho mene odoslalo.
 // issue 257: "order_merge" — e-mail zákazníkovi o zlúčení viacerých jeho
 // objednávok do jednej zásielky (`modules/orders/merge-mail.ts`).
+// issue 500: "order_customer_contact" — ručný e-mail zákazníkovi z riadku "Na
+// objednanie" (@ tlačidlo, `modules/orders/customer-contact.ts`). Nová hodnota
+// enumu, ktorú používa LEN runtime insert (žiadny CHECK/index/generated-column)
+// → bezpečná samostatná `ALTER TYPE ... ADD VALUE` migrácia (issue 476 vzor,
+// `.claude/rules/database.md`).
 export const mailLogSource = pgEnum("mail_log_source", [
   "nedostupne",
   "posta_uncollected",
   "order_reminder",
   "supplier_order",
   "order_merge",
+  "order_customer_contact",
 ]);
 
 // `skipped` = appka SKUTOČNE chcela poslať a nemohla (chýba adresa, chýba

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -95,6 +95,12 @@ const envSchema = z.object({
   // zdieľané všeobecné `MAIL_BCC`). Chýbajúca = automatizácia NEPOŠLE ani
   // jeden e-mail zákazníkovi (fail-closed).
   ORDER_MERGE_BCC_EMAIL: z.string().email().optional(),
+  // issue 500: "Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na
+  // riadku). Rovnaká úvaha ako `NEDOSTUPNE_BCC_EMAIL`/`ORDER_MERGE_BCC_EMAIL`
+  // vyššie (NEZÁVISLÁ, vyhradená premenná, nikdy zdieľané všeobecné
+  // `MAIL_BCC`). Chýbajúca = odoslanie NEODÍDE (fail-closed) a okno náhľadu
+  // ukáže jasnú hlášku.
+  ORDER_CUSTOMER_CONTACT_BCC_EMAIL: z.string().email().optional(),
   // issue 292: prihlasovacie údaje do portálu `dpdshipper.sk` (Playwright
   // robot na objednávanie prepravy/zvozu) — rovnaké pravidlo ako
   // `SHOPTET_ADMIN_USER`/`PASSWORD` vyššie, nikdy do repa/commit

--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -25,6 +25,7 @@ import { registerNedostupneRoutes, type NedostupneRunDeps } from "./nedostupne-r
 import { registerNoteRoutes } from "./note-routes.js";
 import { registerOrderFlagsRoutes } from "./order-flags-routes.js";
 import { registerOrderMergeRoutes, type OrderMergeRunDeps } from "./order-merge-routes.js";
+import { registerOrderCustomerContactRoutes, type OrderCustomerContactRunDeps } from "./order-customer-contact-routes.js";
 import { requireSameOrigin } from "./origin-check.js";
 import { registerPairingRoutes } from "./pairing-routes.js";
 import { registerPairingReviewRoutes } from "./pairing-review-routes.js";
@@ -86,6 +87,11 @@ export function createApp(
     // lokálny vývoj, `index.ts` v produkcii VŽDY nahradí reálnymi
     // dependencies.
     readonly orderMerge?: OrderMergeRunDeps;
+    // issue 500: "Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na
+    // riadku). Voliteľné z rovnakého dôvodu ako `orderMerge` vyššie: bezpečný
+    // default nižšie pre testy/lokálny vývoj, `index.ts` v produkcii VŽDY
+    // nahradí reálnymi dependencies.
+    readonly orderCustomerContact?: OrderCustomerContactRunDeps;
     // issue 212: "Dodávateľský sklad" — sťahovanie stránky dodávateľa.
     // Voliteľné z rovnakého dôvodu ako `nedostupne` vyššie; testy dodajú
     // vlastnú implementáciu a NIKDY nechodia na skutočnú stránku dodávateľa.
@@ -293,6 +299,19 @@ export function createApp(
     app,
     db,
     options.orderMerge ?? {
+      mailTransport: undefined,
+      bccEmail: undefined,
+    },
+  );
+  // issue 500: "Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na
+  // riadku). Bezpečný default z rovnakého dôvodu ako `orderMerge` vyššie. Prefix
+  // `/api/order-customer-contact/*` sa nekríži s `/api/orders/:id`
+  // (`orders-routes.ts`) — iný segment, žiadne poradie registrácie netreba
+  // riešiť (`.claude/rules/http-routes.md`).
+  registerOrderCustomerContactRoutes(
+    app,
+    db,
+    options.orderCustomerContact ?? {
       mailTransport: undefined,
       bccEmail: undefined,
     },

--- a/apps/api/src/http/mail-log-routes.ts
+++ b/apps/api/src/http/mail-log-routes.ts
@@ -11,7 +11,7 @@ import { requireUser, type AppBindings } from "./middleware.js";
 const PERIOD_DAYS: Readonly<Record<string, number | null>> = { "7": 7, "30": 30, "90": 90, all: null };
 
 const listQuery = z.object({
-  source: z.enum(["nedostupne", "posta_uncollected", "order_reminder", "supplier_order", "order_merge"]).optional(),
+  source: z.enum(["nedostupne", "posta_uncollected", "order_reminder", "supplier_order", "order_merge", "order_customer_contact"]).optional(),
   status: z.enum(["sent", "failed", "skipped"]).optional(),
   period: z.enum(["7", "30", "90", "all"]).default("30"),
 });

--- a/apps/api/src/http/order-customer-contact-routes.ts
+++ b/apps/api/src/http/order-customer-contact-routes.ts
@@ -1,0 +1,122 @@
+import { zValidator } from "@hono/zod-validator";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { Database } from "../db/client.js";
+import { record } from "../modules/audit/service.js";
+import type { MailTransport } from "../modules/mail/transport.js";
+import {
+  consumeCustomerContactPreviewToken,
+  issueCustomerContactPreviewToken,
+} from "../modules/orders/customer-contact-preview-tokens.js";
+import { buildCustomerContactMail, findCustomerContactContext, sendCustomerContactMail } from "../modules/orders/customer-contact.js";
+import { requireRole, requireUser, type AppBindings } from "./middleware.js";
+import { requireSameOrigin } from "./origin-check.js";
+
+// issue 500: „Na objednanie" — @ tlačidlo na riadku otvorí okno na ručný e-mail
+// zákazníkovi. Rovnaký HTTP vzor ako `order-merge-routes.ts`/`nedostupne-routes.ts`
+// (povinný server-side vynútený náhľad pred odoslaním, `.claude/rules/nedostupne.md`).
+// Deps sú voliteľné cez `createApp` s bezpečným defaultom (mail transport a BCC
+// môžu chýbať — `sendCustomerContactMail` to sama rieši fail-closed).
+export interface OrderCustomerContactRunDeps {
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+}
+
+const previewBody = z.object({ orderCode: z.string().trim().min(1).max(50) });
+// issue 176/257 vzor: `/send` musí priniesť token vydaný `/preview` PRE PRESNE
+// túto objednávku — server-side vynútenie „náhľad VŽDY predchádza odoslaniu"
+// (`customer-contact-preview-tokens.ts`). `editedBody` je voliteľné (priame API
+// bez úpravy pošle pôvodné vyrenderované znenie).
+const sendBody = previewBody.extend({ previewToken: z.string().min(1), editedBody: z.string().trim().min(1).max(20000).optional() });
+
+type SendFailure = Exclude<Awaited<ReturnType<typeof sendCustomerContactMail>>, { readonly status: "sent" }>;
+
+function sendErrorMessage(result: SendFailure): string {
+  switch (result.status) {
+    case "not_found":
+      return "Objednávka sa nenašla — pravdepodobne sa medzitým zmenil jej stav.";
+    case "no_email":
+      return "Objednávka nemá e-mailovú adresu zákazníka.";
+    case "not_configured":
+      return result.reason;
+    case "send_failed":
+      return "Odoslanie e-mailu zlyhalo — skúste to znova.";
+  }
+}
+
+export function registerOrderCustomerContactRoutes(app: Hono<AppBindings>, db: Database, deps: OrderCustomerContactRunDeps): void {
+  // Povinný náhľad — počítaný ROVNAKOU funkciou (`buildCustomerContactMail`),
+  // akú použije skutočné odoslanie nižšie, a VYDÁ jednorazový token.
+  app.post(
+    "/api/order-customer-contact/preview",
+    requireSameOrigin(),
+    requireUser(db),
+    zValidator("json", previewBody),
+    async (c) => {
+      const { orderCode } = c.req.valid("json");
+      const ctx = await findCustomerContactContext(db, orderCode);
+      if (ctx === null) {
+        // 200 (nikdy 404) — rovnaká disciplína ako `order-merge`/`nedostupne`
+        // (`.claude/rules/testing.md`'s Chromium console-error pravidlo).
+        return c.json({ ok: false as const, error: "Objednávka sa nenašla — pravdepodobne sa medzitým zmenil jej stav." });
+      }
+      const built = await buildCustomerContactMail(db, ctx);
+      const previewToken = issueCustomerContactPreviewToken(orderCode, new Date());
+      // issue 277: `text` je plain-textová verzia (rovnaká, akú appka odošle ako
+      // fallback) — frontend ju predvyplní do editovateľného okna.
+      return c.json({
+        ok: true as const,
+        subject: built.subject,
+        html: built.html,
+        text: built.text,
+        recipient: built.to ?? "",
+        customerName: built.customerName,
+        previewToken,
+      });
+    },
+  );
+
+  // Odoslanie — mutuje (zapíše do Knihy odoslaných e-mailov), rovnaká rola ako
+  // „Nedostupné tovary"/„Zlúčenie objednávok" (admin/manazer).
+  app.post(
+    "/api/order-customer-contact/send",
+    requireSameOrigin(),
+    requireUser(db),
+    requireRole("admin", "manazer"),
+    zValidator("json", sendBody),
+    async (c) => {
+      const { orderCode, previewToken, editedBody } = c.req.valid("json");
+      const user = c.get("user");
+      const now = new Date();
+      // Server-side vynútenie povinného náhľadu — token sa KONZUMUJE (zmaže)
+      // hneď, bez ohľadu na výsledok, takže jeden náhľad = najviac jeden pokus.
+      if (!consumeCustomerContactPreviewToken(previewToken, orderCode, now)) {
+        return c.json({ ok: false as const, error: "Najprv si otvorte náhľad e-mailu — bez neho appka nepošle nič." });
+      }
+      const result = await sendCustomerContactMail({
+        db,
+        now,
+        orderCode,
+        mailTransport: deps.mailTransport,
+        bccEmail: deps.bccEmail,
+        actorUserId: user.userId,
+        ...(editedBody === undefined ? {} : { editedBody }),
+      });
+      if (result.status !== "sent") {
+        return c.json({ ok: false as const, error: sendErrorMessage(result) });
+      }
+      // Žiadna vlastná dedup/stavová tabuľka (rozhodnuté v návrhu) —
+      // `entity`/`entityId` vzorujú `order-merge-routes.ts`'s `order_merge.send`
+      // (mailová akcia bez vlastnej mutovanej tabuľky).
+      await record(db, {
+        at: now,
+        actorUserId: user.userId,
+        action: "order_customer_contact.send",
+        entity: "order",
+        entityId: orderCode,
+        data: { orderCode, to: result.to },
+      });
+      return c.json({ ok: true as const });
+    },
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -239,6 +239,14 @@ const orderMergeDeps = {
   bccEmail: env.ORDER_MERGE_BCC_EMAIL,
 };
 
+// issue 500: "Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na riadku).
+// Rovnaká úvaha ako `orderMergeDeps` vyššie: zdieľaný `sendSupplierMail`, vlastná
+// fail-closed BCC premenná, e-mail posiela človek ručne po povinnom náhľade.
+const orderCustomerContactDeps = {
+  mailTransport: sendSupplierMail,
+  bccEmail: env.ORDER_CUSTOMER_CONTACT_BCC_EMAIL,
+};
+
 // issue 292: "Eshop → Preprava DPD" — vlastné prihlasovacie údaje
 // (`DPD_PORTAL_USER`/`PASSWORD`), nezdieľané so Shoptet-om.
 // `config: undefined` = appka beží ďalej, akcie odosielajúce do DPD vrátia
@@ -276,6 +284,7 @@ const app = createApp(db, {
   orderReminder: orderReminderDeps,
   nedostupne: nedostupneDeps,
   orderMerge: orderMergeDeps,
+  orderCustomerContact: orderCustomerContactDeps,
   fetchSupplierPage,
   restock: { config: shoptetImportConfigFromBaseUrl(env.SHOPTET_ADMIN_BASE_URL, shoptetAdminUser ?? "", shoptetAdminPassword ?? "") },
   dpd: dpdDeps,

--- a/apps/api/src/modules/mail-log/service.ts
+++ b/apps/api/src/modules/mail-log/service.ts
@@ -5,7 +5,14 @@ import { log } from "../../logger.js";
 import type { MailMessage, MailTransport } from "../mail/transport.js";
 import type { MailTemplateKey } from "../mail-templates/registry.js";
 
-export type MailLogSource = "nedostupne" | "posta_uncollected" | "order_reminder" | "supplier_order" | "order_merge";
+export type MailLogSource =
+  | "nedostupne"
+  | "posta_uncollected"
+  | "order_reminder"
+  | "supplier_order"
+  | "order_merge"
+  // issue 500: ručný e-mail zákazníkovi z riadku "Na objednanie".
+  | "order_customer_contact";
 export type MailLogTrigger = "scheduled" | "manual";
 
 /** Spoločný popis "o čom ten e-mail bol" — každé pole je nepovinné, lebo

--- a/apps/api/src/modules/mail-templates/registry.ts
+++ b/apps/api/src/modules/mail-templates/registry.ts
@@ -25,6 +25,7 @@ export const MAIL_TEMPLATE_KEYS = [
   "order_reminder",
   "supplier_order",
   "order_merge",
+  "order_customer_contact",
 ] as const;
 
 export type MailTemplateKey = (typeof MAIL_TEMPLATE_KEYS)[number];
@@ -298,6 +299,29 @@ const KINDS: readonly MailTemplateKind[] = [
         KONTAKTUJTE_NAS,
         "",
         PODPIS_TIM,
+      ].join("\n"),
+    },
+  },
+  {
+    // issue 500: ručný e-mail zákazníkovi z riadku „Na objednanie" (@ tlačidlo).
+    // Prednastavený text zo zadania (Štěpán si stred dopíše sám v okne pred
+    // odoslaním). Podpis je „Drlík, Forestshop.sk" (rovnako ako `nedostupne`,
+    // nie `PODPIS_TIM`) — presne ako v zadaní; kontaktné riadky (telefón/
+    // e-mail/web) NIE SÚ v tele, dopĺňa ich zdieľaná pätička (issue 347/379).
+    key: "order_customer_contact",
+    label: "Kontakt zákazníkovi k objednávke",
+    description:
+      "Ručný e-mail zákazníkovi z riadku Na objednanie / Riešiť (@ tlačidlo) — obsluha si stred textu dopíše sama pred odoslaním.",
+    ownPlaceholders: [MENO, CISLO_OBJEDNAVKY],
+    defaultText: {
+      subject: "Vaša objednávka č. {{cislo_objednavky}} — Forestshop.sk",
+      body: [
+        "Dobrý deň, **{{meno_zakaznika}}**,",
+        "",
+        "Radi by sme Vás kontaktovali ohľadom Vašej objednávky č. **{{cislo_objednavky}}**.",
+        "",
+        "S pozdravom,",
+        "**Drlík, Forestshop.sk**",
       ].join("\n"),
     },
   },

--- a/apps/api/src/modules/orders/customer-contact-preview-tokens.test.ts
+++ b/apps/api/src/modules/orders/customer-contact-preview-tokens.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumeCustomerContactPreviewToken,
+  issueCustomerContactPreviewToken,
+} from "./customer-contact-preview-tokens.js";
+
+// issue 500: rovnaký jednorazový-token vzor ako `nedostupne/preview-tokens`,
+// len kľúčovaný LEN `orderCode` (e-mail zákazníkovi je per-objednávka).
+const NOW = new Date("2026-08-26T10:00:00Z");
+
+describe("issueCustomerContactPreviewToken / consumeCustomerContactPreviewToken", () => {
+  it("token vydaný pre presne túto objednávku sa dá skonzumovať PRESNE raz", () => {
+    const token = issueCustomerContactPreviewToken("20261438", NOW);
+    expect(consumeCustomerContactPreviewToken(token, "20261438", NOW)).toBe(true);
+    expect(consumeCustomerContactPreviewToken(token, "20261438", NOW)).toBe(false);
+  });
+
+  it("token vydaný pre INÚ objednávku sa nedá použiť na iný send", () => {
+    const token = issueCustomerContactPreviewToken("20261438", NOW);
+    expect(consumeCustomerContactPreviewToken(token, "20261439", NOW)).toBe(false);
+  });
+
+  it("neznámy/vymyslený token je vždy neplatný", () => {
+    expect(consumeCustomerContactPreviewToken("vymyslený-token", "20261438", NOW)).toBe(false);
+  });
+
+  it("nezhodný pokus token AJ TAK skonzumuje (jednorazový, bez ohľadu na výsledok)", () => {
+    const token = issueCustomerContactPreviewToken("20261438", NOW);
+    expect(consumeCustomerContactPreviewToken(token, "9999", NOW)).toBe(false);
+    // Druhý pokus s ROVNAKÝM (správnym) číslom už zlyhá — token bol zničený
+    // prvým (nesprávnym) pokusom.
+    expect(consumeCustomerContactPreviewToken(token, "20261438", NOW)).toBe(false);
+  });
+
+  it("token po TOKEN_TTL_MS (15 minút) exspiruje", () => {
+    const token = issueCustomerContactPreviewToken("20261438", NOW);
+    const later = new Date(NOW.getTime() + 16 * 60 * 1000);
+    expect(consumeCustomerContactPreviewToken(token, "20261438", later)).toBe(false);
+  });
+
+  it("dva nezávislé náhľady dostanú DVA rôzne tokeny, oba platné", () => {
+    const tokenA = issueCustomerContactPreviewToken("20261438", NOW);
+    const tokenB = issueCustomerContactPreviewToken("20261431", NOW);
+    expect(tokenA).not.toBe(tokenB);
+    expect(consumeCustomerContactPreviewToken(tokenA, "20261438", NOW)).toBe(true);
+    expect(consumeCustomerContactPreviewToken(tokenB, "20261431", NOW)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/orders/customer-contact-preview-tokens.ts
+++ b/apps/api/src/modules/orders/customer-contact-preview-tokens.ts
@@ -1,0 +1,66 @@
+// issue 500: rovnaký server-side vynútený „náhľad VŽDY pred odoslaním"
+// mechanizmus ako `modules/nedostupne/preview-tokens.ts` /
+// `modules/orders/merge-mail-preview-tokens.ts` (viď návrhový komentár na
+// tickete + `.claude/rules/nedostupne.md`) — `/order-customer-contact/preview`
+// vydá jednorazový token viazaný na presne `orderCode`, `.../send` ho musí
+// priniesť späť a token sa SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie, bez
+// ohľadu na zhodu. Bez tohto by priame volanie API mohlo poslať e-mail
+// zákazníkovi bez toho, aby ho čokoľvek niekedy zobrazilo — presne ten gap,
+// ktorý `nedostupne`/`order-merge` zámerne zatvorili pred mergom. Rovnaký
+// in-process `Map` vzor ako `login-rate-limit.ts` (jedna bežiaca inštancia
+// appky, MVP rozsah — reštart appky token zruší, čo je v poriadku, obsluha si
+// vie náhľad znova otvoriť).
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — rovnaký strop ako nedostupne/order-merge
+const MAX_ENTRIES = 1_000;
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+interface PreviewTokenEntry {
+  readonly orderCode: string;
+  readonly expiresAt: number;
+}
+
+const tokens = new Map<string, PreviewTokenEntry>();
+let lastSweepAtMs = 0;
+
+function sweepExpired(nowMs: number): void {
+  if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
+  lastSweepAtMs = nowMs;
+  for (const [token, entry] of tokens) {
+    if (entry.expiresAt <= nowMs) tokens.delete(token);
+  }
+}
+
+/** Vydá nový jednorazový token pre presne túto objednávku (`externalOrderId`) —
+ * volané `POST /api/order-customer-contact/preview`. */
+export function issueCustomerContactPreviewToken(orderCode: string, now: Date): string {
+  const nowMs = now.getTime();
+  sweepExpired(nowMs);
+  // Strop dosiahnutý → uvoľni miesto zmazaním najskôr vypršiavajúceho záznamu
+  // (rovnaký zámer ako `merge-mail-preview-tokens.ts`).
+  if (tokens.size >= MAX_ENTRIES) {
+    let oldestToken: string | undefined;
+    let oldestExpiresAt = Infinity;
+    for (const [token, entry] of tokens) {
+      if (entry.expiresAt < oldestExpiresAt) {
+        oldestExpiresAt = entry.expiresAt;
+        oldestToken = token;
+      }
+    }
+    if (oldestToken !== undefined) tokens.delete(oldestToken);
+  }
+  const token = crypto.randomUUID();
+  tokens.set(token, { orderCode, expiresAt: nowMs + TOKEN_TTL_MS });
+  return token;
+}
+
+/** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE túto objednávku —
+ * `POST /api/order-customer-contact/send` volá TOTO pred akýmkoľvek odoslaním.
+ * Token sa maže VŽDY (aj pri nezhode) — jednorazový, nikdy sa nedá „vyskúšať"
+ * opakovane. */
+export function consumeCustomerContactPreviewToken(token: string, orderCode: string, now: Date): boolean {
+  const entry = tokens.get(token);
+  tokens.delete(token);
+  if (entry === undefined) return false;
+  if (entry.expiresAt <= now.getTime()) return false;
+  return entry.orderCode === orderCode;
+}

--- a/apps/api/src/modules/orders/customer-contact.ts
+++ b/apps/api/src/modules/orders/customer-contact.ts
@@ -1,0 +1,150 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/client.js";
+import { orders } from "../../db/schema.js";
+import { log } from "../../logger.js";
+import { recordSkippedMail, sendLoggedMail, type MailLogContext } from "../mail-log/service.js";
+import { globalContext, textValue } from "../mail-templates/context.js";
+import { renderEditedBody, renderTemplate } from "../mail-templates/render.js";
+import { resolveTemplate } from "../mail-templates/store.js";
+import type { MailTransport } from "../mail/transport.js";
+
+// issue 500: ručný e-mail zákazníkovi z riadku „Na objednanie" (@ tlačidlo v
+// stĺpci DODÁVATEĽ). Zámerne úzko zrkadlí „Zlúčenie objednávok"
+// (`merge-mail.ts`) — objednávkovo-viazaný zákaznícky e-mail cez JEDINÚ
+// odosielaciu cestu F193 (`sendLoggedMail`), upraviteľnú šablónu F192
+// (`resolveTemplate`) a povinný náhľad pred odoslaním
+// (`customer-contact-preview-tokens.ts`, vynútené v routách). Na rozdiel od
+// `nedostupne` NEMÁ žiadnu dedup/stavovú tabuľku ani advisory zámok — je to
+// bežná ručná akcia zamestnanca, žiadne „už raz odoslané" pravidlo; jedinú
+// pretekársku situáciu (dvojklik) rieši jednorazová spotreba preview tokenu.
+
+export interface CustomerContactContext {
+  readonly orderCode: string;
+  readonly customerName: string;
+  // "" keď objednávka nemá e-mail zákazníka — appka email nikdy needukuje, len
+  // prenáša (rovnaký zámer ako `nedostupne`'s `NedostupneEmailContext`).
+  readonly email: string;
+}
+
+/** Nájde objednávku podľa jej Shoptet čísla (`externalOrderId`, unikátne) a
+ * vytiahne meno + e-mail zákazníka. `null` = objednávka sa nenašla. */
+export async function findCustomerContactContext(db: Database, orderCode: string): Promise<CustomerContactContext | null> {
+  const [row] = await db
+    .select({ customerName: orders.customerName, email: orders.email })
+    .from(orders)
+    .where(eq(orders.externalOrderId, orderCode))
+    .limit(1);
+  if (row === undefined) return null;
+  return { orderCode, customerName: row.customerName, email: row.email ?? "" };
+}
+
+export interface CustomerContactMailContent {
+  readonly to: string | null;
+  readonly customerName: string;
+  readonly subject: string;
+  readonly html: string;
+  readonly text: string;
+}
+
+/** Náhľad aj odoslanie skladajú obsah TOU ISTOU cestou — garantuje, že sa
+ * zákazníkovi pošle PRESNE to, čo obsluha videla v náhľade. Znenie sa načíta z
+ * upraviteľnej šablóny (F192); keď majiteľ nič neupravil, vráti `resolveTemplate`
+ * pôvodné znenie z kódu. */
+export async function buildCustomerContactMail(db: Database, ctx: CustomerContactContext): Promise<CustomerContactMailContent> {
+  const template = await resolveTemplate(db, "order_customer_contact");
+  const rendered = renderTemplate(template, {
+    ...globalContext(),
+    meno_zakaznika: textValue(ctx.customerName),
+    cislo_objednavky: textValue(ctx.orderCode),
+  });
+  const trimmedEmail = ctx.email.trim();
+  return {
+    to: trimmedEmail === "" ? null : trimmedEmail,
+    customerName: ctx.customerName,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+  };
+}
+
+export type SendCustomerContactResult =
+  | { readonly status: "sent"; readonly to: string }
+  | { readonly status: "not_found" }
+  | { readonly status: "no_email" }
+  | { readonly status: "not_configured"; readonly reason: string }
+  | { readonly status: "send_failed" };
+
+export interface SendCustomerContactOptions {
+  readonly db: Database;
+  readonly now: Date;
+  readonly orderCode: string;
+  readonly mailTransport: MailTransport | undefined;
+  readonly bccEmail: string | undefined;
+  // issue 193: kto tlačidlo stlačil — táto cesta je VŽDY ručná akcia
+  // zamestnanca (žiadny naplánovaný beh), zapisuje sa do knihy ako `manual`.
+  readonly actorUserId?: string;
+  // issue 277: obsluha upravila text priamo v okne náhľadu — keď je prítomný,
+  // PREPÍŠE vygenerované `html`/`text` (predmet ostáva pôvodný). Šablóna v DB sa
+  // touto úpravou nikdy nemení.
+  readonly editedBody?: string;
+}
+
+/**
+ * Fail-closed: chýbajúca BCC adresa ALEBO chýbajúci mail transport → NEPOŠLE
+ * NIČ (rovnaký zámer ako `nedostupne`/`order-merge` — majiteľova podmienka
+ * „všade nech je BCC, keď niečo posiela mail"). Žiadny advisory zámok — na
+ * rozdiel od `nedostupne` tu neexistuje „už raz odoslané" business pravidlo;
+ * dvojklik na TO ISTÉ odoslanie je už vyriešený jednorazovou spotrebou preview
+ * tokenu (`customer-contact-preview-tokens.ts`, vynútené v routách).
+ */
+export async function sendCustomerContactMail(options: SendCustomerContactOptions): Promise<SendCustomerContactResult> {
+  const { db, now, orderCode, mailTransport, bccEmail, actorUserId, editedBody } = options;
+
+  const logCtx: MailLogContext = {
+    source: "order_customer_contact",
+    trigger: "manual",
+    templateKey: "order_customer_contact",
+    orderCode,
+    ...(actorUserId === undefined ? {} : { actorUserId }),
+  };
+
+  const ctx = await findCustomerContactContext(db, orderCode);
+  if (ctx === null) return { status: "not_found" };
+
+  const built = await buildCustomerContactMail(db, ctx);
+  const { to } = built;
+  if (to === null) {
+    await recordSkippedMail(db, now, logCtx, "", "objednávka nemá e-mailovú adresu zákazníka");
+    return { status: "no_email" };
+  }
+
+  const bccMissing = bccEmail === undefined || bccEmail.trim() === "";
+  if (bccMissing) {
+    const reason = "chýba adresa pre skrytú kópiu majiteľovi (ORDER_CUSTOMER_CONTACT_BCC_EMAIL)";
+    await recordSkippedMail(db, now, logCtx, to, reason);
+    return { status: "not_configured", reason };
+  }
+  if (mailTransport === undefined) {
+    const reason = "odosielanie e-mailov nie je nakonfigurované (chýba MAIL_HOST)";
+    await recordSkippedMail(db, now, logCtx, to, reason);
+    return { status: "not_configured", reason };
+  }
+
+  // issue 277: obsluha mohla text v okne náhľadu upraviť — odošle sa PRESNE to
+  // (predmet ostáva z pôvodného vyrenderovania), nikdy znova vygenerovaná
+  // šablóna.
+  const finalContent = editedBody === undefined ? built : { ...built, ...renderEditedBody(editedBody) };
+  const sendResult = await sendLoggedMail(
+    db,
+    mailTransport,
+    { to, subject: built.subject, text: finalContent.text, html: finalContent.html, bcc: bccEmail },
+    now,
+    logCtx,
+  );
+  if (!sendResult.ok) {
+    log.error({ orderCode, rawErrorMessage: sendResult.rawErrorMessage }, "Kontakt zákazníkovi: odoslanie e-mailu zlyhalo");
+    return { status: "send_failed" };
+  }
+  log.info({ orderCode }, "Kontakt zákazníkovi: e-mail odoslaný");
+  return { status: "sent", to };
+}

--- a/apps/api/tests/mail-templates.integration.test.ts
+++ b/apps/api/tests/mail-templates.integration.test.ts
@@ -54,7 +54,8 @@ it("zoznam vráti všetky druhy e-mailov s pôvodným znením, kým sa nič neup
   expect(res.status).toBe(200);
   const payload = (await res.json()) as { templates: { key: string; subject: string; isCustomized: boolean; placeholders: unknown[] }[] };
   // issue 257: "order_merge" — deviaty druh e-mailu (Zlúčenie objednávky).
-  expect(payload.templates).toHaveLength(9);
+  // issue 500: "order_customer_contact" — desiaty druh (@ e-mail zákazníkovi).
+  expect(payload.templates).toHaveLength(10);
   const nedostupne = payload.templates.find((t) => t.key === "nedostupne");
   expect(nedostupne?.isCustomized).toBe(false);
   expect(nedostupne?.subject).toBe(MAIL_TEMPLATE_KINDS["nedostupne"].defaultText.subject);

--- a/apps/api/tests/order-customer-contact.integration.test.ts
+++ b/apps/api/tests/order-customer-contact.integration.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, expect, it } from "vitest";
+import { mailLog, orders, users } from "../src/db/schema.js";
+import { createApp } from "../src/http/app.js";
+import { resetLoginRateLimit } from "../src/http/login-rate-limit.js";
+import { hashPassword } from "../src/modules/auth/passwords.js";
+import type { UserRole } from "../src/modules/auth/service.js";
+import type { MailMessage } from "../src/modules/mail/transport.js";
+import { DEFAULT_ORDER_OPEN_STATUS } from "../src/modules/orders/open-statuses.js";
+import { withCleanDb } from "./helpers/db.js";
+
+// issue 500/502: HTTP vrstva ručného e-mailu zákazníkovi z riadku „Na
+// objednanie"/„Riešiť". Falošný mail transport — NIKDY skutočný SMTP (rovnaká
+// majiteľova bezpečnostná podmienka ako `order-merge-http.integration.test.ts`).
+// `findCustomerContactContext` číta VÝHRADNE tabuľku `orders` podľa
+// `externalOrderId`, takže žiadny `order_line`/variant fixtúra tu netreba.
+const HESLO = "test-heslo-abc";
+
+let close: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await close?.();
+  close = undefined;
+  resetLoginRateLimit();
+});
+
+async function boot(role: UserRole, options: { readonly sent?: MailMessage[]; readonly bccEmail?: string } = {}) {
+  const ctx = await withCleanDb();
+  close = ctx.close;
+  await ctx.db.insert(users).values({
+    email: "pouzivatel@forestshop.sk",
+    passwordHash: await hashPassword(HESLO),
+    displayName: "Test",
+    role,
+  });
+
+  const app = createApp(ctx.db, {
+    cookieSecure: false,
+    orderCustomerContact: {
+      mailTransport:
+        options.sent === undefined
+          ? undefined
+          : (m: MailMessage) => {
+              options.sent?.push(m);
+              return Promise.resolve();
+            },
+      bccEmail: options.bccEmail,
+    },
+  });
+  const login = await app.request("/api/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "pouzivatel@forestshop.sk", password: HESLO }),
+  });
+  const cookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+  return { app, cookie, db: ctx.db };
+}
+
+async function seedOrder(
+  db: Awaited<ReturnType<typeof boot>>["db"],
+  externalOrderId: string,
+  options: { readonly customerName?: string; readonly email?: string | null } = {},
+): Promise<void> {
+  await db.insert(orders).values({
+    externalOrderId,
+    customerName: options.customerName ?? "Zákazník Test",
+    email: options.email === undefined ? "zakaznik@example.sk" : options.email,
+    statusName: DEFAULT_ORDER_OPEN_STATUS,
+    placedAt: new Date("2026-08-20T10:00:00Z"),
+  });
+}
+
+async function preview(app: Awaited<ReturnType<typeof boot>>["app"], cookie: string, orderCode: string) {
+  return app.request("/api/order-customer-contact/preview", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode }),
+  });
+}
+
+it("náhľad bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/order-customer-contact/preview", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9401" }),
+  });
+  expect(res.status).toBe(401);
+});
+
+it("neznáma objednávka vráti 200 { ok:false } (nikdy 4xx — konzolové pravidlo)", async () => {
+  const { app, cookie } = await boot("citanie");
+  const res = await preview(app, cookie, "neexistuje");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean };
+  expect(body.ok).toBe(false);
+});
+
+it("náhľad predvyplní meno + číslo objednávky a vydá token; odoslanie bez tokenu zlyhá, s tokenom uspeje a zapíše do Knihy; token je jednorazový", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedOrder(db, "9401", { customerName: "Alfa Zákazník", email: "alfa@example.sk" });
+
+  const previewRes = await preview(app, cookie, "9401");
+  expect(previewRes.status).toBe(200);
+  const previewBody = (await previewRes.json()) as {
+    ok: boolean;
+    subject: string;
+    text: string;
+    recipient: string;
+    customerName: string;
+    previewToken: string;
+  };
+  expect(previewBody.ok).toBe(true);
+  expect(previewBody.recipient).toBe("alfa@example.sk");
+  expect(previewBody.customerName).toBe("Alfa Zákazník");
+  expect(previewBody.subject).toContain("9401");
+  expect(previewBody.text).toContain("Alfa Zákazník");
+  expect(previewBody.text).toContain("9401");
+
+  // Odoslanie BEZ platného tokenu zlyhá — server-side vynútenie náhľadu.
+  const sendBezTokenu = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9401", previewToken: "invalid" }),
+  });
+  const bezTokenuBody = (await sendBezTokenu.json()) as { ok: boolean };
+  expect(bezTokenuBody.ok).toBe(false);
+  expect(sent).toHaveLength(0);
+
+  // Odoslanie SO správnym tokenom uspeje.
+  const sendRes = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9401", previewToken: previewBody.previewToken }),
+  });
+  const sendBody = (await sendRes.json()) as { ok: boolean };
+  expect(sendBody.ok).toBe(true);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.to).toBe("alfa@example.sk");
+  expect(sent[0]?.bcc).toBe("majitel@forestshop.sk");
+
+  const logRows = await db.select({ source: mailLog.source, recipient: mailLog.recipient }).from(mailLog);
+  expect(logRows).toHaveLength(1);
+  expect(logRows[0]?.source).toBe("order_customer_contact");
+  expect(logRows[0]?.recipient).toBe("alfa@example.sk");
+
+  // Ten istý token DRUHÝKRÁT (jednorazová spotreba) zlyhá.
+  const druhe = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9401", previewToken: previewBody.previewToken }),
+  });
+  const druheBody = (await druhe.json()) as { ok: boolean };
+  expect(druheBody.ok).toBe(false);
+  expect(sent).toHaveLength(1);
+});
+
+it("ručne upravené telo (editedBody) sa odošle PRESNE takto (predmet ostáva pôvodný)", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedOrder(db, "9402", { customerName: "Beta Zákazník", email: "beta@example.sk" });
+
+  const previewBody = (await (await preview(app, cookie, "9402")).json()) as { subject: string; previewToken: string };
+  const edited = "Dobrý deň, Beta Zákazník,\n\nMáme pre Vás špeciálnu ponuku k objednávke 9402.\n\nS pozdravom";
+  const sendRes = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9402", previewToken: previewBody.previewToken, editedBody: edited }),
+  });
+  expect(((await sendRes.json()) as { ok: boolean }).ok).toBe(true);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.text).toContain("špeciálnu ponuku");
+  // Predmet sa ručnou úpravou tela NIKDY nemení.
+  expect(sent[0]?.subject).toBe(previewBody.subject);
+});
+
+it("fail-closed: bez BCC adresy sa NEPOŠLE nič (zapíše sa preskočenie)", async () => {
+  const sent: MailMessage[] = [];
+  // sent transport JE, ale bccEmail chýba → not_configured.
+  const { app, cookie, db } = await boot("manazer", { sent });
+  await seedOrder(db, "9403", { customerName: "Gama Zákazník", email: "gama@example.sk" });
+
+  const previewBody = (await (await preview(app, cookie, "9403")).json()) as { previewToken: string };
+  const sendRes = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9403", previewToken: previewBody.previewToken }),
+  });
+  expect(((await sendRes.json()) as { ok: boolean }).ok).toBe(false);
+  expect(sent).toHaveLength(0);
+  const skipped = await db.select({ status: mailLog.status, source: mailLog.source }).from(mailLog);
+  expect(skipped).toHaveLength(1);
+  expect(skipped[0]?.status).toBe("skipped");
+  expect(skipped[0]?.source).toBe("order_customer_contact");
+});
+
+it("objednávka bez e-mailu zákazníka sa NEPOŠLE (no_email)", async () => {
+  const sent: MailMessage[] = [];
+  const { app, cookie, db } = await boot("manazer", { sent, bccEmail: "majitel@forestshop.sk" });
+  await seedOrder(db, "9404", { customerName: "Delta Bez Emailu", email: null });
+
+  const previewBody = (await (await preview(app, cookie, "9404")).json()) as { recipient: string; previewToken: string };
+  expect(previewBody.recipient).toBe("");
+  const sendRes = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9404", previewToken: previewBody.previewToken }),
+  });
+  expect(((await sendRes.json()) as { ok: boolean }).ok).toBe(false);
+  expect(sent).toHaveLength(0);
+});
+
+it("rola citanie NESMIE odoslať (403) — náhľad áno, odosielanie len admin/manazer", async () => {
+  const { app, cookie, db } = await boot("citanie", { sent: [], bccEmail: "majitel@forestshop.sk" });
+  await seedOrder(db, "9405", { customerName: "Zeta Zákazník", email: "zeta@example.sk" });
+
+  const previewBody = (await (await preview(app, cookie, "9405")).json()) as { ok: boolean; previewToken: string };
+  expect(previewBody.ok).toBe(true);
+
+  const res = await app.request("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify({ orderCode: "9405", previewToken: previewBody.previewToken }),
+  });
+  expect(res.status).toBe(403);
+});

--- a/apps/web/src/components/CustomerContactDialog.tsx
+++ b/apps/web/src/components/CustomerContactDialog.tsx
@@ -1,0 +1,42 @@
+import type { JSX } from "react";
+import type { CustomerContactMailApi } from "../useCustomerContactMail.js";
+import { MailPreviewDialog } from "./MailPreviewDialog.js";
+
+// issue 500/502: zdieľané okno na ručný e-mail zákazníkovi (@ tlačidlo na
+// riadku) — jedno na celú sekciu, otvorí ho ktorýkoľvek riadok. Renderuje ho
+// „Na objednanie" (`OrdersSection`) aj „Riešiť" (`RiesitSection`) rovnako, aby
+// bola funkcia identická. Chyba náhľadu (napr. objednávka sa nenašla) sa
+// zobrazí, keď okno NIE JE otvorené; chyby PRI otvorenom okne (napr. chýba BCC)
+// idú priamo do okna.
+export function CustomerContactDialog({ contact }: { readonly contact: CustomerContactMailApi }): JSX.Element {
+  return (
+    <>
+      {contact.pending === null && contact.error !== "" && (
+        <p role="alert" data-testid="customer-contact-error">
+          {contact.error}
+        </p>
+      )}
+      {contact.pending !== null && (
+        <MailPreviewDialog
+          testId="customer-contact-preview"
+          title="Náhľad e-mailu — povinné pred odoslaním"
+          recipient={contact.pending.preview.recipient}
+          subject={contact.pending.preview.subject}
+          bodyText={contact.body}
+          onBodyTextChange={contact.setBody}
+          confirmLabel="📧 Odoslať zákazníkovi"
+          confirmDisabled={contact.busy || contact.body.trim() === ""}
+          onConfirm={contact.confirmSend}
+          returnFocusRef={contact.triggerRef}
+          onClose={contact.close}
+        >
+          {contact.error !== "" && (
+            <p role="alert" data-testid="customer-contact-dialog-error">
+              {contact.error}
+            </p>
+          )}
+        </MailPreviewDialog>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/CustomerContactRowButton.tsx
+++ b/apps/web/src/components/CustomerContactRowButton.tsx
@@ -1,0 +1,35 @@
+import type { JSX } from "react";
+
+// issue 500/502: @ tlačidlo (ručný e-mail zákazníkovi) na riadku „Na
+// objednanie" (`OrderLineRow`) AJ „Riešiť" (`RiesitOrderRow`) — zdieľané, aby
+// bolo v oboch sekciách identické. `testIdKey` je JEDINEČNÝ kľúč riadku (lineId
+// v „Na objednanie", kde jedna objednávka môže mať viac riadkov s tým istým
+// číslom; externalOrderId v „Riešiť", kde riadok je per-objednávka), `orderCode`
+// je číslo objednávky pre náhľad, `customerName` len pre `aria-label`. Spúšťací
+// prvok ide do `onOpen` (návrat fokusu po zavretí dialógu).
+export function CustomerContactRowButton({
+  testIdKey,
+  orderCode,
+  customerName,
+  onOpen,
+}: {
+  readonly testIdKey: string;
+  readonly orderCode: string;
+  readonly customerName: string;
+  readonly onOpen: (orderCode: string, trigger: HTMLElement | null) => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      className="customer-contact-btn"
+      data-testid={`customer-contact-open-${testIdKey}`}
+      aria-label={`Napísať e-mail zákazníkovi ${customerName} k objednávke ${orderCode}`}
+      title="Napísať e-mail zákazníkovi"
+      onClick={(e) => {
+        onOpen(orderCode, e.currentTarget);
+      }}
+    >
+      <span aria-hidden="true">@</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/OrderLineRow.tsx
+++ b/apps/web/src/components/OrderLineRow.tsx
@@ -4,7 +4,9 @@ import type { OrderLine } from "../ordersApi.js";
 import { STATE_LABELS } from "../orderLineStateLabels.js";
 import { formatVariantTotalChip, isStaleOrderLine, orderLineAgeDays, type VariantTotal } from "../ordersSummary.js";
 import { CustomerOrderCountBadge } from "./CustomerOrderCountBadge.js";
+import { CustomerContactRowButton } from "./CustomerContactRowButton.js";
 import { OrderLineStateButtons } from "./OrderLineStateButtons.js";
+import { OrderSupplierLinkDisplay } from "./OrderSupplierLinkDisplay.js";
 
 // issue 162: počet stĺpcov "Na objednanie" tabuľky — MUSÍ sedieť s počtom
 // `<col>` v `SupplierOrderGroup.tsx`'s `<colgroup>` (9). Vlastný rozbaľovací
@@ -35,6 +37,7 @@ export function OrderLineRow({
   onChangeComment,
   onEditorActivityChange,
   onSupplierDraftChange,
+  onOpenCustomerContact,
 }: {
   readonly line: OrderLine;
   readonly canChangeState: boolean;
@@ -91,6 +94,13 @@ export function OrderLineRow({
   // `onEditorActivityChange` vyššie (len boolean) tu ide o SAMOTNÝ TEXT,
   // lebo ten musí prežiť aj presun riadku medzi skupinami (remount).
   readonly onSupplierDraftChange: (lineId: string, value: string) => void;
+  // issue 500: @ tlačidlo v stĺpci DODÁVATEĽ otvorí okno na ručný e-mail
+  // zákazníkovi (`OrdersSection.tsx` vlastní stav modálu). VOLITEĽNÉ — „Riešiť"
+  // (`RiesitOrderRow`) ho neposiela, takže tlačidlo je LEN v „Na objednanie".
+  // Nesie číslo objednávky + spúšťací prvok (návrat fokusu po zavretí dialógu,
+  // `MailPreviewDialog`'s `returnFocusRef`); meno zákazníka si okno vezme z
+  // náhľadu zo servera.
+  readonly onOpenCustomerContact?: (orderCode: string, trigger: HTMLElement | null) => void;
 }): JSX.Element {
   const qtyChip = variantTotal !== undefined ? formatVariantTotalChip(variantTotal) : null;
 
@@ -337,53 +347,27 @@ export function OrderLineRow({
             namiesto dvoch samostatných stĺpcov. */}
         <td className="ord-supplier-merged">
           <div className="ord-supplier-row">
-            <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
-              {line.supplierUrl !== null ? (
-                // issue 119: majiteľ, doslovne "zmen na nejake tlacitko z ikonou
-                // ktore otvori na novom okne ten link, lebo teraz to je tazke
-                // stlacit" — textový odkaz nahradený veľkým ikonovým tlačidlom
-                // (`.ord-supplier-link` v `app.css` teraz štylizuje `<a>` ako
-                // tlačidlo, min. 36×36px klikacej plochy). `aria-label`/`title`
-                // nesú ten istý popis ako predtým (issue 72: variantName sám
-                // nestačí — dva riadky toho istého produktu v rôznych veľkostiach
-                // majú zhodný variantName, líšia sa len variantCode), viditeľný
-                // text je teraz len ikonka (`aria-hidden`, prístupné meno nesie
-                // výlučne `aria-label`).
-                <a
-                  href={line.supplierUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="ord-supplier-link"
-                  aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-                  title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
-                >
-                  <span aria-hidden="true">🔗</span>
-                </a>
-              ) : line.supplierNote !== null ? (
-                <span className="ord-supplier-note" title={line.supplierNote}>
-                  {line.supplierNote}
-                </span>
-              ) : line.supplierAssignable ? (
-                // issue 107 bod 3: majiteľ, komentár #1: "neviem čo tam je
-                // Priradenie dodávateľa stĺpec" — namiesto holej pomlčky (predtým
-                // aj tu, aj v `.ord-supplier-assign` nižšie — DVE pomlčky nad
-                // sebou) je tu teraz VIDITEĽNÝ popis toho, čo vstup pod ním robí.
-                // Zámerne v TEJTO, už existujúcej bunke (nie nový riadok pod
-                // vstupom) — pridanie ĎALŠIEHO riadku by pri úzkom stĺpci
-                // (input+button už zapĺňajú takmer celú šírku) posunulo výšku
-                // riadku nad issue 105's ~95px invariant (živo zmerané: 85px →
-                // 103.5px s popisom na vlastnom riadku).
-                <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>
-              ) : (
-                // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY
-                // nezobrazuje — majiteľ ho nepoužíva ("kody produktov vobec
-                // nepouzivame"), appka používa výlučne odkaz na dodávateľa.
-                // Predtým sa táto pomlčka potláčala, keď `externalCode` bol
-                // vyplnený (zobrazoval sa namiesto nej samostatný "kód …" riadok)
-                // — bez toho riadku je terajší terminálny stav VŽDY pomlčka,
-                // keď riadok nemá ani odkaz, ani poznámku, ani priradenie
-                // (legitímny, `OrderLineRow.supplierAssignCell.test.tsx`).
-                "—"
+            {/* issue 500: 🔗 (odkaz na dodávateľa) + @ (e-mail zákazníkovi)
+                vedľa seba na HORNOM riadku bunky; ✏️ (úprava odkazu) ostáva POD
+                nimi (`.ord-supplier-row` je stĺpcová od issue 476). */}
+            <div className="ord-supplier-top">
+              <div className="ord-supplier-cell" data-testid={`supplier-link-${line.lineId}`}>
+                {/* issue 500: obsah bunky (🔗 / poznámka / hint / „—") vyčlenený
+                    do `OrderSupplierLinkDisplay` (eslint `max-lines`). */}
+                <OrderSupplierLinkDisplay line={line} />
+              </div>
+              {/* issue 500/502: @ tlačidlo — otvorí okno na ručný e-mail
+                  zákazníkovi (`OrdersSection.tsx` vlastní modál). Gated na
+                  `canChangeState` (server `/send` vyžaduje admin/manazer) A
+                  prítomnosť callbacku („Riešiť" ho neposiela). Zdieľané tlačidlo
+                  s „Riešiť" (`CustomerContactRowButton`). */}
+              {canChangeState && onOpenCustomerContact !== undefined && (
+                <CustomerContactRowButton
+                  testIdKey={line.lineId}
+                  orderCode={line.externalOrderId}
+                  customerName={line.customerName}
+                  onOpen={onOpenCustomerContact}
+                />
               )}
             </div>
             {/* issue 121: majiteľ, doslovne "ma byt moznost ho doplnit... pri

--- a/apps/web/src/components/OrderSupplierLinkDisplay.tsx
+++ b/apps/web/src/components/OrderSupplierLinkDisplay.tsx
@@ -1,0 +1,45 @@
+import type { JSX } from "react";
+import type { OrderLine } from "../ordersApi.js";
+
+// issue 500: vyčlenené z `OrderLineRow.tsx` (prekročil eslint `max-lines: 400`
+// po pridaní @ tlačidla) — čisto PREZENTAČNÝ obsah bunky DODÁVATEĽ: veľké
+// ikonové tlačidlo odkazu (🔗) / poznámka dodávateľa / popis „Priradiť
+// dodávateľa" / pomlčka. Rovnaké DOM aj logika ako predtým (žiadna zmena
+// existujúcich testov — `.ord-supplier-cell` textContent ostáva presne „—"
+// pre riadok bez údajov, `OrdersSection.test.tsx`/`supplierAssignCell.test`).
+export function OrderSupplierLinkDisplay({ line }: { readonly line: OrderLine }): JSX.Element {
+  if (line.supplierUrl !== null) {
+    // issue 119: textový odkaz nahradený veľkým ikonovým tlačidlom (36×36px
+    // klikacia plocha). `aria-label`/`title` nesú popis (issue 72: variantName
+    // sám nestačí — dva riadky rovnakého produktu v rôznych veľkostiach majú
+    // zhodný názov, líšia sa len `variantCode`); viditeľný text je len ikonka.
+    return (
+      <a
+        href={line.supplierUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="ord-supplier-link"
+        aria-label={`Odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+        title={`Otvoriť odkaz na dodávateľa — ${line.variantName} (${line.variantCode})`}
+      >
+        <span aria-hidden="true">🔗</span>
+      </a>
+    );
+  }
+  if (line.supplierNote !== null) {
+    return (
+      <span className="ord-supplier-note" title={line.supplierNote}>
+        {line.supplierNote}
+      </span>
+    );
+  }
+  if (line.supplierAssignable) {
+    // issue 107 bod 3: viditeľný popis toho, čo vstup pod bunkou robí (namiesto
+    // holej pomlčky) — zámerne v TEJTO existujúcej bunke, aby nepribudol riadok
+    // výšky (issue 105 invariant).
+    return <span className="ord-supplier-assign-hint">Priradiť dodávateľa</span>;
+  }
+  // issue 117: `externalCode` (dodávateľský kód) sa už NIKDY nezobrazuje —
+  // terminálny stav bez odkazu/poznámky/priradenia je VŽDY pomlčka.
+  return <>—</>;
+}

--- a/apps/web/src/components/OrdersSection.customerContact.test.tsx
+++ b/apps/web/src/components/OrdersSection.customerContact.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { OrdersSection } from "./OrdersSection.js";
+
+// issue 500: @ tlačidlo na riadku „Na objednanie" otvorí okno na ručný e-mail
+// zákazníkovi (zdieľané jadro `useCustomerContactMail`). Mockujú sa len
+// dvojkrokové API funkcie (náhľad → odoslanie) + načítanie zoznamu/prehľadu.
+const { fetchOpenOrders, fetchOrdersOverview, fetchCustomerContactPreview, sendCustomerContactMail } = vi.hoisted(() => ({
+  fetchOpenOrders: vi.fn(),
+  fetchOrdersOverview: vi.fn(),
+  fetchCustomerContactPreview: vi.fn(),
+  sendCustomerContactMail: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return {
+    ...actual,
+    fetchOpenOrders,
+    fetchOrdersOverview,
+    fetchCustomerContactPreview,
+    sendCustomerContactMail,
+  };
+});
+
+const LINE_STARA = {
+  lineId: "11111111-1111-1111-1111-111111111111",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111111",
+  externalOrderId: "1001",
+  customerName: "Zákazník Starý",
+  comment: null,
+  remark: null,
+  shopRemark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=1001&src=orders",
+  placedAt: "2026-07-01T00:00:00.000Z",
+  variantCode: "A-1",
+  variantName: "Nohavice FOREST 1003",
+  sizeLabel: "3XL",
+  quantity: 2,
+  state: "objednane" as const,
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+  customerOpenOrderCount: 1,
+  ourUrl: null,
+};
+
+const PREVIEW = {
+  ok: true as const,
+  subject: "Vaša objednávka č. 1001 — Forestshop.sk",
+  html: "<p>...</p>",
+  text: [
+    "Dobrý deň, Zákazník Starý,",
+    "",
+    "Radi by sme Vás kontaktovali ohľadom Vašej objednávky č. 1001.",
+    "",
+    "S pozdravom,",
+    "Drlík, Forestshop.sk",
+  ].join("\n"),
+  recipient: "zakaznik@example.sk",
+  customerName: "Zákazník Starý",
+  previewToken: "tok-123",
+};
+
+beforeEach(() => {
+  fetchOrdersOverview.mockResolvedValue({
+    today: { orderCount: 0, revenue: "0.00" },
+    week: { orderCount: 0, revenue: "0.00" },
+    month: { orderCount: 0, revenue: "0.00" },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("klik @ otvorí okno predvyplnené menom + číslom objednávky, potvrdenie odošle presne ten text", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+  fetchCustomerContactPreview.mockResolvedValue(PREVIEW);
+  sendCustomerContactMail.mockResolvedValue({ ok: true });
+
+  render(<OrdersSection role="manazer" onSessionExpired={() => {}} />);
+
+  const atBtn = await screen.findByTestId(`customer-contact-open-${LINE_STARA.lineId}`);
+  fireEvent.click(atBtn);
+
+  // Náhľad sa pýta podľa ČÍSLA objednávky (externalOrderId), nie lineId.
+  await waitFor(() => {
+    expect(fetchCustomerContactPreview).toHaveBeenCalledWith("1001");
+  });
+
+  const dialog = await screen.findByTestId("customer-contact-preview");
+  expect(dialog.textContent).toContain("zakaznik@example.sk");
+  // issue 277: telo je kontrolovaná `<textarea>` — hodnotu treba čítať cez
+  // `.value`, nikdy `textContent` (React nastavuje `.value` ako DOM vlastnosť).
+  const body = screen.getByTestId<HTMLTextAreaElement>("customer-contact-preview-body");
+  expect(body.value).toContain("Zákazník Starý");
+  expect(body.value).toContain("1001");
+
+  fireEvent.click(screen.getByTestId("customer-contact-preview-confirm"));
+
+  await waitFor(() => {
+    expect(sendCustomerContactMail).toHaveBeenCalledWith("1001", "tok-123", expect.stringContaining("Zákazník Starý"));
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId("customer-contact-preview")).toBeNull();
+  });
+});
+
+it("pri role bez oprávnenia zmien (citanie) sa @ tlačidlo vôbec nevykreslí", async () => {
+  fetchOpenOrders.mockResolvedValue([{ supplier: "Dodávateľ Alfa", lines: [LINE_STARA], email: null }]);
+
+  render(<OrdersSection role="citanie" onSessionExpired={() => {}} />);
+
+  await screen.findByTestId(`order-line-${LINE_STARA.lineId}`);
+  expect(screen.queryByTestId(`customer-contact-open-${LINE_STARA.lineId}`)).toBeNull();
+});

--- a/apps/web/src/components/OrdersSection.tsx
+++ b/apps/web/src/components/OrdersSection.tsx
@@ -16,6 +16,8 @@ import { OrdersOverviewTiles } from "./OrdersOverviewTiles.js";
 import { OrdersToolbar } from "./OrdersToolbar.js";
 import { OrderWriteFailuresBanner } from "./OrderWriteFailuresBanner.js";
 import { SupplierOrderGroup } from "./SupplierOrderGroup.js";
+import { CustomerContactDialog } from "./CustomerContactDialog.js";
+import { useCustomerContactMail } from "../useCustomerContactMail.js";
 import { fetchOpenOrders, NEZNAMY_DODAVATEL } from "../ordersApi.js";
 
 // Rovnaké dve role, ktoré server vyžaduje pre
@@ -156,6 +158,11 @@ export function OrdersSection({
     [suppliers],
   );
 
+  // issue 500: @ tlačidlo na riadku otvorí okno na ručný e-mail zákazníkovi —
+  // zdieľané jadro (`useCustomerContactMail`) so sekciou „Riešiť" (#502), aby
+  // bola funkcia identická.
+  const contact = useCustomerContactMail(onSessionExpired);
+
   return (
     <section className="orders-section">
       {!loaded && <p>Načítavam otvorené objednávky…</p>}
@@ -239,8 +246,12 @@ export function OrdersSection({
           onOpenPreview={mail.openPreview}
           onClosePreview={mail.closePreview}
           onConfirmSend={mail.confirmSend}
+          onOpenCustomerContact={contact.open}
         />
       ))}
+      {/* issue 500: okno na ručný e-mail zákazníkovi — JEDNO na celú sekciu
+          (zdieľané s „Riešiť" #502), otvorí ho @ tlačidlo ktoréhokoľvek riadku. */}
+      <CustomerContactDialog contact={contact} />
     </section>
   );
 }

--- a/apps/web/src/components/RiesitOrderRow.tsx
+++ b/apps/web/src/components/RiesitOrderRow.tsx
@@ -3,6 +3,7 @@ import { formatSkDate } from "../formatDate.js";
 import { computeVariantTotals, formatItemCount } from "../ordersSummary.js";
 import type { RiesitOrder } from "../riesitOrders.js";
 import type { useOrderLinesBoard } from "../useOrderLinesBoard.js";
+import { CustomerContactRowButton } from "./CustomerContactRowButton.js";
 import { OrderLineRow } from "./OrderLineRow.js";
 import { OrderLinesTableHead } from "./OrderLinesTableHead.js";
 
@@ -21,10 +22,15 @@ export function RiesitOrderRow({
   order,
   canChangeState,
   board,
+  onOpenCustomerContact,
 }: {
   readonly order: RiesitOrder;
   readonly canChangeState: boolean;
   readonly board: Board;
+  // issue 502: @ tlačidlo za menom zákazníka otvorí to isté okno na ručný
+  // e-mail zákazníkovi ako „Na objednanie" (#500) — `RiesitSection` vlastní
+  // zdieľaný modál (`useCustomerContactMail`).
+  readonly onOpenCustomerContact: (orderCode: string, trigger: HTMLElement | null) => void;
 }): JSX.Element {
   // Rozbalený/zbalený stav je lokálny per-objednávka. Kľúč zoznamu je `orderId`
   // (RiesitSection), takže inštancia (a teda aj tento stav) prežije re-render
@@ -65,6 +71,19 @@ export function RiesitOrderRow({
           {order.externalOrderId}
         </a>
         <span className="riesit-order-customer">{order.customerName}</span>
+        {/* issue 502: @ tlačidlo — hneď za menom zákazníka (VĽAVO, nikdy
+            napravo, Štěpán), otvorí to isté okno na e-mail zákazníkovi ako „Na
+            objednanie" (#500). Gated na `canChangeState` (server `/send`
+            vyžaduje admin/manazer). `.riesit-order-count`'s `margin-left: auto`
+            (app.css) drží počet+dátum vpravo, takže @ ostáva pri mene vľavo. */}
+        {canChangeState && (
+          <CustomerContactRowButton
+            testIdKey={order.externalOrderId}
+            orderCode={order.externalOrderId}
+            customerName={order.customerName}
+            onOpen={onOpenCustomerContact}
+          />
+        )}
         <span className="riesit-order-count" data-testid={`riesit-order-count-${order.externalOrderId}`}>
           {formatItemCount(order.lines.length)}
         </span>

--- a/apps/web/src/components/RiesitSection.customerContact.test.tsx
+++ b/apps/web/src/components/RiesitSection.customerContact.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { RiesitBadgeRefreshContext } from "../riesitBadgeContext.js";
+import { RiesitSection } from "./RiesitSection.js";
+import type { OrderLine, SupplierOpenOrders } from "../ordersApi.js";
+
+// issue 502: @ tlačidlo za menom zákazníka na riadku „Riešiť" otvorí to isté
+// okno na e-mail zákazníkovi ako „Na objednanie" (#500) — zdieľané jadro
+// `useCustomerContactMail`. Mockujú sa len sieťové funkcie `ordersApi.js`.
+const { fetchRiesitOrders, fetchCustomerContactPreview, sendCustomerContactMail } = vi.hoisted(() => ({
+  fetchRiesitOrders: vi.fn(),
+  fetchCustomerContactPreview: vi.fn(),
+  sendCustomerContactMail: vi.fn(),
+}));
+
+vi.mock("../ordersApi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ordersApi.js")>();
+  return { ...actual, fetchRiesitOrders, fetchCustomerContactPreview, sendCustomerContactMail };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const LINE_RIESIT: OrderLine = {
+  lineId: "11111111-1111-1111-1111-111111111476",
+  orderId: "aaaaaaaa-1111-1111-1111-111111111476",
+  externalOrderId: "7001",
+  customerName: "Zákazník Riešiť",
+  comment: null,
+  remark: null,
+  shopRemark: null,
+  adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=7001&src=orders",
+  placedAt: "2026-08-01T00:00:00.000Z",
+  variantCode: "R-1",
+  variantName: "Produkt na riešenie",
+  sizeLabel: null,
+  ourUrl: null,
+  quantity: 1,
+  state: "riesit",
+  ordered: false,
+  supplierUrl: null,
+  supplierNote: null,
+  externalCode: null,
+  supplierAssignable: false,
+  manualSupplierOverride: null,
+  customerOpenOrderCount: 1,
+};
+
+const GROUP: SupplierOpenOrders = { supplier: "DODAVATEL-RIESIT", lines: [LINE_RIESIT], email: null };
+
+const PREVIEW = {
+  ok: true as const,
+  subject: "Vaša objednávka č. 7001 — Forestshop.sk",
+  html: "<p>...</p>",
+  text: [
+    "Dobrý deň, Zákazník Riešiť,",
+    "",
+    "Radi by sme Vás kontaktovali ohľadom Vašej objednávky č. 7001.",
+    "",
+    "S pozdravom,",
+    "Drlík, Forestshop.sk",
+  ].join("\n"),
+  recipient: "riesit@example.sk",
+  customerName: "Zákazník Riešiť",
+  previewToken: "tok700",
+};
+
+function renderRiesit(): void {
+  render(
+    <RiesitBadgeRefreshContext.Provider value={{ refresh: () => {} }}>
+      <RiesitSection role="manazer" onSessionExpired={() => {}} />
+    </RiesitBadgeRefreshContext.Provider>,
+  );
+}
+
+it("klik @ na kompaktnom riadku Riešiť otvorí okno predvyplnené menom + číslom objednávky", async () => {
+  fetchRiesitOrders.mockResolvedValue([GROUP]);
+  fetchCustomerContactPreview.mockResolvedValue(PREVIEW);
+  sendCustomerContactMail.mockResolvedValue({ ok: true });
+
+  renderRiesit();
+
+  // @ tlačidlo je na hlavičke riadku (testid podľa čísla objednávky), bez
+  // potreby rozrolovania.
+  const atBtn = await screen.findByTestId("customer-contact-open-7001");
+  fireEvent.click(atBtn);
+
+  await waitFor(() => {
+    expect(fetchCustomerContactPreview).toHaveBeenCalledWith("7001");
+  });
+
+  const dialog = await screen.findByTestId("customer-contact-preview");
+  expect(dialog.textContent).toContain("riesit@example.sk");
+  const body = screen.getByTestId<HTMLTextAreaElement>("customer-contact-preview-body");
+  expect(body.value).toContain("Zákazník Riešiť");
+  expect(body.value).toContain("7001");
+
+  fireEvent.click(screen.getByTestId("customer-contact-preview-confirm"));
+
+  await waitFor(() => {
+    expect(sendCustomerContactMail).toHaveBeenCalledWith("7001", "tok700", expect.stringContaining("Zákazník Riešiť"));
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId("customer-contact-preview")).toBeNull();
+  });
+});

--- a/apps/web/src/components/RiesitSection.tsx
+++ b/apps/web/src/components/RiesitSection.tsx
@@ -6,6 +6,8 @@ import { groupRiesitLinesByOrder } from "../riesitOrders.js";
 import { useOrderLinesBoard } from "../useOrderLinesBoard.js";
 import { OrderWriteFailuresBanner } from "./OrderWriteFailuresBanner.js";
 import { RiesitOrderRow } from "./RiesitOrderRow.js";
+import { CustomerContactDialog } from "./CustomerContactDialog.js";
+import { useCustomerContactMail } from "../useCustomerContactMail.js";
 
 // issue 450: šéfov kolega Štěpán (Discord 19.8.2026) — pôvodne placeholder.
 // issue 476 (Štěpán, Discord 23.8.2026): funkcia doplnená — sekcia „Riešiť"
@@ -91,6 +93,11 @@ export function RiesitSection({
       });
   };
 
+  // issue 502: @ tlačidlo za menom zákazníka otvorí okno na ručný e-mail
+  // zákazníkovi — ZDIEĽANÉ jadro (`useCustomerContactMail`) s „Na objednanie"
+  // (#500), aby bola funkcia úplne identická.
+  const contact = useCustomerContactMail(onSessionExpired);
+
   // issue 484: plochý zoznam objednávok odvodený z rovnakého `board.suppliers`
   // (žiadny nový dopyt) — preskupené podľa `orderId`, najnovšia prvá.
   const orders = groupRiesitLinesByOrder(board.suppliers);
@@ -157,10 +164,19 @@ export function RiesitSection({
       {orders.length > 0 && (
         <div className="riesit-orders" data-testid="riesit-orders">
           {orders.map((order) => (
-            <RiesitOrderRow key={order.orderId} order={order} canChangeState={canChangeState} board={board} />
+            <RiesitOrderRow
+              key={order.orderId}
+              order={order}
+              canChangeState={canChangeState}
+              board={board}
+              onOpenCustomerContact={contact.open}
+            />
           ))}
         </div>
       )}
+      {/* issue 502: okno na ručný e-mail zákazníkovi — zdieľané s „Na
+          objednanie" (#500), otvorí ho @ tlačidlo ktoréhokoľvek riadku. */}
+      <CustomerContactDialog contact={contact} />
     </section>
   );
 }

--- a/apps/web/src/components/SupplierOrderGroup.tsx
+++ b/apps/web/src/components/SupplierOrderGroup.tsx
@@ -53,6 +53,7 @@ export function SupplierOrderGroup({
   onOpenPreview,
   onClosePreview,
   onConfirmSend,
+  onOpenCustomerContact,
   selectedSupplier,
 }: {
   readonly group: SupplierOpenOrders;
@@ -112,6 +113,9 @@ export function SupplierOrderGroup({
   readonly onOpenPreview: (supplier: string) => void;
   readonly onClosePreview: () => void;
   readonly onConfirmSend: (supplier: string) => void;
+  // issue 500: @ tlačidlo na riadku otvorí okno na ručný e-mail zákazníkovi
+  // (`OrdersSection.tsx` vlastní modál). Prechádza ĎALEJ do `OrderLineRow`.
+  readonly onOpenCustomerContact: (orderCode: string, trigger: HTMLElement | null) => void;
 }): JSX.Element | null {
   const visibleLines = group.lines.filter((line) => !isLineHiddenByFilter(line, hideResolved, dirtyEditorLineIds));
   // issue 480: predajňové riadky skupiny (skryté pri „skryť vybavené", keď sú
@@ -192,6 +196,7 @@ export function SupplierOrderGroup({
                 onChangeComment={onChangeComment}
                 onEditorActivityChange={onEditorActivityChange}
                 onSupplierDraftChange={supplierDrafts.setDraft}
+                onOpenCustomerContact={onOpenCustomerContact}
               />
             ))}
             {/* issue 480: predajňové riadky POD riadkami objednávok tej istej

--- a/apps/web/src/mailLogApi.ts
+++ b/apps/web/src/mailLogApi.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 // issue 193: obrazovka "Odoslané e-maily" — zrkadlí `http/mail-log-routes.ts`.
 // Len čítanie, žiadny zápis (do knihy zapisujú samy odosielacie cesty).
 
-export const MAIL_LOG_SOURCES = ["nedostupne", "posta_uncollected", "order_reminder", "supplier_order", "order_merge"] as const;
+export const MAIL_LOG_SOURCES = ["nedostupne", "posta_uncollected", "order_reminder", "supplier_order", "order_merge", "order_customer_contact"] as const;
 export type MailLogSource = (typeof MAIL_LOG_SOURCES)[number];
 
 // Popisky sú TU (nie na serveri) z rovnakého dôvodu ako pri stavoch riadkov
@@ -14,6 +14,7 @@ export const MAIL_LOG_SOURCE_LABELS: Readonly<Record<MailLogSource, string>> = {
   order_reminder: "Pripomienky objednávok",
   supplier_order: "Objednávka dodávateľovi",
   order_merge: "Zlúčenie objednávky",
+  order_customer_contact: "Kontakt zákazníkovi",
 };
 
 const rowSchema = z.object({

--- a/apps/web/src/ordersApi.ts
+++ b/apps/web/src/ordersApi.ts
@@ -449,3 +449,51 @@ export async function sendSupplierOrderMail(supplier: string): Promise<{ ok: boo
   const telo = sendOrderMailResultSchema.parse(await response.json());
   return { ok: telo.ok, ...(telo.error === undefined ? {} : { error: telo.error }) };
 }
+
+// issue 500: „Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na riadku).
+// Rovnaký dvojkrokový tok ako „Nedostupné tovary"/„Zlúčenie objednávok": povinný
+// náhľad (vydá jednorazový `previewToken`) → odoslanie s tým istým tokenom +
+// (prípadne) ručne upraveným telom.
+const customerContactPreviewSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    subject: z.string(),
+    html: z.string(),
+    // `text` je plain-textová verzia — frontend ju predvyplní do editovateľného okna.
+    text: z.string(),
+    recipient: z.string(),
+    customerName: z.string(),
+    previewToken: z.string(),
+  }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+export type CustomerContactPreview = Extract<z.infer<typeof customerContactPreviewSchema>, { readonly ok: true }>;
+
+export async function fetchCustomerContactPreview(orderCode: string): Promise<CustomerContactPreview> {
+  const response = await fetch("/api/order-customer-contact/preview", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode }),
+  });
+  const parsed = customerContactPreviewSchema.parse(await readJson(response, "Náhľad e-mailu sa nepodarilo načítať"));
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed;
+}
+
+// issue 176/257 vzor: server VYŽADUJE `previewToken` vydaný `/preview` PRE
+// PRESNE túto objednávku — volajúci musí poslať TEN ISTÝ token, aký dostal z
+// `fetchCustomerContactPreview`. NEhádže na doménové zlyhanie (200 `{ok:false}`,
+// rovnako ako `sendSupplierOrderMail`).
+export async function sendCustomerContactMail(orderCode: string, previewToken: string, editedBody: string): Promise<{ ok: boolean; error?: string }> {
+  const response = await fetch("/api/order-customer-contact/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ orderCode, previewToken, editedBody }),
+  });
+  if (response.status === 401) throw new OrdersUnauthorizedError();
+  if (!response.ok) {
+    return { ok: false, error: await serverErrorMessage(response, "Odoslanie e-mailu sa nepodarilo") };
+  }
+  const telo = sendOrderMailResultSchema.parse(await response.json());
+  return { ok: telo.ok, ...(telo.error === undefined ? {} : { error: telo.error }) };
+}

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1446,7 +1446,10 @@ tr:last-child td {
 }
 /* Meno zákazníka zaberie zvyšné miesto, orezané na jednom riadku. */
 .riesit-order-customer {
-  flex: 1 1 8rem;
+  /* issue 502: NErásť (predtým `1 1 8rem`) — meno má prirodzenú šírku (dlhé sa
+     oreže ellipsom), aby @ tlačidlo sedelo HNEĎ ZA ním VĽAVO; počet+dátum drží
+     vpravo `.riesit-order-count`'s `margin-left: auto` nižšie. */
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1457,6 +1460,12 @@ tr:last-child td {
   flex: 0 0 auto;
   color: var(--fs-ink-muted);
   font-size: var(--fs-text-sm);
+}
+/* issue 502: počet položiek (prvý z pravej skupiny) odtlačí seba + dátum
+   vpravo — medzi menom+@ (vľavo) a počtom+dátumom (vpravo) tak ostane medzera,
+   presne ako v nákrese. */
+.riesit-order-count {
+  margin-left: auto;
 }
 /* Poznámka k objednávke — na vlastnom riadku pod hlavičkou, orezaná. */
 .riesit-order-note {
@@ -1486,6 +1495,12 @@ tr:last-child td {
    nesie teraz `.ord-supplier-assign`'s vlastný `margin-top` nižšie. */
 .ord-supplier-merged {
   max-width: 100%;
+  /* issue 500: zúžené ĽAVÉ/PRAVÉ odsadenie LEN tejto bunky (vzor `.ord-qty`/
+     issue 214) — uvoľní ~8px, aby sa 🔗 + @ (2×36px) zmestili vedľa seba do
+     úzkeho `col-supplier` (8.5 %) bez presúvania colgroup percent iným
+     stĺpcom. */
+  padding-left: var(--fs-space-1);
+  padding-right: var(--fs-space-1);
 }
 /* issue 67: odkaz/kód dodávateľa pri riadku objednávky. */
 .ord-supplier-cell {
@@ -1617,13 +1632,48 @@ tr:last-child td {
   gap: var(--fs-space-1);
   min-width: 0;
 }
-.ord-supplier-row > .ord-supplier-cell {
+/* issue 500: horný riadok bunky DODÁVATEĽ — 🔗 (odkaz) + @ (e-mail
+   zákazníkovi) VEDĽA seba; ✏️ (úprava odkazu) ostáva POD nimi (`.ord-supplier
+   -row` stĺpcová). `nowrap`: nikdy sa nezalomí (zalomenie by zvýšilo výšku
+   riadku) — miesto na dve 36px tlačidlá uvoľňuje zúžené odsadenie bunky
+   (`.ord-supplier-merged` nižšie, vzor `.ord-qty`/issue 214). */
+.ord-supplier-top {
+  display: flex;
+  align-items: center;
+  gap: var(--fs-space-1);
+  flex-wrap: nowrap;
   min-width: 0;
-  /* issue 476: v stĺpcovom rozložení NErásť vertikálne (predtým `1 1 auto`
-     v riadku roztiahlo bunku vodorovne) — 🔗/„—"/hint sedí na vlastnej
-     výške, ceruzka je pod ním. */
-  flex: 0 0 auto;
   max-width: 100%;
+}
+.ord-supplier-top > .ord-supplier-cell {
+  /* Bunka sa smie zmenšiť (poznámka/hint sa oreže cez `.ord-supplier-note`'s
+     ellipsis), aby @ tlačidlo vedľa nej vždy udržalo svoj klikací cieľ. */
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+/* issue 500: @ tlačidlo (e-mail zákazníkovi) vedľa 🔗 — rovnaký 36px ikonový
+   rozmer/vzhľad ako `.ord-supplier-link`, aby dvojica pôsobila konzistentne;
+   `flex-shrink: 0`, nikdy pod klikací cieľ. */
+.customer-contact-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  padding: var(--fs-space-1);
+  font-size: var(--fs-text-lg);
+  line-height: 1;
+  color: var(--fs-brand);
+  background: var(--fs-surface-alt);
+  border: 1px solid var(--fs-border);
+  border-radius: var(--fs-radius-sm);
+  cursor: pointer;
+}
+.customer-contact-btn:hover {
+  background: var(--fs-brand);
+  color: var(--fs-surface);
 }
 /* "veľké tlačidlá" — rovnaký 2.25rem (36px) klikací rozmer ako
    `.ord-supplier-link`, aby zamestnanec mohol rýchlo kliknúť aj na úzkej

--- a/apps/web/src/useCustomerContactMail.ts
+++ b/apps/web/src/useCustomerContactMail.ts
@@ -1,0 +1,94 @@
+import { useCallback, useRef, useState, type RefObject } from "react";
+import {
+  fetchCustomerContactPreview,
+  OrdersUnauthorizedError,
+  sendCustomerContactMail,
+  type CustomerContactPreview,
+} from "./ordersApi.js";
+
+// issue 500/502: ručný e-mail zákazníkovi z riadku objednávky (@ tlačidlo).
+// Zdieľané JADRO okna náhľadu — používa ho „Na objednanie" (`OrdersSection`) AJ
+// „Riešiť" (`RiesitSection`), aby bola funkcia úplne identická (Štěpán: „nič
+// nemeň, len ju tam vlož"). Rovnaký dvojkrokový tok ako „Nedostupné
+// tovary"/„Zlúčenie objednávok": povinný náhľad zo servera → odoslanie s
+// jednorazovým tokenom + (prípadne) ručne upraveným telom.
+
+export interface PendingContact {
+  readonly orderCode: string;
+  readonly preview: CustomerContactPreview;
+}
+
+export interface CustomerContactMailApi {
+  readonly pending: PendingContact | null;
+  readonly body: string;
+  readonly setBody: (value: string) => void;
+  readonly busy: boolean;
+  readonly error: string;
+  // issue 191: spúšťacie tlačidlo si pamätáme pri kliknutí — dialóg naň vráti
+  // fokus po zavretí (`MailPreviewDialog`'s `returnFocusRef`).
+  readonly triggerRef: RefObject<HTMLElement | null>;
+  readonly open: (orderCode: string, trigger: HTMLElement | null) => void;
+  readonly confirmSend: () => void;
+  readonly close: () => void;
+}
+
+export function useCustomerContactMail(onSessionExpired: () => void): CustomerContactMailApi {
+  const [pending, setPending] = useState<PendingContact | null>(null);
+  const [body, setBody] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const open = useCallback(
+    (orderCode: string, trigger: HTMLElement | null) => {
+      triggerRef.current = trigger;
+      setError("");
+      setBusy(true);
+      fetchCustomerContactPreview(orderCode)
+        .then((preview) => {
+          setPending({ orderCode, preview });
+          setBody(preview.text);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof OrdersUnauthorizedError) {
+            onSessionExpired();
+            return;
+          }
+          setError(err instanceof Error ? err.message : "Náhľad e-mailu sa nepodarilo načítať.");
+        })
+        .finally(() => {
+          setBusy(false);
+        });
+    },
+    [onSessionExpired],
+  );
+
+  const confirmSend = useCallback(() => {
+    if (pending === null) return;
+    setBusy(true);
+    sendCustomerContactMail(pending.orderCode, pending.preview.previewToken, body)
+      .then((result) => {
+        if (!result.ok) {
+          setError(result.error ?? "Odoslanie zlyhalo.");
+          return;
+        }
+        setPending(null);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof OrdersUnauthorizedError) {
+          onSessionExpired();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Odoslanie zlyhalo.");
+      })
+      .finally(() => {
+        setBusy(false);
+      });
+  }, [pending, body, onSessionExpired]);
+
+  const close = useCallback(() => {
+    setPending(null);
+  }, []);
+
+  return { pending, body, setBody, busy, error, triggerRef, open, confirmSend, close };
+}

--- a/apps/web/src/useCustomerContactMail.ts
+++ b/apps/web/src/useCustomerContactMail.ts
@@ -38,18 +38,27 @@ export function useCustomerContactMail(onSessionExpired: () => void): CustomerCo
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const triggerRef = useRef<HTMLElement | null>(null);
+  // issue 500 (review): generation guard — keď obsluha klikne @ na riadku A a
+  // rýchlo potom na B, VYHRÁ najnovší klik, nikdy ten, čo dobehne posledný.
+  // Bez neho by okno mohlo ukázať ZLÚ objednávku (frontend-design.md „latest
+  // ref"/`fetchSeqRef` vzor, issue 251/264). Zavretie okno tiež bumpne, takže
+  // dobiehajúci náhľad po zavretí sa ignoruje.
+  const seqRef = useRef(0);
 
   const open = useCallback(
     (orderCode: string, trigger: HTMLElement | null) => {
+      const seq = ++seqRef.current;
       triggerRef.current = trigger;
       setError("");
       setBusy(true);
       fetchCustomerContactPreview(orderCode)
         .then((preview) => {
+          if (seq !== seqRef.current) return;
           setPending({ orderCode, preview });
           setBody(preview.text);
         })
         .catch((err: unknown) => {
+          if (seq !== seqRef.current) return;
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
@@ -57,7 +66,7 @@ export function useCustomerContactMail(onSessionExpired: () => void): CustomerCo
           setError(err instanceof Error ? err.message : "Náhľad e-mailu sa nepodarilo načítať.");
         })
         .finally(() => {
-          setBusy(false);
+          if (seq === seqRef.current) setBusy(false);
         });
     },
     [onSessionExpired],
@@ -87,7 +96,11 @@ export function useCustomerContactMail(onSessionExpired: () => void): CustomerCo
   }, [pending, body, onSessionExpired]);
 
   const close = useCallback(() => {
+    // Zruší prípadný ešte bežiaci náhľad (generation guard) a VYČISTÍ chybu,
+    // aby po zavretí okna neostala visieť ako sekciová `role="alert"` hláška.
+    seqRef.current++;
     setPending(null);
+    setError("");
   }, []);
 
   return { pending, body, setBody, busy, error, triggerRef, open, confirmSend, close };

--- a/apps/web/tests/e2e/order-customer-contact.spec.ts
+++ b/apps/web/tests/e2e/order-customer-contact.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+
+const E2E_HESLO = "e2e-test-heslo"; // účet existuje len v testovacej databáze
+// issue 500/502: znovupoužívame izolovaný účet `riesit.spec.ts` (jediný ďalší
+// spec, ktorý sa naň prihlasuje) — 2 prihlásenia na (IP, e-mail) pár, ďaleko
+// pod `MAX_ATTEMPTS=10`, takže netreba nový seedovaný účet.
+const E2E_EMAIL = "e2e-riesit@forestshop.sk"; // musí sa zhodovať s hodnotou v scripts/e2e-setup.ts
+
+// issue 500/502: @ tlačidlo (e-mail zákazníkovi) na riadku „Na objednanie" AJ
+// „Riešiť" — klik-flow. Prečo prepichnutý `window.fetch` (`addInitScript`), nie
+// reálne seedované dáta: `orders.spec.ts` asertuje PRESNÉ globálne počty riadkov
+// a mutovanie zdieľaných objednávok medzi paralelnými spec súbormi je race
+// (`.claude/rules/frontend-design.md`, vzor `riesit.spec.ts`/`orders-write-
+// failures.spec.ts`). JS-level override nič v DB nemení, je retry-safe a
+// NEloguje „Failed to load resource" do konzoly (na rozdiel od `page.route`).
+// Skutočná preview/send cesta end-to-end je pokrytá
+// `apps/api/tests/order-customer-contact.integration.test.ts`; reálny
+// komponent+hook `OrdersSection.customerContact.test.tsx`/
+// `RiesitSection.customerContact.test.tsx`.
+const FAKE_LINE_ID = "e2e00000-0000-0000-0000-000000000500";
+
+test("@ e-mail zákazníkovi: klik na riadku Na objednanie aj Riešiť otvorí okno predvyplnené menom + číslom objednávky, konzola je čistá", async ({
+  page,
+}) => {
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.addInitScript((lineId: string) => {
+    const puvodny = window.fetch.bind(window);
+    const line = {
+      lineId,
+      orderId: "e2e00000-0000-0000-0000-0000000005aa",
+      externalOrderId: "9500",
+      customerName: "E2E Kontakt Zákazník",
+      comment: null,
+      remark: null,
+      shopRemark: null,
+      adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=9500&src=orders",
+      placedAt: "2026-08-20T00:00:00.000Z",
+      variantCode: "K-1",
+      variantName: "Kontaktný produkt",
+      sizeLabel: null,
+      ourUrl: null,
+      quantity: 1,
+      state: "objednane",
+      ordered: false,
+      supplierUrl: null,
+      supplierNote: null,
+      externalCode: null,
+      supplierAssignable: false,
+      manualSupplierOverride: null,
+      customerOpenOrderCount: 1,
+    };
+    const naObjednanieGroup = { supplier: "DODAVATEL-KONTAKT", email: null, lines: [line] };
+    const riesitGroup = {
+      supplier: "DODAVATEL-KONTAKT-RIESIT",
+      email: null,
+      lines: [{ ...line, lineId: "e2e00000-0000-0000-0000-000000000501", orderId: "e2e00000-0000-0000-0000-0000000005bb", externalOrderId: "9501", customerName: "E2E Riešiť Zákazník", state: "riesit" }],
+    };
+    const json = (body: unknown, status = 200): Response =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/api/orders/open")) return Promise.resolve(json({ suppliers: [naObjednanieGroup] }));
+      if (url.includes("/api/orders/riesit/count")) return Promise.resolve(json({ count: 1 }));
+      if (url.includes("/api/orders/riesit")) return Promise.resolve(json({ suppliers: [riesitGroup] }));
+      if (url.includes("/api/order-customer-contact/preview")) {
+        const telo = typeof init?.body === "string" ? init.body : "{}";
+        const code = (JSON.parse(telo) as { orderCode?: string }).orderCode ?? "";
+        const meno = code === "9501" ? "E2E Riešiť Zákazník" : "E2E Kontakt Zákazník";
+        return Promise.resolve(
+          json({
+            ok: true,
+            subject: `Vaša objednávka č. ${code} — Forestshop.sk`,
+            html: "<p>náhľad</p>",
+            text: `Dobrý deň, ${meno},\n\nRadi by sme Vás kontaktovali ohľadom Vašej objednávky č. ${code}.\n\nS pozdravom,\nDrlík, Forestshop.sk`,
+            recipient: "kontakt@example.sk",
+            customerName: meno,
+            previewToken: "e2etok",
+          }),
+        );
+      }
+      return puvodny(input, init);
+    };
+  }, FAKE_LINE_ID);
+
+  await page.goto("/?tab=orders");
+  await page.getByLabel("E-mail").fill(E2E_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+
+  await expect(page.getByRole("heading", { name: "Na objednanie" })).toBeVisible();
+
+  // „Na objednanie": @ tlačidlo na riadku otvorí okno predvyplnené menom +
+  // číslom objednávky (telo je `<textarea>` — hodnotu treba čítať cez
+  // `toHaveValue`, nikdy text-content, `.claude/rules/nedostupne.md`).
+  await page.getByTestId(`customer-contact-open-${FAKE_LINE_ID}`).click();
+  await expect(page.getByTestId("customer-contact-preview")).toBeVisible();
+  await expect(page.getByTestId("customer-contact-preview")).toContainText("kontakt@example.sk");
+  const bodyNaObjednanie = page.getByTestId("customer-contact-preview-body");
+  await expect(bodyNaObjednanie).toHaveValue(/E2E Kontakt Zákazník/);
+  await expect(bodyNaObjednanie).toHaveValue(/9500/);
+  await page.getByTestId("customer-contact-preview-cancel").click();
+  await expect(page.getByTestId("customer-contact-preview")).toHaveCount(0);
+
+  // „Riešiť": to isté @ tlačidlo za menom zákazníka na kompaktnom riadku.
+  await page.getByTestId("nav-tab-riesit").click();
+  await expect(page.getByRole("heading", { name: "Riešiť" })).toBeVisible();
+  await expect(page.getByTestId("riesit-order-9501")).toContainText("E2E Riešiť Zákazník");
+
+  await page.getByTestId("customer-contact-open-9501").click();
+  await expect(page.getByTestId("customer-contact-preview")).toBeVisible();
+  const bodyRiesit = page.getByTestId("customer-contact-preview-body");
+  await expect(bodyRiesit).toHaveValue(/E2E Riešiť Zákazník/);
+  await expect(bodyRiesit).toHaveValue(/9501/);
+  await page.getByTestId("customer-contact-preview-cancel").click();
+  await expect(page.getByTestId("customer-contact-preview")).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/apps/web/tests/e2e/order-customer-contact.spec.ts
+++ b/apps/web/tests/e2e/order-customer-contact.spec.ts
@@ -66,7 +66,9 @@ test("@ e-mail zákazníkovi: klik na riadku Na objednanie aj Riešiť otvorí o
       new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
     window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      if (url.includes("/api/orders/open")) return Promise.resolve(json({ suppliers: [naObjednanieGroup] }));
+      // Presná cesta (nie `includes`) — inak by zachytila aj
+      // `/api/orders/open-statuses` a vrátila zlý tvar.
+      if (/\/api\/orders\/open(?:$|\?)/.test(url)) return Promise.resolve(json({ suppliers: [naObjednanieGroup] }));
       if (url.includes("/api/orders/riesit/count")) return Promise.resolve(json({ count: 1 }));
       if (url.includes("/api/orders/riesit")) return Promise.resolve(json({ suppliers: [riesitGroup] }));
       if (url.includes("/api/order-customer-contact/preview")) {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -171,6 +171,12 @@ services:
       # vyššie). Chýbajúca = automatizácia NEPOŠLE ani jeden e-mail
       # zákazníkovi (fail-closed).
       ORDER_MERGE_BCC_EMAIL:
+      # issue 500: "Na objednanie"/"Riešiť" — ručný e-mail zákazníkovi (@).
+      # NEZÁVISLÁ vyhradená premenná (rovnaký dôvod ako ostatné *_BCC_EMAIL
+      # vyššie). Chýbajúca = odoslanie NEODÍDE (fail-closed) a okno náhľadu
+      # ukáže jasnú hlášku (issue 198/292: nová env.ts premenná MUSÍ mať
+      # riadok tu, inak sa do kontajnera nikdy nedostane).
+      ORDER_CUSTOMER_CONTACT_BCC_EMAIL:
       # issue 309: "Eshop → Upozornenia" — najbližšia udalosť z majiteľovho
       # Google kalendára. Rovnaká úvaha ako SHOPTET_EXPORT_URL vyššie:
       # `.optional()` v `env.ts`, bare kľúč preberá `/srv/forestshop/.env`,

--- a/docs/autopilot-log.md
+++ b/docs/autopilot-log.md
@@ -4536,3 +4536,28 @@ Bundle (jedna PR #165, dev→main), rovnaké súbory (`OrderLineRow.tsx`/`app.cs
   pridania stavu). Migrácia číslo `0060` — kolíziu s paralelným workerom (issue 492)
   rieši supervisor pri integrácii. Ticket 493 ostáva OTVORENÝ (worktree worker,
   merge/deploy/overenie rieši supervisor).
+
+## 2026-08-26 — issues 500 + 502 (@ e-mail zákazníkovi na riadku, bundled)
+- Verzia `0.3.0-dev.294` (re-bump z .292 po merge origin/dev .293, issue 501 lane).
+- #500 (Na objednanie) + #502 (Riešiť) — tá istá funkcia, jedna vetva/PR do dev.
+  @ tlačidlo → okno na ručný e-mail zákazníkovi (vzor „Nedostupné"/„Zlúčenie objednávok"):
+  editovateľné telo, povinný náhľad + jednorazový token, odoslanie IBA cez F193
+  `sendLoggedMail`, znenie ako F192 šablóna `order_customer_contact`.
+- Server: `modules/orders/customer-contact.ts` + `customer-contact-preview-tokens.ts`
+  + `http/order-customer-contact-routes.ts` (preview=requireUser, send=admin/manazer),
+  nový `mail_log_source order_customer_contact` (migrácia `0061_far_rawhide_kid.sql`,
+  samostatný ADD VALUE — bezpečný vzor issue 476), `ORDER_CUSTOMER_CONTACT_BCC_EMAIL`.
+- Frontend (DRY): zdieľaný hook `useCustomerContactMail` + `CustomerContactDialog`
+  + `CustomerContactRowButton` (obe sekcie identické); `OrderSupplierLinkDisplay`
+  vyčlenené z OrderLineRow (max-lines).
+- Fable review chytil 2 blokery: chýbajúci riadok v `docker-compose.prod.yml`
+  (ORDER_CUSTOMER_CONTACT_BCC_EMAIL) a chýbajúci `order_customer_contact` v
+  mail-log enumoch (`mailLogApi.ts` + `mail-log-routes.ts`) — obidva opravené.
+  Follow-up 505: zjednotiť tri identické preview-token moduly.
+- Playbook: `mail-log.md` (nový mail_log_source = update na 3 miestach, inak
+  zhodí Knihu odoslaných e-mailov).
+- RED/GREEN nie je (nová funkcia, nie bug-fix) — testy v tom istom PR: unit
+  (preview-tokens, OrdersSection/RiesitSection @ modál), integračný, e2e.
+- Layout (2×36px v úzkom col-supplier) — UNVERIFIED, nasadzovateľ overí naživo.
+- Tickety 500/502 ostávajú OTVORENÉ (worktree worker, PR do dev; merge/deploy/
+  overenie rieši supervisor).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.291",
+  "version": "0.3.0-dev.292",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 500 + issue 502 — nové tlačidlo **@** (e-mail zákazníkovi) na riadkoch v Na objednanie (v skupine tlačidiel pri 🔗) a v Riešiť (za menom zákazníka). Klik otvorí editovateľný náhľad e-mailu presne ako v Nedostupných: predvyplnené „Dobrý deň, {meno}… ohľadom Vašej objednávky č. {číslo}…" + podpis; Štěpán si vlastný text dopíše pred odoslaním. Odosielanie jedinou cestou F193 (Kniha odoslaných e-mailov), šablóna + predmet upraviteľné vo F192 Texty e-mailov. Migrácia 0061 (ALTER TYPE mail_log_source ADD VALUE, bezpečný vzor issue 476).

Obsahuje aj test-sync `b4a1463` (mail-templates zoznam ráta 10 druhov po pridaní desiateho).

v0.3.0-dev.294. Tickety 500 a 502 ostávajú otvorené — zavrú sa ručne po naživo overení.
