### PR TITLE
issue 505 — zdieľané jadro jednorazových preview-tokenov (v0.3.0-dev.295)

### DIFF
--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -4,6 +4,9 @@ paths:
   - "apps/api/src/http/nedostupne-routes.ts"
   - "apps/web/src/components/NedostupneSection*.tsx"
   - "apps/web/src/nedostupneApi.ts"
+  - "apps/api/src/modules/single-use-preview-tokens.ts"
+  - "apps/api/src/modules/orders/merge-mail-preview-tokens.ts"
+  - "apps/api/src/modules/orders/customer-contact-preview-tokens.ts"
 ---
 
 # Nedostupné tovary (issue 176)
@@ -21,6 +24,20 @@ paths:
   MVP rozsah — reštart appky tokeny zruší, v poriadku). Ďalšia automatizácia
   s ticketovou podmienkou "povinný náhľad pred odoslaním" potrebuje TEN ISTÝ
   mechanizmus, nie len frontend disciplínu.
+- **issue 505: jadro jednorazových preview-tokenov je ZDIEĽANÉ v
+  `apps/api/src/modules/single-use-preview-tokens.ts`** (factory
+  `createSingleUsePreviewTokenStore()` → `{ issue(key, now), consume(token,
+  key, now) }`, kľúčovaný ĽUBOVOĽNÝM reťazcom). Tri moduly, čo ho volajú, sú
+  už len TENKÉ WRAPPERY so zachovanými verejnými signatúrami:
+  `nedostupne/preview-tokens.ts`, `orders/merge-mail-preview-tokens.ts`,
+  `orders/customer-contact-preview-tokens.ts`. **TTL (15 min), `MAX_ENTRIES`
+  strop, sweep interval a eviction sa menia na JEDNOM mieste** (v zdieľanom
+  jadre), nie trikrát. Každý wrapper má VLASTNÝ store (nezdieľaný Map + strop),
+  takže eviction jednej feature nevyhadzuje tokeny inej. Viac-poľové kľúče vo
+  wrapperi serializuj cez `JSON.stringify([...])` (nie `join(oddeľovač)`,
+  ktorý pri hodnote s oddeľovačom kolidoval) — je injektívny, takže porovnanie
+  reťazcového kľúča je ekvivalentné pôvodnému porovnaniu po poliach. Nová
+  automatizácia s povinným náhľadom = nový tenký wrapper nad týmto jadrom.
 - **ŽIADNY scheduler/`enabled` prepínač, na rozdiel od #172/#173** — táto
   automatizácia nemá žiadny naplánovaný beh (ticket nič také nežiadal).
   `GET /api/nedostupne` je VŽDY živý DB dopyt, nikdy `job_run.detail` cache.

--- a/apps/api/src/modules/nedostupne/preview-tokens.ts
+++ b/apps/api/src/modules/nedostupne/preview-tokens.ts
@@ -1,4 +1,5 @@
 import type { NedostupneEmailType } from "./constants.js";
+import { createSingleUsePreviewTokenStore } from "../single-use-preview-tokens.js";
 
 // issue 176 (code review pred mergom, PR #182): ticketova podmienka "e-mail
 // sa NIKDY nesmie odoslať automaticky, len po potvrdení náhľadu človekom" bola
@@ -10,63 +11,31 @@ import type { NedostupneEmailType } from "./constants.js";
 // `/preview` vydá jednorazový token viazaný na presne (orderCode,
 // variantCode, emailType), `/send` ho musí priniesť späť a token sa
 // SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie — bez ohľadu na to, či sa
-// zhoduje. Rovnaký in-process Map vzor ako `login-rate-limit.ts` (jedna
-// bežiaca inštancia appky, MVP rozsah — reštart appky token zruší, čo je
-// v poriadku, obsluha si vie náhľad znova otvoriť).
-const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — dosť na to, aby si obsluha náhľad prečítala, nie navždy platné
-const MAX_ENTRIES = 1_000; // strop proti neobmedzenému rastu (opakované náhľady bez odoslania)
-const SWEEP_INTERVAL_MS = 60 * 1000;
+// zhoduje.
+//
+// issue 505: jadro (Map, TTL, MAX_ENTRIES eviction, sweep, issue/consume) sa
+// presunulo do zdieľaného `modules/single-use-preview-tokens.ts`; tento súbor
+// je už len tenký wrapper, ktorý serializuje svoj (orderCode, variantCode,
+// emailType) kľúč a deleguje na vlastný store. Verejné signatúry sa nemenia.
+const store = createSingleUsePreviewTokenStore();
 
