### PR TITLE
issue 499 — dedup-key + machine-channel routing pre uptime alerty (v0.3.0-dev.296)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -48,13 +48,22 @@ paths:
   obe verejné adresy (`forestshop.newlevel.media`,
   `forestshop-novy.newlevel.media`) každých 5 minút, alertuje až po 2
   zlyhaniach za sebou (~10 min súvislého výpadku, nie jeden blik) cez
-  `~/devel/airuleset/airuleset.py notify --body ... --owner-name marek`,
-  opakovaný alert pre TÚ ISTÚ prebiehajúcu udalosť najviac raz za ~1h
-  (throttle) + jedna správa pri zotavení. **Systemd `.timer`/`.service`
-  súbory sa NEVERZUJÚ do repa** (`~/.config/systemd/user/uptime-check.
-  {timer,service}` na dev1, rovnaký vzor ako `parovanie-backup.timer`) —
-  repo drží len skript, inštalácia je ručný jednorazový krok. Stavový súbor
-  (potvrdzovací počítadlo + throttle) je v `${XDG_RUNTIME_DIR:-/tmp}` —
+  `~/devel/airuleset/airuleset.py notify --body ... --owner-name marek
+  --dedup-key ...`. **Routing alertov (issue 499, doktrína analyze-not-ping —
+  airuleset #704/#705):** telefón (Discord) dostane LEN genuine nový actionable
+  prechod stavu — prvé potvrdenie výpadku a zotavenie — vždy s per-incident
+  `--dedup-key` (`forestshop-uptime:<down|up>:<url>:<incident-id>`), takže ten
+  istý prebiehajúci incident NEpinguje znova; prebiehajúci (už oznámený)
+  výpadok sa na každom ďalšom prechode zapíše LEN do journalu (machine
+  channel), nikdy znova na telefón. Keyless `notify --body` (bez `--dedup-key`)
+  je flood primitív a je v skripte ZAKÁZANÝ. Logika je testovaná
+  `scripts/uptime-check.test.sh` (root `pnpm test:uptime-script`, beží v CI
+  `check` jobe cez PATH-stub `curl`/`python3`/`date`). **Systemd
+  `.timer`/`.service` súbory sa NEVERZUJÚ do repa** (`~/.config/systemd/user/
+  uptime-check.{timer,service}` na dev1, rovnaký vzor ako
+  `parovanie-backup.timer`) — repo drží len skript, inštalácia je ručný
+  jednorazový krok. Stavový súbor (potvrdzovací počítadlo + alerted flag +
+  incident-id) je v `${XDG_RUNTIME_DIR:-/tmp}` —
   netreba ho zálohovať, monitor sa po reštarte dev1 sám znovu rozbehne od
   nuly (najhorší prípad: jeden alert navyše, nikdy tichý výpadok).
 

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -45,8 +45,9 @@ paths:
   beží appka — monitor na tom istom stroji, čo sleduje, by zomrel spolu s
   tým, čo má hlásiť; rovnaký vzor ako
   `api-watchdog.timer`/`imag-obs-alert-watchdog.timer`), kontroluje
