### PR TITLE
Release v0.3.0-dev.297 — Zlúčenie: klikateľné objednávky + badge prípadov (issue 512)

### DIFF
--- a/apps/api/src/http/app.ts
+++ b/apps/api/src/http/app.ts
@@ -86,7 +86,11 @@ export function createApp(
     // rovnakého dôvodu ako `nedostupne` vyššie: bezpečný default pre testy/
     // lokálny vývoj, `index.ts` v produkcii VŽDY nahradí reálnymi
     // dependencies.
-    readonly orderMerge?: OrderMergeRunDeps;
+    // issue 512: `adminBaseUrl` sa NEPOSIELA tu — injektuje ho `createApp`
+    // z top-level `options.adminBaseUrl` (rovnaký vzor ako orders/search/dpd
+    // trasy), takže volajúci (testy aj `index.ts`) ho v `orderMerge` objekte
+    // vôbec neuvádzajú.
+    readonly orderMerge?: Omit<OrderMergeRunDeps, "adminBaseUrl">;
     // issue 500: "Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na
     // riadku). Voliteľné z rovnakého dôvodu ako `orderMerge` vyššie: bezpečný
     // default nižšie pre testy/lokálny vývoj, `index.ts` v produkcii VŽDY
@@ -295,14 +299,15 @@ export function createApp(
   );
   // issue 257: "Zlúčenie objednávok" — bezpečný default z rovnakého dôvodu
   // ako `nedostupne` vyššie.
-  registerOrderMergeRoutes(
-    app,
-    db,
-    options.orderMerge ?? {
+  registerOrderMergeRoutes(app, db, {
+    ...(options.orderMerge ?? {
       mailTransport: undefined,
       bccEmail: undefined,
-    },
-  );
+    }),
+    // issue 512: základ priameho odkazu na objednávku (klikateľné čísla vo
+    // výpise) — ten istý default ako ostatné trasy.
+    adminBaseUrl: options.adminBaseUrl ?? "https://www.forestshop.sk",
+  });
   // issue 500: "Na objednanie" — ručný e-mail zákazníkovi (@ tlačidlo na
   // riadku). Bezpečný default z rovnakého dôvodu ako `orderMerge` vyššie. Prefix
   // `/api/order-customer-contact/*` sa nekríži s `/api/orders/:id`

--- a/apps/api/src/http/order-merge-routes.ts
+++ b/apps/api/src/http/order-merge-routes.ts
@@ -5,7 +5,12 @@ import type { Database } from "../db/client.js";
 import { record } from "../modules/audit/service.js";
 import type { MailTransport } from "../modules/mail/transport.js";
 import { consumeMergePreviewToken, issueMergePreviewToken } from "../modules/orders/merge-mail-preview-tokens.js";
-import { buildOrderMergeMailContent, listMergeCandidateGroups, sendOrderMergeMail } from "../modules/orders/merge-mail.js";
+import {
+  buildOrderMergeMailContent,
+  countMergeCandidateGroups,
+  listMergeCandidateGroups,
+  sendOrderMergeMail,
+} from "../modules/orders/merge-mail.js";
 import { requireRole, requireUser, type AppBindings } from "./middleware.js";
 import { requireSameOrigin } from "./origin-check.js";
 
@@ -15,6 +20,9 @@ import { requireSameOrigin } from "./origin-check.js";
 export interface OrderMergeRunDeps {
   readonly mailTransport: MailTransport | undefined;
   readonly bccEmail: string | undefined;
+  // issue 512: `env.ts`'s `SHOPTET_ADMIN_BASE_URL` — základ priameho odkazu
+  // na objednávku (klikateľné čísla vo výpise, `buildShoptetAdminOrderUrl`).
+  readonly adminBaseUrl: string;
 }
 
 const previewBody = z.object({ baseOrderId: z.string().uuid(), otherOrderIds: z.array(z.string().uuid()).min(1) });
@@ -53,8 +61,18 @@ export function registerOrderMergeRoutes(app: Hono<AppBindings>, db: Database, d
   // Čítanie — každý prihlásený zamestnanec (rovnaká úroveň ako "Nedostupné
   // tovary").
   app.get("/api/order-merge/candidates", requireUser(db), async (c) => {
-    const groups = await listMergeCandidateGroups(db);
+    const groups = await listMergeCandidateGroups(db, deps.adminBaseUrl);
     return c.json({ groups, bccMissing: bccMissing(deps), mailNotConfigured: mailNotConfigured(deps) });
+  });
+
+  // issue 512: počet PRÍPADOV pre menu odznak — zákazníci (osoby) s ≥2
+  // otvorenými objednávkami, NIE počet objednávok. `requireUser`, žiadne
+  // obmedzenie roly (čítanie počtu nie je citlivejšie než čítanie zoznamu) —
+  // rovnaký vzor ako `GET /api/orders/riesit/count`. Žiadny `:param`
+  // konflikt v tomto súbore (všetky trasy sú literal).
+  app.get("/api/order-merge/count", requireUser(db), async (c) => {
+    const count = await countMergeCandidateGroups(db);
+    return c.json({ count });
   });
 
   // Povinný náhľad — počítaný ROVNAKOU funkciou, akú použije skutočné

--- a/apps/api/src/modules/orders/merge-mail.ts
+++ b/apps/api/src/modules/orders/merge-mail.ts
@@ -9,6 +9,7 @@ import { resolveTemplate } from "../mail-templates/store.js";
 import type { MailTransport } from "../mail/transport.js";
 import { customerIdentityKey } from "./customer-identity.js";
 import { listOpenStatusNames } from "./open-statuses.js";
+import { buildShoptetAdminOrderUrl } from "./queries.js";
 
 // issue 257: e-mail zákazníkovi, keď sa jeho viaceré objednávky posielajú
 // spolu ako jedna zásielka. "Ten istý zákazník" = zdieľaný `customerIdentityKey`
@@ -19,6 +20,16 @@ export interface MergeCandidateOrder {
   readonly orderId: string;
   readonly externalOrderId: string;
   readonly placedAt: string;
+}
+
+// issue 512: kandidát vo VÝPISE záložky navyše nesie priamy odkaz do Shoptet
+// administrácie na TÚTO objednávku (`buildShoptetAdminOrderUrl` — ten istý
+// serverom-počítaný `adminUrl` string ako „Na objednanie"/„Riešiť"/„Vyhľadať")
+// — LEN pre klikateľné čísla objednávok vo výpise; send/preview tok
+// (`listMergeableOrders`) ho nepotrebuje, preto zostáva na holom
+// `MergeCandidateOrder`.
+export interface MergeCandidateGroupOrder extends MergeCandidateOrder {
+  readonly adminUrl: string;
 }
 
 export interface MergeableOrders {
@@ -43,16 +54,21 @@ export interface MergeCandidateGroup {
   // `candidates`. Prvý prvok slúži ako `baseOrderId` pri odoslaní (server aj
   // tak celú skupinu prepočíta nanovo podľa identity zákazníka, takže na
   // tom, KTORÁ objednávka skupiny je "base", nezáleží).
-  readonly orders: readonly MergeCandidateOrder[];
+  readonly orders: readonly MergeCandidateGroupOrder[];
 }
 
 /**
- * Zákazníci s ≥2 OTVORENÝMI objednávkami — presne zoznam, ktorý nová
- * záložka "Zlúčenie objednávok" vypíše. Skupiny zoradené od NAJVÄČŠEJ
- * (najviac objednávok na zlúčenie), pri zhode abecedne podľa mena.
+ * Otvorené objednávky zoskupené podľa IDENTITY zákazníka
+ * (`customerIdentityKey`), len skupiny s ≥2 objednávkami. Vnútri skupiny
+ * najnovšia objednávka prvá; skupiny zoradené od NAJVÄČŠEJ (najviac
+ * objednávok na zlúčenie), pri zhode abecedne podľa mena.
+ *
+ * issue 512: JEDINÝ zdroj pravdy pre „ktorí zákazníci sa dajú zlúčiť" —
+ * zdieľajú ho VÝPIS (`listMergeCandidateGroups`) AJ POČET pre menu odznak
+ * (`countMergeCandidateGroups`), aby sa odznak (počet prípadov) a samotné
+ * zlúčenie NIKDY nerozišli (rovnaká úvaha ako odznak „Na objednanie", #431).
  */
-export async function listMergeCandidateGroups(db: Database): Promise<readonly MergeCandidateGroup[]> {
-  const openOrders = await loadOpenOrders(db);
+function groupOpenOrdersByCustomer(openOrders: readonly OpenOrderRow[]): OpenOrderRow[][] {
   const byIdentity = new Map<string, OpenOrderRow[]>();
   for (const order of openOrders) {
     const key = customerIdentityKey(order.email, order.customerName);
@@ -60,20 +76,56 @@ export async function listMergeCandidateGroups(db: Database): Promise<readonly M
     if (bucket === undefined) byIdentity.set(key, [order]);
     else bucket.push(order);
   }
-  const groups: MergeCandidateGroup[] = [];
+  const buckets: OpenOrderRow[][] = [];
   for (const bucket of byIdentity.values()) {
     if (bucket.length < 2) continue;
-    const sorted = [...bucket].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime());
-    const first = sorted[0];
+    buckets.push([...bucket].sort((a, b) => b.placedAt.getTime() - a.placedAt.getTime()));
+  }
+  buckets.sort(
+    (a, b) => b.length - a.length || (a[0]?.customerName ?? "").localeCompare(b[0]?.customerName ?? "", "sk"),
+  );
+  return buckets;
+}
+
+/**
+ * Zákazníci s ≥2 OTVORENÝMI objednávkami — presne zoznam, ktorý nová
+ * záložka "Zlúčenie objednávok" vypíše. `adminBaseUrl` (`env.ts`'s
+ * `SHOPTET_ADMIN_BASE_URL`) je základ priameho odkazu na objednávku
+ * (issue 512, klikateľné čísla — ten istý `buildShoptetAdminOrderUrl` ako
+ * „Na objednanie"/„Riešiť"/„Vyhľadať").
+ */
+export async function listMergeCandidateGroups(
+  db: Database,
+  adminBaseUrl: string,
+): Promise<readonly MergeCandidateGroup[]> {
+  const buckets = groupOpenOrdersByCustomer(await loadOpenOrders(db));
+  const groups: MergeCandidateGroup[] = [];
+  for (const bucket of buckets) {
+    const first = bucket[0];
     if (first === undefined) continue;
     groups.push({
       customerName: first.customerName,
       email: first.email,
-      orders: sorted.map((o) => ({ orderId: o.id, externalOrderId: o.externalOrderId, placedAt: o.placedAt.toISOString() })),
+      orders: bucket.map((o) => ({
+        orderId: o.id,
+        externalOrderId: o.externalOrderId,
+        placedAt: o.placedAt.toISOString(),
+        adminUrl: buildShoptetAdminOrderUrl(adminBaseUrl, o.externalOrderId, o.shoptetOrderId),
+      })),
     });
   }
-  groups.sort((a, b) => b.orders.length - a.orders.length || a.customerName.localeCompare(b.customerName, "sk"));
   return groups;
+}
+
+/**
+ * issue 512: počet PRÍPADOV pre menu odznak — zákazníci (osoby) s ≥2
+ * otvorenými objednávkami, NIE počet objednávok (Jozef Stroška s 3
+ * objednávkami = 1). Zdieľa `groupOpenOrdersByCustomer` s výpisom vyššie,
+ * takže odznak a zlúčenie sa nikdy nerozídu; nepotrebuje `adminBaseUrl`
+ * (len počíta skupiny).
+ */
+export async function countMergeCandidateGroups(db: Database): Promise<number> {
+  return groupOpenOrdersByCustomer(await loadOpenOrders(db)).length;
 }
 
 interface OpenOrderRow {
@@ -82,6 +134,9 @@ interface OpenOrderRow {
   readonly customerName: string;
   readonly email: string | null;
   readonly placedAt: Date;
+  // issue 512: interné Shoptet id (keď ho appka pozná, migrácia 0016) — pre
+  // priamy odkaz na detail objednávky vo výpise záložky.
+  readonly shoptetOrderId: number | null;
 }
 
 // Otvorené objednávky (`order.status_name` v nastavenom otvorenom zozname) —
@@ -98,6 +153,7 @@ async function loadOpenOrders(db: Database): Promise<readonly OpenOrderRow[]> {
       customerName: orders.customerName,
       email: orders.email,
       placedAt: orders.placedAt,
+      shoptetOrderId: orders.shoptetOrderId,
     })
     .from(orders)
     .where(inArray(orders.statusName, [...openStatuses]));

--- a/apps/api/tests/order-merge-http.integration.test.ts
+++ b/apps/api/tests/order-merge-http.integration.test.ts
@@ -57,7 +57,15 @@ async function boot(role: UserRole, options: { readonly sent?: MailMessage[]; re
 async function seedOrder(
   db: Awaited<ReturnType<typeof boot>>["db"],
   externalOrderId: string,
-  options: { readonly customerName?: string; readonly email?: string | null; readonly statusName?: string; readonly placedAt?: Date } = {},
+  options: {
+    readonly customerName?: string;
+    readonly email?: string | null;
+    readonly statusName?: string;
+    readonly placedAt?: Date;
+    // issue 512: interné Shoptet id — keď je nastavené, `adminUrl` je priamy
+    // odkaz `?id=`; keď null (default), vyhľadávací fallback `?string=`.
+    readonly shoptetOrderId?: number;
+  } = {},
 ): Promise<string> {
   const [order] = await db
     .insert(orders)
@@ -67,6 +75,7 @@ async function seedOrder(
       email: options.email === undefined ? "zakaznik@example.sk" : options.email,
       statusName: options.statusName ?? DEFAULT_ORDER_OPEN_STATUS,
       placedAt: options.placedAt ?? new Date("2026-07-20T10:00:00Z"),
+      ...(options.shoptetOrderId === undefined ? {} : { shoptetOrderId: options.shoptetOrderId }),
     })
     .returning({ id: orders.id });
   if (order === undefined) throw new Error("test objednávka sa nepodarila vložiť");
@@ -115,6 +124,54 @@ it("zákazník bez e-mailu sa zlučuje podľa MENA (fallback)", async () => {
   const body = (await res.json()) as { groups: { customerName: string }[] };
   expect(body.groups).toHaveLength(1);
   expect(body.groups[0]?.customerName).toBe("Delta Bez Emailu");
+});
+
+it("issue 512: každá objednávka vo výpise nesie adminUrl — priamy ?id= keď je Shoptet id, inak ?string= fallback", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  // Ten istý zákazník, dve otvorené objednávky — jedna s interným Shoptet id,
+  // druhá bez neho.
+  await seedOrder(db, "9201", {
+    customerName: "Epsilon Zákazník",
+    email: "epsilon@example.sk",
+    placedAt: new Date("2026-07-21T10:00:00Z"),
+    shoptetOrderId: 58656,
+  });
+  await seedOrder(db, "9202", {
+    customerName: "Epsilon Zákazník",
+    email: "epsilon@example.sk",
+    placedAt: new Date("2026-07-20T10:00:00Z"),
+  });
+
+  const res = await app.request("/api/order-merge/candidates", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { groups: { orders: { externalOrderId: string; adminUrl: string }[] }[] };
+  const byCode = new Map((body.groups[0]?.orders ?? []).map((o) => [o.externalOrderId, o.adminUrl]));
+  expect(byCode.get("9201")).toBe("https://www.forestshop.sk/admin/objednavky-detail/?id=58656");
+  expect(byCode.get("9202")).toBe("https://www.forestshop.sk/admin/vyhladavanie/?string=9202&src=orders");
+});
+
+it("issue 512: /count počíta PRÍPADY (osoby) s ≥2 otvorenými objednávkami, NIE objednávky", async () => {
+  const { app, cookie, db } = await boot("citanie");
+  // Alfa: 3 otvorené objednávky → 1 prípad.
+  await seedOrder(db, "9211", { customerName: "Alfa", email: "alfa@example.sk" });
+  await seedOrder(db, "9212", { customerName: "Alfa", email: "alfa@example.sk" });
+  await seedOrder(db, "9213", { customerName: "Alfa", email: "alfa@example.sk" });
+  // Gama: 2 otvorené objednávky → 1 prípad.
+  await seedOrder(db, "9214", { customerName: "Gama", email: "gama@example.sk" });
+  await seedOrder(db, "9215", { customerName: "Gama", email: "gama@example.sk" });
+  // Beta: 1 otvorená objednávka → 0 prípadov.
+  await seedOrder(db, "9216", { customerName: "Beta", email: "beta@example.sk" });
+
+  const res = await app.request("/api/order-merge/count", { headers: { cookie } });
+  expect(res.status).toBe(200);
+  // 6 objednávok, ale iba 2 PRÍPADY (osoby) — Alfa a Gama; Beta sa nepočíta.
+  expect((await res.json()) as { count: number }).toEqual({ count: 2 });
+});
+
+it("issue 512: GET /count bez prihlásenia vráti 401", async () => {
+  const { app } = await boot("manazer");
+  const res = await app.request("/api/order-merge/count");
+  expect(res.status).toBe(401);
 });
 
 it("bccMissing/mailNotConfigured — bez BCC ani mail transportu", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import { FloorNotesBadgeRefreshContext } from "./floorNotesBadgeContext.js";
 import { DEFAULT_TAB_ID, NAV, findTab, isVisibleTabId } from "./nav.js";
 import { fetchOrderFlagCounts } from "./orderFlagsApi.js";
 import { OrderFlagsBadgeRefreshContext } from "./orderFlagsBadgeContext.js";
+import { fetchOrderMergeCount } from "./orderMergeApi.js";
 import { fetchRiesitCount } from "./ordersApi.js";
 import { fetchOrderReminderStatus } from "./orderReminderApi.js";
 import { OrdersRemainingCountContext } from "./ordersRemainingCountContext.js";
@@ -270,6 +271,28 @@ export function App(): JSX.Element {
     };
   }, [me, activeTabId, riesitRefreshNonce]);
 
+  // issue 512: odznak „Zlúčenie objednávok" — počet PRÍPADOV (osoby s ≥2
+  // otvorenými objednávkami). Rovnaký PRIAMY vzor ako `riesitCount` vyššie
+  // (App.tsx vlastní count, fetchuje pri prihlásení/zmene záložky). ŽIADNY
+  // refresh-context: odoslanie e-mailu o zlúčení NEMENÍ počet otvorených
+  // objednávok, takže stačí refetch pri prepnutí záložky.
+  const [orderMergeCount, setOrderMergeCount] = useState<number | null>(null);
+  useEffect(() => {
+    if (me === null) return;
+    let cancelled = false;
+    fetchOrderMergeCount()
+      .then((count) => {
+        if (!cancelled) setOrderMergeCount(count);
+      })
+      .catch(() => {
+        // `fetchOrderMergeCount` interne zachytáva všetky chyby a vždy vráti 0
+        // (`orderMergeApi.ts`) — poistka pre eslint `no-floating-promises`.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, activeTabId]);
+
   const badgeCounts = useMemo<Readonly<Record<string, number>>>(() => {
     const counts: Record<string, number> = {};
     if (ordersRemainingCount !== null) counts["orders"] = ordersRemainingCount;
@@ -283,6 +306,10 @@ export function App(): JSX.Element {
     // issue 476: odznak „Riešiť" — ukazuje sa AJ pri nule (rovnako ako
     // „ulohy"/„floor-orders" vyššie); kľúč `riesit` = `nav.ts`'s `tab.id`.
     if (riesitCount !== null) counts["riesit"] = riesitCount;
+    // issue 512: odznak „Zlúčenie objednávok" — počet prípadov (osôb) s ≥2
+    // otvorenými objednávkami; ukazuje sa AJ pri nule (zadanie: „ako ostatné
+    // položky — Na objednanie, Riešiť…"). Kľúč `order-merge` = `nav.ts`'s `tab.id`.
+    if (orderMergeCount !== null) counts["order-merge"] = orderMergeCount;
     // issue 445: odznak sa ukazuje AJ pri nule (rovnako ako "upozornenia"/
     // "pairing-review" — appka tým hovorí "toto číslo poznám, je 0"), aby
     // šéf hneď videl "dnes netreba objednať žiadnu DPD prepravu".
@@ -308,7 +335,7 @@ export function App(): JSX.Element {
     // istý tvar bugu ako `UpozorneniaSection.tsx`'s `withBusy`), takže lint
     // to nezachytí a stará hodnota (chýbajúce odznaky hneď po prihlásení,
     // kým sa nespustí NEJAKÝ INÝ trigger) prežije bez varovania.
-  }, [ordersRemainingCount, upozorneniaCount, dpdCount, pairingReviewUnreviewedCount, orderFlagCounts, dailyTasksCount, floorNotesCount, riesitCount]);
+  }, [ordersRemainingCount, upozorneniaCount, dpdCount, pairingReviewUnreviewedCount, orderFlagCounts, dailyTasksCount, floorNotesCount, riesitCount, orderMergeCount]);
 
   // issue 185: stav zapnuté/vypnuté pre "Automatizácie" priečinok v menu.
   // Na rozdiel od `ordersRemainingCount` vyššie (publikované OBRAZOVKOU

--- a/apps/web/src/components/OrderMergeSection.test.tsx
+++ b/apps/web/src/components/OrderMergeSection.test.tsx
@@ -20,8 +20,8 @@ const GROUP = {
   customerName: "Eva Kováčová",
   email: "eva@example.sk",
   orders: [
-    { orderId: "order-a", externalOrderId: "27700101", placedAt: "2026-08-01T10:00:00.000Z" },
-    { orderId: "order-b", externalOrderId: "27700100", placedAt: "2026-07-31T10:00:00.000Z" },
+    { orderId: "order-a", externalOrderId: "27700101", placedAt: "2026-08-01T10:00:00.000Z", adminUrl: "https://www.forestshop.sk/admin/objednavky-detail/?id=12345" },
+    { orderId: "order-b", externalOrderId: "27700100", placedAt: "2026-07-31T10:00:00.000Z", adminUrl: "https://www.forestshop.sk/admin/vyhladavanie/?string=27700100&src=orders" },
   ],
 };
 
@@ -98,6 +98,16 @@ it("zrušenie náhľadu NEPOŠLE nič", async () => {
     expect(screen.queryByTestId("order-merge-preview")).toBeNull();
   });
   expect(sendOrderMergeMail).not.toHaveBeenCalled();
+});
+
+it("issue 512: číslo objednávky je klikateľný odkaz do Shoptet administrácie", async () => {
+  fetchOrderMergeCandidates.mockResolvedValue(LIST_WITH_GROUP);
+  render(<OrderMergeSection role="citanie" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("order-merge-group-27700101");
+
+  const odkaz = screen.getByRole("link", { name: "Otvoriť objednávku 27700101 v administrácii Shoptet" });
+  expect(odkaz.getAttribute("href")).toBe("https://www.forestshop.sk/admin/objednavky-detail/?id=12345");
+  expect(odkaz.textContent).toBe("27700101");
 });
 
 it("rola citanie NEVIDÍ tlačidlo odoslania", async () => {

--- a/apps/web/src/components/OrderMergeSection.tsx
+++ b/apps/web/src/components/OrderMergeSection.tsx
@@ -162,7 +162,22 @@ export function OrderMergeSection({ role, onSessionExpired }: { readonly role: M
                 </div>
                 <ul className="order-merge-orders">
                   {group.orders.map((o) => (
-                    <li key={o.orderId}>č. {o.externalOrderId}</li>
+                    // issue 512: číslo objednávky je klikateľné — priamy odkaz
+                    // do Shoptet administrácie (rovnaký `.ord-admin-link` vzor
+                    // ako „Na objednanie"/„Riešiť"/„Vyhľadať").
+                    <li key={o.orderId}>
+                      č.{" "}
+                      <a
+                        href={o.adminUrl}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="ord-admin-link"
+                        aria-label={`Otvoriť objednávku ${o.externalOrderId} v administrácii Shoptet`}
+                        title="Otvoriť v administrácii Shoptet"
+                      >
+                        {o.externalOrderId}
+                      </a>
+                    </li>
                   ))}
                 </ul>
                 {canControl && (

--- a/apps/web/src/orderMergeApi.ts
+++ b/apps/web/src/orderMergeApi.ts
@@ -3,7 +3,15 @@ import { z } from "zod";
 // issue 257: "Zlúčenie objednávok" — zrkadlí `apps/api/src/http/order-merge-routes.ts`.
 // Rovnaký tvar ako `nedostupneApi.ts`.
 
-const candidateOrderSchema = z.object({ orderId: z.string(), externalOrderId: z.string(), placedAt: z.string() });
+// issue 512: `adminUrl` = priamy odkaz do Shoptet administrácie na objednávku
+// (server ho počíta `buildShoptetAdminOrderUrl`, ten istý tvar ako
+// `ordersApi.ts`'s `orderLineSchema`).
+const candidateOrderSchema = z.object({
+  orderId: z.string(),
+  externalOrderId: z.string(),
+  placedAt: z.string(),
+  adminUrl: z.string().regex(/^https?:\/\//),
+});
 export type MergeCandidateOrder = z.infer<typeof candidateOrderSchema>;
 
 const groupSchema = z.object({
@@ -63,6 +71,21 @@ async function readJson(response: Response, fallback: string): Promise<unknown> 
 export async function fetchOrderMergeCandidates(): Promise<OrderMergeList> {
   const response = await fetch("/api/order-merge/candidates");
   return listSchema.parse(await readJson(response, "Zoznam sa nepodarilo načítať"));
+}
+
+const countSchema = z.object({ count: z.number() });
+
+// issue 512: počet PRÍPADOV (osoby s ≥2 otvorenými objednávkami) pre menu
+// odznak — vzor `ordersApi.ts`'s `fetchRiesitCount`. Chybu zachytáva volajúci
+// `App.tsx` (vždy vráti 0 pri zlyhaní).
+export async function fetchOrderMergeCount(): Promise<number> {
+  try {
+    const response = await fetch("/api/order-merge/count");
+    if (!response.ok) return 0;
+    return countSchema.parse(await response.json()).count;
+  } catch {
+    return 0;
+  }
 }
 
 export async function fetchOrderMergePreview(baseOrderId: string, otherOrderIds: readonly string[]): Promise<OrderMergePreview> {

--- a/apps/web/tests/e2e/order-merge.spec.ts
+++ b/apps/web/tests/e2e/order-merge.spec.ts
@@ -39,6 +39,20 @@ test("záložka vypíše zákazníkov s ≥2 otvorenými objednávkami, povinný
   await expect(group).toContainText("č. 9010");
   await expect(group).toContainText("č. 9011");
 
+  // issue 512: číslo objednávky je klikateľný odkaz do Shoptet administrácie
+  // (rovnaký vzor ako „Na objednanie"/„Riešiť"). Seed objednávka nemá interné
+  // Shoptet id, takže odkaz je vyhľadávací fallback `?string=<kód>`.
+  const odkaz9010 = group.getByRole("link", { name: "Otvoriť objednávku 9010 v administrácii Shoptet" });
+  await expect(odkaz9010).toBeVisible();
+  const href9010 = await odkaz9010.getAttribute("href");
+  expect(href9010).toMatch(/\/admin\//);
+  expect(href9010).toContain("9010");
+
+  // issue 512: menu odznak „Zlúčenie objednávok" ukazuje počet PRÍPADOV (osôb) —
+  // kladné celé číslo, nikdy presné (zdieľaná seed DB seeduje viac objednávok,
+  // `.claude/rules/testing.md`/#445).
+  await expect(page.getByTestId("nav-badge-order-merge")).toHaveText(/^[1-9]\d*$/);
+
   // Klik otvorí POVINNÝ náhľad PRED akýmkoľvek odoslaním (rovnaký kontrakt
   // ako "Nedostupné tovary" — server-side vynútený token).
   await group.getByTestId("order-merge-send-9011").click();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.296",
+  "version": "0.3.0-dev.297",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Release v0.3.0-dev.297 — issue 512 (Zlúčenie objednávok: klikateľné čísla objednávok + badge počtu prípadov).

- Čísla objednávok na kartách Zlúčenia sú odkazy do Shoptet admin detailu (rovnaký vzor ako Na objednanie/Riešiť/Vyhľadať; serverom stavané adminUrl).
- Menu položka „Zlúčenie objednávok" má badge s počtom PRÍPADOV (osôb s ≥2 otvorenými objednávkami), nie objednávok — zdieľaný grouping helper medzi výpisom a /count, takže sa nemôžu rozísť.
- Testy: integračné (adminUrl, /count osoby-nie-objednávky, 401), unit render odkazu, e2e (href + nav badge, zero console errors).

Ticket 512 ostáva otvorený do naživo overenia; zavriem ho ručne po deployi.