-interface PreviewTokenEntry {
-  readonly orderCode: string;
-  readonly variantCode: string;
-  readonly emailType: NedostupneEmailType;
-  readonly expiresAt: number;
-}
-
-const tokens = new Map<string, PreviewTokenEntry>();
-let lastSweepAtMs = 0;
-
-function sweepExpired(nowMs: number): void {
-  if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
-  lastSweepAtMs = nowMs;
-  for (const [token, entry] of tokens) {
-    if (entry.expiresAt <= nowMs) tokens.delete(token);
-  }
+// Injektívny reťazcový kľúč z (objednávka, variant, typ). `JSON.stringify`
+// (nie join s oddeľovačom) zaručuje, že dve rôzne trojice nikdy nedajú rovnaký
+// reťazec — porovnanie kľúča je tak ekvivalentné pôvodnému porovnaniu po poliach.
+function keyOf(orderCode: string, variantCode: string, emailType: NedostupneEmailType): string {
+  return JSON.stringify([orderCode, variantCode, emailType]);
 }
 
 /** Vydá nový jednorazový token pre presne tento (objednávka, variant, typ) —
  * volané `POST /api/nedostupne/preview`. */
 export function issuePreviewToken(orderCode: string, variantCode: string, emailType: NedostupneEmailType, now: Date): string {
-  const nowMs = now.getTime();
-  sweepExpired(nowMs);
-  // Strop dosiahnutý → uvoľni miesto zmazaním najskôr vypršiavajúceho záznamu
-  // (rovnaký zámer ako `login-rate-limit.ts`'s dávkové mazanie, len po
-  // jednom — tokeny sú oveľa menej časté než prihlasovacie pokusy).
-  if (tokens.size >= MAX_ENTRIES) {
-    let oldestToken: string | undefined;
-    let oldestExpiresAt = Infinity;
-    for (const [token, entry] of tokens) {
-      if (entry.expiresAt < oldestExpiresAt) {
-        oldestExpiresAt = entry.expiresAt;
-        oldestToken = token;
-      }
-    }
-    if (oldestToken !== undefined) tokens.delete(oldestToken);
-  }
-  const token = crypto.randomUUID();
-  tokens.set(token, { orderCode, variantCode, emailType, expiresAt: nowMs + TOKEN_TTL_MS });
-  return token;
+  return store.issue(keyOf(orderCode, variantCode, emailType), now);
 }
 
 /** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE tento (objednávka,
  * variant, typ) — `POST /api/nedostupne/send` volá TOTO pred akýmkoľvek
- * odoslaním. Token sa maže VŽDY (aj pri nezhode) — jednorazový, nikdy sa
- * nedá "vyskúšať" opakovane. */
+ * odoslaním. Token sa maže VŽDY (aj pri nezhode) — jednorazový, nikdy sa nedá
+ * "vyskúšať" opakovane. */
 export function consumePreviewToken(token: string, orderCode: string, variantCode: string, emailType: NedostupneEmailType, now: Date): boolean {
-  const entry = tokens.get(token);
-  tokens.delete(token);
-  if (entry === undefined) return false;
-  if (entry.expiresAt <= now.getTime()) return false;
-  return entry.orderCode === orderCode && entry.variantCode === variantCode && entry.emailType === emailType;
+  return store.consume(token, keyOf(orderCode, variantCode, emailType), now);
 }

--- a/apps/api/src/modules/orders/customer-contact-preview-tokens.ts
+++ b/apps/api/src/modules/orders/customer-contact-preview-tokens.ts
@@ -1,3 +1,5 @@
+import { createSingleUsePreviewTokenStore } from "../single-use-preview-tokens.js";
+
 // issue 500: rovnaký server-side vynútený „náhľad VŽDY pred odoslaním"
 // mechanizmus ako `modules/nedostupne/preview-tokens.ts` /
 // `modules/orders/merge-mail-preview-tokens.ts` (viď návrhový komentár na
@@ -5,52 +7,18 @@
 // vydá jednorazový token viazaný na presne `orderCode`, `.../send` ho musí
 // priniesť späť a token sa SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie, bez
 // ohľadu na zhodu. Bez tohto by priame volanie API mohlo poslať e-mail
-// zákazníkovi bez toho, aby ho čokoľvek niekedy zobrazilo — presne ten gap,
-// ktorý `nedostupne`/`order-merge` zámerne zatvorili pred mergom. Rovnaký
-// in-process `Map` vzor ako `login-rate-limit.ts` (jedna bežiaca inštancia
-// appky, MVP rozsah — reštart appky token zruší, čo je v poriadku, obsluha si
-// vie náhľad znova otvoriť).
-const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — rovnaký strop ako nedostupne/order-merge
-const MAX_ENTRIES = 1_000;
-const SWEEP_INTERVAL_MS = 60 * 1000;
-
-interface PreviewTokenEntry {
-  readonly orderCode: string;
-  readonly expiresAt: number;
-}
-
-const tokens = new Map<string, PreviewTokenEntry>();
-let lastSweepAtMs = 0;
-
-function sweepExpired(nowMs: number): void {
-  if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
-  lastSweepAtMs = nowMs;
-  for (const [token, entry] of tokens) {
-    if (entry.expiresAt <= nowMs) tokens.delete(token);
-  }
-}
+// zákazníkovi bez toho, aby ho čokoľvek niekedy zobrazilo.
+//
+// issue 505: jadro sa presunulo do zdieľaného
+// `modules/single-use-preview-tokens.ts`; tento súbor je už len tenký wrapper.
+// Kľúč je jediné pole `orderCode` (e-mail zákazníkovi je per-objednávka), takže
+// sa použije priamo ako reťazcový kľúč. Verejné signatúry sa nemenia.
+const store = createSingleUsePreviewTokenStore();
 
 /** Vydá nový jednorazový token pre presne túto objednávku (`externalOrderId`) —
  * volané `POST /api/order-customer-contact/preview`. */
 export function issueCustomerContactPreviewToken(orderCode: string, now: Date): string {
-  const nowMs = now.getTime();
-  sweepExpired(nowMs);
-  // Strop dosiahnutý → uvoľni miesto zmazaním najskôr vypršiavajúceho záznamu
-  // (rovnaký zámer ako `merge-mail-preview-tokens.ts`).
-  if (tokens.size >= MAX_ENTRIES) {
-    let oldestToken: string | undefined;
-    let oldestExpiresAt = Infinity;
-    for (const [token, entry] of tokens) {
-      if (entry.expiresAt < oldestExpiresAt) {
-        oldestExpiresAt = entry.expiresAt;
-        oldestToken = token;
-      }
-    }
-    if (oldestToken !== undefined) tokens.delete(oldestToken);
-  }
-  const token = crypto.randomUUID();
-  tokens.set(token, { orderCode, expiresAt: nowMs + TOKEN_TTL_MS });
-  return token;
+  return store.issue(orderCode, now);
 }
 
 /** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE túto objednávku —
@@ -58,9 +26,5 @@ export function issueCustomerContactPreviewToken(orderCode: string, now: Date): 
  * Token sa maže VŽDY (aj pri nezhode) — jednorazový, nikdy sa nedá „vyskúšať"
  * opakovane. */
 export function consumeCustomerContactPreviewToken(token: string, orderCode: string, now: Date): boolean {
-  const entry = tokens.get(token);
-  tokens.delete(token);
-  if (entry === undefined) return false;
-  if (entry.expiresAt <= now.getTime()) return false;
-  return entry.orderCode === orderCode;
+  return store.consume(token, orderCode, now);
 }

--- a/apps/api/src/modules/orders/merge-mail-preview-tokens.ts
+++ b/apps/api/src/modules/orders/merge-mail-preview-tokens.ts
@@ -1,3 +1,5 @@
+import { createSingleUsePreviewTokenStore } from "../single-use-preview-tokens.js";
+
 // issue 257: rovnaký server-side vynútený "náhľad VŽDY pred odoslaním"
 // mechanizmus ako `modules/nedostupne/preview-tokens.ts` (viď návrhový
 // komentár na tickete + `.claude/rules/nedostupne.md`) — `/merge-mail/preview`
@@ -5,29 +7,13 @@
 // vybraných orderId), `/merge-mail/send` ho musí priniesť späť a token sa
 // SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie, bez ohľadu na zhodu. Bez
 // tohto by priame volanie API mohlo poslať e-mail zákazníkovi bez toho, aby
-// ho čokoľvek niekedy zobrazilo — presne ten gap, ktorý `nedostupne` opravil
-// pred mergom PR #182 (dôvod, prečo sa tu znovu zavádza TÁ ISTÁ obrana,
-// nikdy staršia slabšia konvencia `orders/mail.ts`'s dodávateľského náhľadu).
-const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — rovnaký strop ako nedostupne
-const MAX_ENTRIES = 1_000;
-const SWEEP_INTERVAL_MS = 60 * 1000;
-
-interface PreviewTokenEntry {
-  readonly baseOrderId: string;
-  readonly selectionKey: string;
-  readonly expiresAt: number;
-}
-
-const tokens = new Map<string, PreviewTokenEntry>();
-let lastSweepAtMs = 0;
-
-function sweepExpired(nowMs: number): void {
-  if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
-  lastSweepAtMs = nowMs;
-  for (const [token, entry] of tokens) {
-    if (entry.expiresAt <= nowMs) tokens.delete(token);
-  }
-}
+// ho čokoľvek niekedy zobrazilo.
+//
+// issue 505: jadro sa presunulo do zdieľaného
+// `modules/single-use-preview-tokens.ts`; tento súbor je už len tenký wrapper,
+// ktorý serializuje svoj (baseOrderId, selectionKey) kľúč a deleguje na vlastný
+// store. Verejné signatúry sa nemenia.
+const store = createSingleUsePreviewTokenStore();
 
 /** Kanonický, poradie-nezávislý kľúč vybraných "ostatných" objednávok —
  * `/preview` aj `/send` ho počítajú z rovnakého poľa `otherOrderIds`, takže
@@ -36,25 +22,17 @@ export function mergeSelectionKey(otherOrderIds: readonly string[]): string {
   return [...otherOrderIds].sort().join(",");
 }
 
+// Injektívny reťazcový kľúč z (základná objednávka, kanonický výber).
+// `JSON.stringify` zaručuje, že sa (baseOrderId, selectionKey) nikdy nezlejú
+// nejednoznačne — porovnanie je ekvivalentné pôvodnému porovnaniu po poliach.
+function keyOf(baseOrderId: string, otherOrderIds: readonly string[]): string {
+  return JSON.stringify([baseOrderId, mergeSelectionKey(otherOrderIds)]);
+}
+
 /** Vydá nový jednorazový token pre presne túto (základná objednávka, výber) —
  * volané `POST /api/orders/:id/merge-mail/preview`. */
 export function issueMergePreviewToken(baseOrderId: string, otherOrderIds: readonly string[], now: Date): string {
-  const nowMs = now.getTime();
-  sweepExpired(nowMs);
-  if (tokens.size >= MAX_ENTRIES) {
-    let oldestToken: string | undefined;
-    let oldestExpiresAt = Infinity;
-    for (const [token, entry] of tokens) {
-      if (entry.expiresAt < oldestExpiresAt) {
-        oldestExpiresAt = entry.expiresAt;
-        oldestToken = token;
-      }
-    }
-    if (oldestToken !== undefined) tokens.delete(oldestToken);
-  }
-  const token = crypto.randomUUID();
-  tokens.set(token, { baseOrderId, selectionKey: mergeSelectionKey(otherOrderIds), expiresAt: nowMs + TOKEN_TTL_MS });
-  return token;
+  return store.issue(keyOf(baseOrderId, otherOrderIds), now);
 }
 
 /** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE tento (základná
@@ -66,9 +44,5 @@ export function consumeMergePreviewToken(
   otherOrderIds: readonly string[],
   now: Date,
 ): boolean {
-  const entry = tokens.get(token);
-  tokens.delete(token);
-  if (entry === undefined) return false;
-  if (entry.expiresAt <= now.getTime()) return false;
-  return entry.baseOrderId === baseOrderId && entry.selectionKey === mergeSelectionKey(otherOrderIds);
+  return store.consume(token, keyOf(baseOrderId, otherOrderIds), now);
 }

--- a/apps/api/src/modules/single-use-preview-tokens.test.ts
+++ b/apps/api/src/modules/single-use-preview-tokens.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createSingleUsePreviewTokenStore } from "./single-use-preview-tokens.js";
+
+// issue 505: priamy unit test zdieľaného jadra jednorazových preview-tokenov
+// (tri tenké wrappery — nedostupne/order-merge/customer-contact — ho volajú
+// cez svoje serializované kľúče a majú vlastné testy). Overuje generický
+// kontrakt store-u: jednorazovosť, viazanie na kľúč, TTL a izoláciu inštancií.
+const NOW = new Date("2026-08-26T10:00:00Z");
+
+describe("createSingleUsePreviewTokenStore", () => {
+  it("token vydaný pre presne tento kľúč sa dá skonzumovať PRESNE raz", () => {
+    const store = createSingleUsePreviewTokenStore();
+    const token = store.issue("k1", NOW);
+    expect(store.consume(token, "k1", NOW)).toBe(true);
+    expect(store.consume(token, "k1", NOW)).toBe(false);
+  });
+
+  it("token vydaný pre INÝ kľúč sa nedá použiť na iný consume", () => {
+    const store = createSingleUsePreviewTokenStore();
+    const token = store.issue("k1", NOW);
+    expect(store.consume(token, "k2", NOW)).toBe(false);
+  });
+
+  it("neznámy/vymyslený token je vždy neplatný", () => {
+    const store = createSingleUsePreviewTokenStore();
+    expect(store.consume("vymyslený-token", "k1", NOW)).toBe(false);
+  });
+
+  it("nezhodný pokus token AJ TAK skonzumuje (jednorazový, bez ohľadu na výsledok)", () => {
+    const store = createSingleUsePreviewTokenStore();
+    const token = store.issue("k1", NOW);
+    expect(store.consume(token, "iný-kľúč", NOW)).toBe(false);
+    // Druhý pokus so SPRÁVNYM kľúčom už zlyhá — token bol zničený prvým
+    // (nesprávnym) pokusom.
+    expect(store.consume(token, "k1", NOW)).toBe(false);
+  });
+
+  it("token po TOKEN_TTL_MS (15 minút) exspiruje", () => {
+    const store = createSingleUsePreviewTokenStore();
+    const token = store.issue("k1", NOW);
+    const later = new Date(NOW.getTime() + 16 * 60 * 1000);
+    expect(store.consume(token, "k1", later)).toBe(false);
+  });
+
+  it("dva nezávislé kľúče dostanú DVA rôzne tokeny, oba platné", () => {
+    const store = createSingleUsePreviewTokenStore();
+    const tokenA = store.issue("kA", NOW);
+    const tokenB = store.issue("kB", NOW);
+    expect(tokenA).not.toBe(tokenB);
+    expect(store.consume(tokenA, "kA", NOW)).toBe(true);
+    expect(store.consume(tokenB, "kB", NOW)).toBe(true);
+  });
+
+  it("dve nezávislé inštancie store majú oddelené tokeny (žiadny zdieľaný stav)", () => {
+    const storeA = createSingleUsePreviewTokenStore();
+    const storeB = createSingleUsePreviewTokenStore();
+    const token = storeA.issue("k1", NOW);
+    // Ten istý token v druhom store neexistuje — Map je per-inštancia.
+    expect(storeB.consume(token, "k1", NOW)).toBe(false);
+    // A v pôvodnom store stále platí (druhý store ho neskonzumoval).
+    expect(storeA.consume(token, "k1", NOW)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/single-use-preview-tokens.ts
+++ b/apps/api/src/modules/single-use-preview-tokens.ts
@@ -1,0 +1,84 @@
+// issue 505: zdieľané jadro troch pôvodne bajt-na-bajt identických modulov
+// jednorazových preview-tokenov — `nedostupne/preview-tokens.ts`,
+// `orders/merge-mail-preview-tokens.ts` a `orders/customer-contact-preview-tokens.ts`.
+//
+// Server-side vynútený „náhľad VŽDY pred odoslaním": `/preview` vydá jednorazový
+// token viazaný na presný KĽÚČ, `/send` ho musí priniesť späť a token sa
+// SKONZUMUJE (zmaže) pri prvom pokuse o odoslanie, bez ohľadu na zhodu. Bez tohto
+// by priame volanie API (skript, iný klient, budúca frontendová regresia) mohlo
+// poslať e-mail bez toho, aby ho čokoľvek niekedy zobrazilo — presne ten gap,
+// ktorý `nedostupne` zámerne zatvoril pred mergom PR #182. Rovnaký in-process
+// `Map` vzor ako `http/login-rate-limit.ts` (jedna bežiaca inštancia appky, MVP
+// rozsah — reštart appky token zruší, čo je v poriadku, obsluha si vie náhľad
+// znova otvoriť).
+//
+// Tvar kľúča je vecou volajúceho wrappera (ĽUBOVOĽNÝ reťazec) — každá z troch
+// features si serializuje svoje polia do injektívneho reťazca. Každý wrapper má
+// VLASTNÝ nezávislý store (samostatná Map + strop), aby sa `MAX_ENTRIES`
+// eviction nezdieľal naprieč features — správanie ostáva presne také, ako keď
+// išlo o tri oddelené moduly.
+const TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minút — dosť na to, aby si obsluha náhľad prečítala, nie navždy platné
+const MAX_ENTRIES = 1_000; // strop proti neobmedzenému rastu (opakované náhľady bez odoslania)
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+interface PreviewTokenEntry {
+  readonly key: string;
+  readonly expiresAt: number;
+}
+
+export interface SingleUsePreviewTokenStore {
+  /** Vydá nový jednorazový token viazaný na presne tento `key` — volané z `/preview`. */
+  issue(key: string, now: Date): string;
+  /** Skonzumuje (zmaže) token a vráti, či bol platný PRE PRESNE tento `key` —
+   * volané z `/send` pred akýmkoľvek odoslaním. Token sa maže VŽDY (aj pri
+   * nezhode) — jednorazový, nikdy sa nedá „vyskúšať" opakovane. */
+  consume(token: string, key: string, now: Date): boolean;
+}
+
+/** Vytvorí nezávislý in-process store jednorazových preview-tokenov. Každý
+ * wrapper (nedostupne / order-merge / customer-contact) si drží jednu inštanciu
+ * na úrovni modulu — presne ako pôvodné tri oddelené moduly. */
+export function createSingleUsePreviewTokenStore(): SingleUsePreviewTokenStore {
+  const tokens = new Map<string, PreviewTokenEntry>();
+  let lastSweepAtMs = 0;
+
+  function sweepExpired(nowMs: number): void {
+    if (nowMs - lastSweepAtMs < SWEEP_INTERVAL_MS) return;
+    lastSweepAtMs = nowMs;
+    for (const [token, entry] of tokens) {
+      if (entry.expiresAt <= nowMs) tokens.delete(token);
+    }
+  }
+
+  function issue(key: string, now: Date): string {
+    const nowMs = now.getTime();
+    sweepExpired(nowMs);
+    // Strop dosiahnutý → uvoľni miesto zmazaním najskôr vypršiavajúceho záznamu
+    // (rovnaký zámer ako `login-rate-limit.ts`'s dávkové mazanie, len po jednom —
+    // tokeny sú oveľa menej časté než prihlasovacie pokusy).
+    if (tokens.size >= MAX_ENTRIES) {
+      let oldestToken: string | undefined;
+      let oldestExpiresAt = Infinity;
+      for (const [token, entry] of tokens) {
+        if (entry.expiresAt < oldestExpiresAt) {
+          oldestExpiresAt = entry.expiresAt;
+          oldestToken = token;
+        }
+      }
+      if (oldestToken !== undefined) tokens.delete(oldestToken);
+    }
+    const token = crypto.randomUUID();
+    tokens.set(token, { key, expiresAt: nowMs + TOKEN_TTL_MS });
+    return token;
+  }
+
+  function consume(token: string, key: string, now: Date): boolean {
+    const entry = tokens.get(token);
+    tokens.delete(token);
+    if (entry === undefined) return false;
+    if (entry.expiresAt <= now.getTime()) return false;
+    return entry.key === key;
+  }
+
+  return { issue, consume };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.294",
+  "version": "0.3.0-dev.295",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
issue 505 — čistý refaktor: tri identické moduly jednorazových preview-tokenov (Nedostupné, zlúčenie objednávok, e-mail zákazníkovi) teraz delegujú na zdieľané jadro `single-use-preview-tokens.ts` (factory, per-feature store, injektívne kľúče). Verejné signatúry nezmenené, správanie bit-identické — existujúce testy wrapperov prešli bez zmeny; nový priamy unit test jadra (7/7). Fable review PASS.

v0.3.0-dev.295. Ticket 505 ostáva otvorený — zavrie sa ručne po naživo overení.