-  obe verejné adresy (`forestshop.newlevel.media`,
-  `forestshop-novy.newlevel.media`) každých 5 minút, alertuje až po 2
+  verejnú adresu `forestshop.newlevel.media` (default od issue 488 už len
+  hlavná; `UPTIME_CHECK_URLS` override vie pridať ďalšie) každých 5 minút,
+  alertuje až po 2
   zlyhaniach za sebou (~10 min súvislého výpadku, nie jeden blik) cez
   `~/devel/airuleset/airuleset.py notify --body ... --owner-name marek
   --dedup-key ...`. **Routing alertov (issue 499, doktrína analyze-not-ping —

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -59,7 +59,14 @@ paths:
   channel), nikdy znova na telefón. Keyless `notify --body` (bez `--dedup-key`)
   je flood primitív a je v skripte ZAKÁZANÝ. Logika je testovaná
   `scripts/uptime-check.test.sh` (root `pnpm test:uptime-script`, beží v CI
-  `check` jobe cez PATH-stub `curl`/`python3`/`date`). **Systemd
+  `check` jobe cez PATH-stub `curl`/`python3`/`date`).
+  **GOTCHA — airuleset drží dedup marker aj po TRANSIENT zlyhaní POSTu
+  (`notify/__init__.py`, „a timeout can fire AFTER Discord accepted"); marker
+  uvoľní LEN pri no-token/no-channel.** Preto retry alertu s ROVNAKÝM
+  `--dedup-key` po zlyhanom `notify` je airulesetom ZDEDUPOVANÝ (tichý výpadok).
+  Down alert sa preto označí ako oznámený AŽ po úspešnom doručení a retry použije
+  NOVÝ incident-id (nový kľúč) — platí pre KAŽDÝ budúci alert skript v tomto repe,
+  čo volá airuleset `notify` a chce „nikdy nezmeškaj". **Systemd
   `.timer`/`.service` súbory sa NEVERZUJÚ do repa** (`~/.config/systemd/user/
   uptime-check.{timer,service}` na dev1, rovnaký vzor ako
   `parovanie-backup.timer`) — repo drží len skript, inštalácia je ručný

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       # (mockuje docker/curl cez PATH stuby — CI skutočný produkčný deploy
       # odbehnúť nevie, túto logiku áno). Beží pri každom push/PR.
       - run: pnpm test:deploy-script
+      # issue 499: bash-unit test alertovacieho routingu z scripts/uptime-check.sh
+      # (mockuje curl/python3/date cez PATH stuby) — overí per-incident
+      # --dedup-key + machine-channel routing (doktrína analyze-not-ping).
+      - run: pnpm test:uptime-script
 
   integration:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.295",
+  "version": "0.3.0-dev.296",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint . --concurrency=off",
     "test": "pnpm -r test",
     "test:deploy-script": "bash scripts/deploy-verify.test.sh",
+    "test:uptime-script": "bash scripts/uptime-check.test.sh",
     "test:integration": "pnpm --filter @forestshop/api test:integration",
     "gates:local": "pnpm typecheck && pnpm lint && pnpm test",
     "catalog:ingest": "tsx scripts/catalog-ingest.ts",

--- a/scripts/uptime-check.sh
+++ b/scripts/uptime-check.sh
@@ -17,11 +17,20 @@
 #
 # Perióda (systemd timer) 5 min. Potvrdenie po 2 zlyhaniach OKAMIHU za sebou
 # (~10 min súvislého výpadku) — jeden jednorazový blik (krátky sieťový hik) sa
-# nealertuje. Alert pre TÚ ISTÚ prebiehajúcu udalosť sa neopakuje častejšie než
-# raz za ALERT_THROTTLE_PASSES prechodov (predvolene 12 = ~1h pri 5min cadence)
-# — žiadny spam pre jeden trvajúci výpadok. Pri zotavení (URL, čo bolo predtým
-# potvrdene dole, teraz vráti 200) sa pošle JEDNA správa o zotavení a stav sa
-# vyčistí.
+# nealertuje.
+#
+# Routing alertov (issue 499, doktrína analyze-not-ping — airuleset #704/#705):
+# telefón (Discord) dostane LEN genuine nový actionable prechod stavu, a to
+# vždy s per-incident `--dedup-key`, takže ten istý incident nikdy nepinguje
+# znova:
+#   * prvé potvrdenie výpadku -> JEDEN keyed ping (kľúč `<prefix>:down:<url>:<id>`),
+#   * zotavenie predtým potvrdeného výpadku -> JEDEN keyed ping (`…:up:…:<id>`),
+#     s ROVNAKÝM incident-id ako down alert, ktorý uzatvára.
+# Prebiehajúci (už oznámený) výpadok sa na KAŽDOM ďalšom prechode zapíše LEN do
+# journalu (machine channel), NIKDY znova na telefón — žiadny spam pre jeden
+# trvajúci výpadok. `<id>` = epoch prvého potvrdenia; nový skutočný výpadok
+# dostane nový id -> nový kľúč -> alert. Keyless `notify --body` (bez
+# `--dedup-key`) je flood primitív a je tu ZAKÁZANÝ.
 #
 # Usage:
 #   scripts/uptime-check.sh            # one pass: measure -> decide -> alert
@@ -62,12 +71,18 @@ esac
 # `UPTIME_CHECK_URLS` ostáva, keby bolo treba sledovať aj ďalšie adresy.
 read -ra URLS <<< "${UPTIME_CHECK_URLS:-https://forestshop.newlevel.media}"
 CONFIRM_THRESHOLD="${UPTIME_CHECK_CONFIRM_THRESHOLD:-2}"
-ALERT_THROTTLE_PASSES="${UPTIME_CHECK_ALERT_THROTTLE_PASSES:-12}"   # ~1h at the 5-min cadence
 CURL_TIMEOUT="${UPTIME_CHECK_CURL_TIMEOUT:-10}"
 
 NOTIFY="${AIRULESET_NOTIFY:-$HOME/devel/airuleset/airuleset.py}"
 OWNER_NAME="${UPTIME_CHECK_OWNER:-marek}"
 REPO_SLUG="${UPTIME_CHECK_REPO:-zbynekdrlik/forestshop-app}"
+
+# issue 499 (airuleset #704/#705, doktrína analyze-not-ping): každý telefónny
+# alert nesie stabilný per-incident `--dedup-key` `<prefix>:<down|up>:<url-key>:
+# <incident-id>`, aby ten istý prebiehajúci incident NEpingoval znova (airuleset
+# `notify` zdedupe podľa kľúča). Keyless send (bez `--dedup-key`) je flood
+# primitív a je tu ZAKÁZANÝ.
+DEDUP_PREFIX="${UPTIME_CHECK_DEDUP_PREFIX:-forestshop-uptime}"
 
 STATE_DIR="${UPTIME_CHECK_STATE_DIR:-${XDG_RUNTIME_DIR:-/tmp}}"
 STATE_FILE="${UPTIME_CHECK_STATE_FILE:-$STATE_DIR/forestshop-app-uptime-check.state}"
@@ -84,7 +99,8 @@ probe_one() {
 
 # ── read / write persisted per-URL state ────────────────────────────────────
 # Key namespaced by a sanitized URL so both endpoints get independent
-# confirm/throttle tracking (one down, one up must not mask each other).
+# confirm / alerted / incident tracking (one down, one up must not mask each
+# other).
 sanitize_key() { printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'; }
 
 read_state_field() {
@@ -103,20 +119,39 @@ write_state_field() {
   mv -f "$tmp" "$STATE_FILE" 2>/dev/null || true
 }
 
-send_alert() {
-  local body="$1"
+# PHONE (Discord) — ONLY a genuine NEW actionable state TRANSITION (outage
+# start / recovery). ALWAYS carries a stable per-incident `--dedup-key` so the
+# SAME incident never re-pings (airuleset dedups on the key). A repeated status
+# for an UNCHANGED state must NEVER come here — route it through log_machine().
+send_phone_alert() {
+  local dedup_key="$1" body="$2"
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "[dry-run] WOULD alert: $body"
+    log "[dry-run] WOULD phone-alert (dedup-key=$dedup_key): $body"
     return 0
   fi
-  log "ALERT: firing Discord notification"
+  log "ALERT: firing Discord notification (dedup-key=$dedup_key)"
   python3 "$NOTIFY" notify --body "$body" --owner-name "$OWNER_NAME" \
+    --dedup-key "$dedup_key" \
     >/dev/null 2>&1 || log "ALERT: airuleset.py notify failed (non-fatal)"
 }
 
-# ── one URL: measure -> confirm -> throttle -> alert/recover ───────────────
+# MACHINE CHANNEL — a periodic / repeated STATE report goes to the journal
+# (stderr -> systemd journal), NEVER the phone (doktrína analyze-not-ping,
+# airuleset #704/#705). No `notify` call is made here.
+log_machine() {
+  log "MACHINE-CHANNEL: $*"
+}
+
+# ── one URL: measure -> confirm -> route (phone transition / journal state) ──
+# Three routing lanes (issue 499, doktrína analyze-not-ping):
+#   1. NEW confirmed outage      -> ONE keyed PHONE alert  (down:<incident-id>)
+#   2. ongoing known outage      -> journal (machine channel) only, NEVER phone
+#   3. recovery of a known outage-> ONE keyed PHONE alert  (up:<same incident-id>)
+# The incident-id (epoch of the first confirmation) makes each real outage's
+# dedup key unique, so a genuinely new outage always alerts while the same
+# ongoing incident never re-pings.
 check_url() {
-  local url="$1" key code down prev_confirm confirm
+  local url="$1" key code down prev_confirm confirm was_alerted incident_id
   key="$(sanitize_key "$url")"
 
   code="$(probe_one "$url")"
@@ -133,16 +168,20 @@ check_url() {
   write_state_field "${key}_confirm" "$confirm"
   log "url=$url confirm=$prev_confirm -> $confirm (threshold=$CONFIRM_THRESHOLD)"
 
-  # Recovered (was previously CONFIRMED down, now healthy) -> one recovery
-  # message, then clear the alert dedup so a FUTURE fresh outage always alerts.
-  local was_alerted
   was_alerted="$(read_state_field "${key}_alerted" 0)"
+
+  # Lane 3 — recovered (was CONFIRMED down, now healthy): ONE keyed recovery
+  # phone ping for THIS incident, then clear incident state so a FUTURE fresh
+  # outage always alerts with a new incident-id.
   if [ "$down" -eq 0 ]; then
     if [ "$was_alerted" = "1" ]; then
-      send_alert "✅ uptime-check ($REPO_SLUG): $url je opäť dostupná (HTTP $code)."
+      incident_id="$(read_state_field "${key}_incident" 0)"
+      send_phone_alert "${DEDUP_PREFIX}:up:${key}:${incident_id}" \
+        "✅ uptime-check ($REPO_SLUG): $url je opäť dostupná (HTTP $code)."
     fi
     write_state_field "${key}_alerted" 0
-    write_state_field "${key}_throttle_passes" 0
+    write_state_field "${key}_incident" 0
+    write_state_field "${key}_incident_passes" 0
     return 0
   fi
 
@@ -151,26 +190,30 @@ check_url() {
     return 0
   fi
 
-  # Confirmed down. Throttle repeat alerts for the SAME ongoing outage.
-  local prior_passes
+  # Lane 2 — already alerted for this ongoing incident: a periodic STATE report,
+  # NOT a phone ping. Route to the machine channel (journal) only.
   if [ "$was_alerted" = "1" ]; then
-    prior_passes="$(read_state_field "${key}_throttle_passes" 0)"
-    prior_passes=$((prior_passes + 1))
-    if [ "$prior_passes" -lt "$ALERT_THROTTLE_PASSES" ]; then
-      write_state_field "${key}_throttle_passes" "$prior_passes"
-      log "url=$url already alerted, suppressed by throttle (pass ${prior_passes}/${ALERT_THROTTLE_PASSES})"
-      return 0
-    fi
-    log "url=$url still down after throttle window — re-alerting"
+    local passes
+    passes="$(read_state_field "${key}_incident_passes" 0)"
+    passes=$((passes + 1))
+    write_state_field "${key}_incident_passes" "$passes"
+    incident_id="$(read_state_field "${key}_incident" 0)"
+    log_machine "url=$url STÁLE NEDOSTUPNÁ (HTTP ${code:-<žiadna odpoveď>}) — incident=$incident_id, prechod ${passes} — telefón sa NEpinguje (periodický stavový report)"
+    return 0
   fi
 
+  # Lane 1 — first confirmation of a NEW outage: the ONE genuine new actionable
+  # event. Capture a fresh incident-id and send exactly ONE keyed phone alert.
+  incident_id="$(date +%s)"
   write_state_field "${key}_alerted" 1
-  write_state_field "${key}_throttle_passes" 0
-  send_alert "🚨 uptime-check ($REPO_SLUG): $url NEODPOVEDÁ (HTTP ${code:-<žiadna odpoveď>}) už ${CONFIRM_THRESHOLD}+ prechodov za sebou."
+  write_state_field "${key}_incident" "$incident_id"
+  write_state_field "${key}_incident_passes" 0
+  send_phone_alert "${DEDUP_PREFIX}:down:${key}:${incident_id}" \
+    "🚨 uptime-check ($REPO_SLUG): $url NEODPOVEDÁ (HTTP ${code:-<žiadna odpoveď>}) už ${CONFIRM_THRESHOLD}+ prechodov za sebou."
 }
 
 main() {
-  log "pass start (dry_run=$DRY_RUN, threshold=$CONFIRM_THRESHOLD, throttle=$ALERT_THROTTLE_PASSES)"
+  log "pass start (dry_run=$DRY_RUN, threshold=$CONFIRM_THRESHOLD, dedup_prefix=$DEDUP_PREFIX)"
   for url in "${URLS[@]}"; do
     check_url "$url"
   done

--- a/scripts/uptime-check.sh
+++ b/scripts/uptime-check.sh
@@ -29,8 +29,11 @@
 # Prebiehajúci (už oznámený) výpadok sa na KAŽDOM ďalšom prechode zapíše LEN do
 # journalu (machine channel), NIKDY znova na telefón — žiadny spam pre jeden
 # trvajúci výpadok. `<id>` = epoch prvého potvrdenia; nový skutočný výpadok
-# dostane nový id -> nový kľúč -> alert. Keyless `notify --body` (bez
-# `--dedup-key`) je flood primitív a je tu ZAKÁZANÝ.
+# dostane nový id -> nový kľúč -> alert. Down alert sa označí ako oznámený AŽ po
+# skutočnom DORUČENÍ — ak `notify` zlyhá, ďalší prechod ho zopakuje s novým
+# incident-id (nový kľúč, airuleset nezdedupe), kým sa nedoručí (nikdy tichý
+# výpadok). Keyless `notify --body` (bez `--dedup-key`) je flood primitív a je
+# tu ZAKÁZANÝ.
 #
 # Usage:
 #   scripts/uptime-check.sh            # one pass: measure -> decide -> alert
@@ -113,7 +116,10 @@ read_state_field() {
 write_state_field() {
   local key="$1" val="$2" tmp
   mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
-  tmp="$(mktemp "${STATE_FILE}.XXXXXX" 2>/dev/null || echo "$STATE_FILE")"
+  # Fallback must be a DISTINCT path, never $STATE_FILE itself — the `> "$tmp"`
+  # redirection below would otherwise truncate the state file before `grep -v`
+  # reads it, silently dropping every other key (review finding, issue 499).
+  tmp="$(mktemp "${STATE_FILE}.XXXXXX" 2>/dev/null || printf '%s' "${STATE_FILE}.tmp.$$")"
   { [ -f "$STATE_FILE" ] && grep -v "^${key}=" "$STATE_FILE"; printf '%s=%s\n' "$key" "$val"; } \
     > "$tmp" 2>/dev/null || true
   mv -f "$tmp" "$STATE_FILE" 2>/dev/null || true
@@ -123,6 +129,9 @@ write_state_field() {
 # start / recovery). ALWAYS carries a stable per-incident `--dedup-key` so the
 # SAME incident never re-pings (airuleset dedups on the key). A repeated status
 # for an UNCHANGED state must NEVER come here — route it through log_machine().
+# Returns 0 iff the notification was DELIVERED (or dry-run) — the caller advances
+# the incident state machine only on delivery, so a failed transition alert is
+# retried on the next pass instead of being lost (never a silent outage).
 send_phone_alert() {
   local dedup_key="$1" body="$2"
   if [ "$DRY_RUN" -eq 1 ]; then
@@ -130,9 +139,12 @@ send_phone_alert() {
     return 0
   fi
   log "ALERT: firing Discord notification (dedup-key=$dedup_key)"
-  python3 "$NOTIFY" notify --body "$body" --owner-name "$OWNER_NAME" \
-    --dedup-key "$dedup_key" \
-    >/dev/null 2>&1 || log "ALERT: airuleset.py notify failed (non-fatal)"
+  if python3 "$NOTIFY" notify --body "$body" --owner-name "$OWNER_NAME" \
+       --dedup-key "$dedup_key" >/dev/null 2>&1; then
+    return 0
+  fi
+  log "ALERT: airuleset.py notify failed (non-fatal) — retry next pass"
+  return 1
 }
 
 # MACHINE CHANNEL — a periodic / repeated STATE report goes to the journal
@@ -203,13 +215,25 @@ check_url() {
   fi
 
   # Lane 1 — first confirmation of a NEW outage: the ONE genuine new actionable
-  # event. Capture a fresh incident-id and send exactly ONE keyed phone alert.
+  # event. Send the keyed phone alert; mark the incident ALERTED only once the
+  # phone actually received it. If delivery fails, leave `_alerted=0` so the
+  # next pass retries here with a FRESH incident-id (a fresh dedup key). This is
+  # required because airuleset KEEPS the dedup marker on a transient POST failure
+  # (deliberate — a timeout can fire after Discord accepted), so a same-key retry
+  # would be suppressed; a fresh key is never suppressed and guarantees the alert
+  # eventually lands. Cost: a rare double-ping only if a POST timed out AFTER
+  # Discord accepted it — far better than a silently-missed outage for a monitor.
+  # `_incident` is written BEFORE `_alerted` so no crash can leave alerted=1 with
+  # a zero incident-id.
   incident_id="$(date +%s)"
-  write_state_field "${key}_alerted" 1
   write_state_field "${key}_incident" "$incident_id"
-  write_state_field "${key}_incident_passes" 0
-  send_phone_alert "${DEDUP_PREFIX}:down:${key}:${incident_id}" \
-    "🚨 uptime-check ($REPO_SLUG): $url NEODPOVEDÁ (HTTP ${code:-<žiadna odpoveď>}) už ${CONFIRM_THRESHOLD}+ prechodov za sebou."
+  if send_phone_alert "${DEDUP_PREFIX}:down:${key}:${incident_id}" \
+       "🚨 uptime-check ($REPO_SLUG): $url NEODPOVEDÁ (HTTP ${code:-<žiadna odpoveď>}) už ${CONFIRM_THRESHOLD}+ prechodov za sebou."; then
+    write_state_field "${key}_alerted" 1
+    write_state_field "${key}_incident_passes" 0
+  else
+    log "url=$url down alert NEDORUČENÝ — zopakujem s novým incident-id na ďalšom prechode"
+  fi
 }
 
 main() {

--- a/scripts/uptime-check.test.sh
+++ b/scripts/uptime-check.test.sh
@@ -64,7 +64,7 @@ CASE=""
 ok()   { echo "  ✓ [$CASE] $1"; }
 fail() { echo "  ✗ [$CASE] $1"; FAILS=$((FAILS + 1)); }
 
-OUT=""; RC=0; NOW=1000
+OUT=""; NOW=1000
 newscenario() { rm -f "$STATE" "$STATE".* 2>/dev/null || true; : > "$NOTIFYLOG"; }
 
 # pass HTTP_CODE [extra-script-args...]  — jeden beh skriptu (jeden „tick")
@@ -77,7 +77,6 @@ pass() {
     UPTIME_CHECK_STATE_FILE="$STATE" \
     AIRULESET_NOTIFY="/fake/airuleset.py" \
     bash "$SCRIPT" "$@" 2>&1)
-  RC=$?
   set -e
 }
 

--- a/scripts/uptime-check.test.sh
+++ b/scripts/uptime-check.test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bash-unit test alertovacieho routingu z scripts/uptime-check.sh (issue 499).
+# Doktrína analyze-not-ping (airuleset #704/#705): keyless `notify --body` je
+# flood primitív; každý telefónny alert musí niesť stabilný per-incident
+# `--dedup-key`, a periodické/stavové hlásenia idú do machine channelu
+# (journal), nie na telefón. Tento test mockuje `curl`/`python3`/`date` cez
+# PATH stuby a overí, že:
+#   - potvrdený výpadok pošle PRÁVE JEDEN keyed telefónny down alert / incident,
+#   - „stále down" NEvolá notify (ide do journalu),
+#   - zotavenie pošle JEDEN keyed up alert s ROVNAKÝM incident id,
+#   - nový výpadok po zotavení dostane NOVÝ incident id,
+#   - --dry-run nikdy nevolá notify,
+#   - KAŽDÉ notify volanie nesie --dedup-key (žiadny keyless send).
+# Spustenie: bash scripts/uptime-check.test.sh  (alebo `pnpm test:uptime-script`)
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/uptime-check.sh"
+[ -f "$SCRIPT" ] || { echo "nenašiel som $SCRIPT" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+STATE="$WORK/state"
+NOTIFYLOG="$WORK/notify.log"
+
+# --- curl stub: vráti MOCK_HTTP_CODE ako `-w '%{http_code}'`. "FAIL" =
+#     curl-level chyba (DNS/timeout/refused) → prázdny výstup, exit 22
+#     (script's `|| true` → code="" → down=1). Inak vytlačí kód, exit 0.
+cat > "$BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+if [ "${MOCK_HTTP_CODE:-}" = "FAIL" ]; then exit 22; fi
+printf '%s' "${MOCK_HTTP_CODE:-000}"
+STUB
+chmod +x "$BIN/curl"
+
+# --- python3 stub: zachytí notify argv (všetko za python3), exit 0.
+cat > "$BIN/python3" <<'STUB'
+#!/usr/bin/env bash
+echo "NOTIFY_ARGS: $*" >> "$MOCK_NOTIFY_LOG"
+exit 0
+STUB
+chmod +x "$BIN/python3"
+
+# --- date stub: `+%s` vráti MOCK_NOW (riadené incident id); inak reálny date
+#     (log timestamp `+%Y-...`). PATH má $BIN prvý, preto reálny date cez
+#     absolútnu cestu (inak rekurzia).
+cat > "$BIN/date" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    +%s) printf '%s\n' "${MOCK_NOW:-1000}"; exit 0 ;;
+  esac
+done
+if [ -x /usr/bin/date ]; then exec /usr/bin/date "$@"; else exec /bin/date "$@"; fi
+STUB
+chmod +x "$BIN/date"
+
+# --- výsledky
+FAILS=0
+CASE=""
+ok()   { echo "  ✓ [$CASE] $1"; }
+fail() { echo "  ✗ [$CASE] $1"; FAILS=$((FAILS + 1)); }
+
+OUT=""; RC=0; NOW=1000
+newscenario() { rm -f "$STATE" "$STATE".* 2>/dev/null || true; : > "$NOTIFYLOG"; }
+
+# pass HTTP_CODE [extra-script-args...]  — jeden beh skriptu (jeden „tick")
+pass() {
+  local http="$1"; shift
+  set +e
+  OUT=$(PATH="$BIN:$PATH" \
+    MOCK_HTTP_CODE="$http" MOCK_NOW="$NOW" MOCK_NOTIFY_LOG="$NOTIFYLOG" \
+    UPTIME_CHECK_URLS="https://test.example" \
+    UPTIME_CHECK_STATE_FILE="$STATE" \
+    AIRULESET_NOTIFY="/fake/airuleset.py" \
+    bash "$SCRIPT" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+# grep -c vytlačí "0" a zároveň skončí exitom 1 pri nula zhodách — preto NIE
+# `|| echo 0` (zdvojilo by 0 na "0\n0"), ale zachytenie + `|| n=0` (rovnaká
+# hodnota, jeden riadok).
+notify_count() { local n; n="$(grep -c '^NOTIFY_ARGS:' "$NOTIFYLOG" 2>/dev/null)" || n=0; printf '%s' "$n"; }
+last_notify()  { grep '^NOTIFY_ARGS:' "$NOTIFYLOG" 2>/dev/null | tail -n1; }
+
+assert_notify_count()  { local n; n="$(notify_count)"; if [ "$n" = "$1" ]; then ok "notify volaní = $1"; else fail "notify volaní: čakal $1, dostal $n"; fi; }
+assert_last_has()      { if printf '%s' "$(last_notify)" | grep -qF -- "$1"; then ok "posledný notify obsahuje: $1"; else fail "posledný notify NEobsahuje: $1 (bol: $(last_notify))"; fi; }
+assert_last_hasnt()    { if printf '%s' "$(last_notify)" | grep -qF -- "$1"; then fail "posledný notify NEMAL obsahovať: $1"; else ok "posledný notify neobsahuje: $1"; fi; }
+assert_out_has()       { if printf '%s' "$OUT" | grep -qF -- "$1"; then ok "výstup obsahuje: $1"; else fail "výstup NEobsahuje: $1"; fi; }
+# každý notify riadok musí niesť --dedup-key (žiadny keyless send)
+assert_all_keyed() {
+  local total keyed
+  total="$(notify_count)"
+  keyed="$(grep -c -- '--dedup-key' "$NOTIFYLOG" 2>/dev/null)" || keyed=0
+  if [ "$total" = "$keyed" ]; then ok "všetkých $total notify volaní je keyed (0 keyless)"; else fail "keyless notify volania: $total celkom, $keyed keyed"; fi
+}
+
+# ---------------------------------------------------------------------------
+CASE="1. zdravé (200) — žiaden alert"
+newscenario
+pass 200
+assert_notify_count 0
+assert_out_has "down=0"
+
+# ---------------------------------------------------------------------------
+CASE="2. jeden blik (1× FAIL) — pod prahom, žiaden alert"
+newscenario
+pass FAIL
+assert_notify_count 0
+assert_out_has "not yet confirmed"
+
+# ---------------------------------------------------------------------------
+CASE="3. potvrdený výpadok (2× FAIL) — JEDEN keyed down alert"
+newscenario
+NOW=1000
+pass FAIL
+pass FAIL
+assert_notify_count 1
+assert_last_has "--dedup-key"
+assert_last_has "forestshop-uptime:down:"
+assert_last_has ":1000"
+assert_last_has "NEODPOVEDÁ"
+assert_last_has "--owner-name marek"
+assert_all_keyed
+
+# ---------------------------------------------------------------------------
+CASE="4. stále down (ďalšie FAIL) — machine channel, ŽIADEN nový notify"
+# pokračuje zo stavu scenára 3 (rovnaký state súbor)
+pass FAIL
+assert_notify_count 1
+assert_out_has "MACHINE-CHANNEL"
+pass FAIL
+assert_notify_count 1
+
+# ---------------------------------------------------------------------------
+CASE="5. zotavenie (200) — JEDEN keyed up alert, rovnaký incident id"
+pass 200
+assert_notify_count 2
+assert_last_has "forestshop-uptime:up:"
+assert_last_has ":1000"
+assert_last_has "opäť dostupná"
+assert_all_keyed
+
+# ---------------------------------------------------------------------------
+CASE="6. nový výpadok po zotavení — NOVÝ incident id"
+NOW=2000
+pass FAIL
+pass FAIL
+assert_notify_count 3
+assert_last_has "forestshop-uptime:down:"
+assert_last_has ":2000"
+assert_last_hasnt ":1000"
+assert_all_keyed
+
+# ---------------------------------------------------------------------------
+CASE="7. --dry-run — nikdy nevolá notify"
+newscenario
+NOW=1000
+pass FAIL --dry-run
+pass FAIL --dry-run
+assert_notify_count 0
+assert_out_has "WOULD phone-alert"
+assert_out_has "dedup-key"
+
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$FAILS" -eq 0 ]; then
+  echo "VŠETKY testy prešli."
+else
+  echo "ZLYHANÍ: $FAILS"
+  exit 1
+fi

--- a/scripts/uptime-check.test.sh
+++ b/scripts/uptime-check.test.sh
@@ -25,6 +25,8 @@ BIN="$WORK/bin"
 mkdir -p "$BIN"
 STATE="$WORK/state"
 NOTIFYLOG="$WORK/notify.log"
+OKLOG="$WORK/notify-ok.log"
+CNTFILE="$WORK/notify.cnt"
 
 # --- curl stub: vráti MOCK_HTTP_CODE ako `-w '%{http_code}'`. "FAIL" =
 #     curl-level chyba (DNS/timeout/refused) → prázdny výstup, exit 22
@@ -36,10 +38,19 @@ printf '%s' "${MOCK_HTTP_CODE:-000}"
 STUB
 chmod +x "$BIN/curl"
 
-# --- python3 stub: zachytí notify argv (všetko za python3), exit 0.
+# --- python3 stub: zachytí notify argv (každý POKUS) do MOCK_NOTIFY_LOG.
+#     Injektovateľné zlyhanie: prvých MOCK_NOTIFY_FAIL_N volaní skončí exitom 1
+#     (nedoručené); ostatné exit 0 a zapíšu DELIVERED do MOCK_NOTIFY_OK_LOG
+#     (počet skutočných DORUČENÍ). Modeluje airuleset transient POST failure.
 cat > "$BIN/python3" <<'STUB'
 #!/usr/bin/env bash
 echo "NOTIFY_ARGS: $*" >> "$MOCK_NOTIFY_LOG"
+if [ "${MOCK_NOTIFY_FAIL_N:-0}" -gt 0 ]; then
+  n=0; [ -f "$MOCK_NOTIFY_CNT" ] && n="$(cat "$MOCK_NOTIFY_CNT")"
+  n=$((n + 1)); printf '%s' "$n" > "$MOCK_NOTIFY_CNT"
+  if [ "$n" -le "$MOCK_NOTIFY_FAIL_N" ]; then exit 1; fi
+fi
+echo "DELIVERED: $*" >> "$MOCK_NOTIFY_OK_LOG"
 exit 0
 STUB
 chmod +x "$BIN/python3"
@@ -64,8 +75,8 @@ CASE=""
 ok()   { echo "  ✓ [$CASE] $1"; }
 fail() { echo "  ✗ [$CASE] $1"; FAILS=$((FAILS + 1)); }
 
-OUT=""; NOW=1000
-newscenario() { rm -f "$STATE" "$STATE".* 2>/dev/null || true; : > "$NOTIFYLOG"; }
+OUT=""; NOW=1000; FAIL_N=0
+newscenario() { rm -f "$STATE" "$STATE".* "$CNTFILE" 2>/dev/null || true; : > "$NOTIFYLOG"; : > "$OKLOG"; FAIL_N=0; }
 
 # pass HTTP_CODE [extra-script-args...]  — jeden beh skriptu (jeden „tick")
 pass() {
@@ -73,6 +84,7 @@ pass() {
   set +e
   OUT=$(PATH="$BIN:$PATH" \
     MOCK_HTTP_CODE="$http" MOCK_NOW="$NOW" MOCK_NOTIFY_LOG="$NOTIFYLOG" \
+    MOCK_NOTIFY_OK_LOG="$OKLOG" MOCK_NOTIFY_CNT="$CNTFILE" MOCK_NOTIFY_FAIL_N="$FAIL_N" \
     UPTIME_CHECK_URLS="https://test.example" \
     UPTIME_CHECK_STATE_FILE="$STATE" \
     AIRULESET_NOTIFY="/fake/airuleset.py" \
@@ -83,10 +95,12 @@ pass() {
 # grep -c vytlačí "0" a zároveň skončí exitom 1 pri nula zhodách — preto NIE
 # `|| echo 0` (zdvojilo by 0 na "0\n0"), ale zachytenie + `|| n=0` (rovnaká
 # hodnota, jeden riadok).
-notify_count() { local n; n="$(grep -c '^NOTIFY_ARGS:' "$NOTIFYLOG" 2>/dev/null)" || n=0; printf '%s' "$n"; }
-last_notify()  { grep '^NOTIFY_ARGS:' "$NOTIFYLOG" 2>/dev/null | tail -n1; }
+notify_count()    { local n; n="$(grep -c '^NOTIFY_ARGS:' "$NOTIFYLOG" 2>/dev/null)" || n=0; printf '%s' "$n"; }
+delivered_count() { local n; n="$(grep -c '^DELIVERED:'  "$OKLOG"     2>/dev/null)" || n=0; printf '%s' "$n"; }
+last_notify()     { grep '^NOTIFY_ARGS:' "$NOTIFYLOG" 2>/dev/null | tail -n1; }
 
-assert_notify_count()  { local n; n="$(notify_count)"; if [ "$n" = "$1" ]; then ok "notify volaní = $1"; else fail "notify volaní: čakal $1, dostal $n"; fi; }
+assert_notify_count()    { local n; n="$(notify_count)"; if [ "$n" = "$1" ]; then ok "notify volaní = $1"; else fail "notify volaní: čakal $1, dostal $n"; fi; }
+assert_delivered_count() { local n; n="$(delivered_count)"; if [ "$n" = "$1" ]; then ok "doručených alertov = $1"; else fail "doručených alertov: čakal $1, dostal $n"; fi; }
 assert_last_has()      { if printf '%s' "$(last_notify)" | grep -qF -- "$1"; then ok "posledný notify obsahuje: $1"; else fail "posledný notify NEobsahuje: $1 (bol: $(last_notify))"; fi; }
 assert_last_hasnt()    { if printf '%s' "$(last_notify)" | grep -qF -- "$1"; then fail "posledný notify NEMAL obsahovať: $1"; else ok "posledný notify neobsahuje: $1"; fi; }
 assert_out_has()       { if printf '%s' "$OUT" | grep -qF -- "$1"; then ok "výstup obsahuje: $1"; else fail "výstup NEobsahuje: $1"; fi; }
@@ -164,6 +178,26 @@ pass FAIL --dry-run
 assert_notify_count 0
 assert_out_has "WOULD phone-alert"
 assert_out_has "dedup-key"
+
+# ---------------------------------------------------------------------------
+CASE="8. down alert NEDORUČENÝ na 1. pokus — zopakuje sa (nový kľúč) a doručí PRÁVE RAZ"
+newscenario
+FAIL_N=1              # airuleset notify zlyhá pri PRVOM volaní, potom uspeje
+NOW=3000
+pass FAIL             # confirm=1 (pod prahom)
+pass FAIL             # confirm=2 -> Lane 1 pokus#1 -> notify ZLYHÁ, _alerted ostáva 0
+assert_out_has "NEDORUČENÝ"
+assert_delivered_count 0
+assert_last_has ":3000"
+NOW=3300             # čas postúpi -> ďalší pokus dostane NOVÝ incident-id (nový kľúč)
+pass FAIL             # confirm=3 -> Lane 1 pokus#2 -> notify USPEJE, _alerted=1
+assert_delivered_count 1
+assert_last_has "forestshop-uptime:down:"
+assert_last_has ":3300"
+NOW=3600
+pass FAIL             # confirm=4 -> Lane 2 (journal), žiaden ďalší pokus
+assert_delivered_count 1
+assert_out_has "MACHINE-CHANNEL"
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
issue 499 — uptime-check.sh už nespamuje Discord: down-prechod pošle JEDEN kľúčovaný alert (`--dedup-key`, retry s čerstvým incident-id — airuleset drží dedup marker aj pri transientnom POST zlyhaní), prebiehajúci výpadok ide len do journalu, zotavenie JEDEN kľúčovaný ping. Nový PATH-stub test harness (8 scenárov, 35 assertov, RED→GREEN) zapojený do CI check jobu; shellcheck clean; opravená aj mktemp-fallback strata dát.

v0.3.0-dev.296. Ticket 499 ostáva otvorený — zavrie sa po overení na dev1 (timer beží tam).
