### PR TITLE
Vymena tovaru: len aktivne objednavky + badge poctu v menu (issue 514)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1524,3 +1524,9 @@ paths:
   inde na tej istej obrazovke znamená CHYBU (BCC/mail varovania, issue 344 preto
   pre RIADOK zvolil zelenú `--fs-success`) — pri „daj to červené" over, či to šéf
   myslí naozaj (issue 466: myslel, výslovne zopakoval), a zdôvodnenie napíš na tiket.
+
+- **Badge v nav tabe mení accessible name tlačidla** (#512): číselný badge je
+  `<span>` s `aria-label` VNÚTRI tab buttonu, takže jeho text sa PRIDÁVA do
+  accessible name — `getByRole` kliky s NEexact menom v e2e ostávajú bezpečné,
+  exact-name kliky by sa rozbili. Pri pridávaní badge na existujúci tab netreba
+  meniť nav counts logiku, len over e2e selektory tabu.

--- a/.claude/rules/order-flags.md
+++ b/.claude/rules/order-flags.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "apps/api/src/modules/orders/order-flags*.ts"
+  - "apps/api/src/modules/orders/return-status.ts"
+  - "apps/api/src/http/order-flags-routes.ts"
+  - "apps/web/src/components/ExchangeOrdersSection.tsx"
+  - "apps/web/src/components/ReturnedOrdersSection.tsx"
+  - "apps/web/src/components/ClaimOrdersSection.tsx"
+  - "apps/web/src/components/OrderFlagTable.tsx"
+  - "apps/web/src/orderFlagsApi.ts"
+---
+
+# Eshop → Výmena tovaru / Vrátený tovar / Reklamácie (order-flags, #290)
+
+Tri READ-ONLY sekcie nad `order.status_name` (Výmena/Vrátený tovar) a nad
+appkiným `order.claim_marked_at` (Reklamácie). Modul: `order-flags.ts`
+(klasifikátory stavov), `order-flags-queries.ts` (výpisy + počty),
+`order-flags-routes.ts` (HTTP), zdieľaný `OrderFlagTable.tsx`.
+
+- **Výpis sekcie AJ jej menu-odznak zdieľajú JEDEN predikát + JEDNU query
+  cestu.** `listExchangeOrders`/`listReturnedOrders` aj `countOrderFlags`
+  idú OBA cez `selectFlaggedByStatus(db, isExchangeOrderStatus)` (resp.
+  `isReturnedOrderStatus`). Zmena, ktorá má invertovať/rozšíriť „ktoré
+  objednávky sekcia ukazuje", sa robí v JEDNOM klasifikátore v
+  `order-flags.ts` (`EXCHANGE_STATUS`/`RETURNED_*_STATUS`) — výpis aj počet
+  ju preberú automaticky, nikdy neduplikuj SQL/JS count. Issue 514 tak
+  invertovalo „Výmena tovaru" jedinou zmenou `EXCHANGE_STATUS` (z „Vybavená
+  výmena" na „Výmena tovaru").
+- **Menu-odznaky exchange/returned/claims sú UŽ NAPOJENÉ v `App.tsx` (#290)**
+  — `fetchOrderFlagCounts` → `orderFlagCounts` → `badgeCounts["exchange"/…]`,
+  zobrazené LEN pri `> 0` (skryté pri 0, na rozdiel od orders/upozornenia,
+  ktoré ukazujú aj 0). „Pridaj badge na Výmena/Vrátený/Reklamácie" preto
+  NEvyžaduje zmenu `App.tsx`/`nav.ts` — stačí zmeniť SÉMANTIKU príslušného
+  poľa v `countOrderFlags`. Badge testid je `nav-badge-<tab.id>`
+  (`nav-badge-exchange` atď.), e2e ho over ako `/^[1-9]\d*$/` (nie presné
+  číslo — zdieľaná seed DB, vzor #445), nikdy neasertuj jeho neprítomnosť.
+- **`OrderFlagRow.unresolved` (štítok „nevybavené") = objednávka má ešte
+  OTVORENÚ „vratenie" kartu na Upozorneniach** (`return-status.ts`'s
+  `returnUpozornenieDedupKey`, kľúč na objednávku). Kritická doménová fakt:
+  ktoré stavy vôbec zakladajú/držia kartu, hovorí `return-status.ts` —
+  ACTIVE = „Vratený tovar" (zakladá/obnovuje), FINISHED = „Vybavená
+  výmena"/„Vybavený Dobropis" (auto-zatvárajú). **Stav „Výmena tovaru" je v
+  ANI JEDNEJ mape**, takže preň karta nikdy nevznikne → `unresolved` je preň
+  prakticky vždy `false` a štítok sa v sekcii „Výmena tovaru" bežne
+  nezobrazí (ostáva len pre zriedkavý prechod „Vratený tovar → Výmena
+  tovaru" s lingering otvorenou kartou). Preto (issue 514) je exchange badge
+  = počet VŠETKÝCH aktívnych výmen (`exchangeRows.length`), NIE
+  unresolved-filtrovaný — filtrovať by ho navždy skrylo; returned ostáva
+  unresolved-filtrovaný, lebo „Vratený tovar" JE aktívny vrátkový stav s
+  kartami. Táto asymetria počtov je zámerná, nie bug.
+- **Priradenie stavu VŽDY over naživo na produkcii, nie zo starej appky ani
+  z odhadu** — issue 290 aj 514 to overili priamo v prod DB
+  (`docker exec forestshop-postgres-1 psql -U forestshop -d forestshop -c
+  "select status_name, count(*) from \"order\" where status_name ilike
+  '%mena%' group by 1"`, iba čítanie). Realita sa mení: #290 priradilo
+  „Vybavená výmena", lebo vtedy nebola žiadna „Výmena tovaru"; #514 to
+  invertovalo, keď pribudli aktívne výmeny. Porovnanie beží cez
+  `normalizeStatusName` (NFC + orez) na oboch stranách — rovnaká funkcia ako
+  `ingest.ts` pri ukladaní `order.status_name`.
+- **`unresolved` sa počíta DVOJKROKOVO bez `.for("update")`**
+  (`unresolvedDedupKeySet`): najprv objednávky filtrom, potom otvorené
+  „vratenie" karty pre ich dedup kľúče. Čisté čítanie, žiadny zápis do
+  `upozornenie` (to ostáva výhradne `return-upozornenia.ts`/#269).
+- **`unresolved` NEMÁ e2e pokrytie zámerne** — `upozornenie` je globálna
+  tabuľka zdieľaná so `upozornenia.spec.ts` (seedovaná karta by zmenila jeho
+  „žiadne upozornenia" prázdny stav). Logiku pokrýva
+  `order-flags-http.integration.test.ts` (izolovaná DB) + komponentové
+  vitest testy (mock). Nový test tejto oblasti nech drží ten istý rozdel.

--- a/.claude/rules/orders.md
+++ b/.claude/rules/orders.md
@@ -833,3 +833,18 @@ paths:
   stav AUTOMATICKY. Klient výslovne NEŽIADAL vlastnú sekciu (na rozdiel od Riešiť)
   — len tlačidlo + stav; `ordered`-boolean toky (hromadné označenie, Skryť
   vybavené, súčty, supplier e-mail) sa NEMENIA.
+
+## Zlúčenie objednávok — klikateľné objednávky + badge prípadov (#512)
+
+- **Nav badge „Zlúčenie objednávok" počíta OSOBY (prípady), nie objednávky** —
+  `/api/order-merge/count` aj výpis zdieľajú JEDEN grouping helper
+  (`groupOpenOrdersByCustomer` v `apps/api/src/modules/orders/merge-mail.ts`);
+  nikdy nereplikuj počítanie ako samostatný SQL `COUNT(DISTINCT)` — identita
+  zákazníka žije v JS (rozšírenie precedensu identity kľúča z #431) a duplikácia
+  by sa časom rozišla s výpisom.
+- **Odkazy na objednávky v kartách Zlúčenia** = serverom stavané `adminUrl`
+  (`buildShoptetAdminOrderUrl`, `.ord-admin-link`, target `_blank`) — FE nikdy
+  nestavia Shoptet admin URL sám. Vzor vlákna `adminBaseUrl` do `createApp`:
+  option typu `Omit<Deps,"adminBaseUrl">` + `options.adminBaseUrl ?? default`
+  za spreadom, existujúci volajúci/testy sa nemenia (rovnako ako
+  orders/search/dpd trasy).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Zápisová cesta `product_supplier_link_override` (#239, obrazovka odstránená #400 — API + zdieľaný upsert s #121 ostávajú, volajú ich Vyhľadať #240 a Párovanie #387 E6) → `.claude/rules/product-links.md`
 - Eshop → Vyhľadať (#240 — dve oddelené polia produkty/objednávky, detail produktu, zdieľaná zapisovacia cesta s #239) → `.claude/rules/search.md`
 - Eshop → Upozornenia (#267 — nástenka, čiastočný unique dedup index, počítaný stav bez cron-u, zdieľaná zapisovacia cesta pre budúce #268/#269) → `.claude/rules/upozornenia.md`
+- Eshop → Výmena tovaru / Vrátený tovar / Reklamácie (#290/#514 — READ-ONLY sekcie nad order.status_name, výpis+badge zdieľajú jeden predikát, väzba „nevybavené" na vratenie karty) → `.claude/rules/order-flags.md`
 - Preprava DPD (#292 — per-zásielkový Playwright robot na dpdshipper.sk, appka-vlastný `dpd_shipment`/`dpd_pickup_request` záznam, náhľad pred odoslaním, fail-loud nedomapovaný formulár) → `.claude/rules/dpd.md`
 - Google kalendár — najbližšia udalosť (#309 — samostatný modul od `upozornenia` (žiadny dedupKey/resolve), krátkodobá in-memory cache namiesto scheduler jobu, node-ical proces-TZ past pri celodenných udalostiach) → `.claude/rules/calendar.md`
 - Profesionálne párovanie produktov (#387 E1+ — port starej appky @60b6164, rapidfuzz case-sensitive token_set_ratio, viac-kódová adaptácia, nahradilo `restock-links.md` v E8) → `.claude/rules/pairing-search.md`

--- a/apps/api/src/modules/orders/order-flags-queries.ts
+++ b/apps/api/src/modules/orders/order-flags-queries.ts
@@ -155,9 +155,17 @@ export interface OrderFlagCounts {
   readonly claims: number;
 }
 
-/** Počty pre odznaky v ľavom menu (`nav.ts`) — `exchange`/`returned` =
- * počet NEVYBAVENÝCH (`unresolved`), `claims` = počet AKTUÁLNE OZNAČENÝCH
- * (žiadny ďalší "vybavené" koncept, viď `listClaimOrders` vyššie). */
+/** Počty pre odznaky v ľavom menu (`nav.ts`):
+ * - `exchange` = počet VŠETKÝCH aktívnych výmen (stav "Výmena tovaru") — issue
+ *   514, Štěpán: „koľko objendávok so stavom Výmena tovaru je aktualnych".
+ *   Zdieľa PRESNE tú istú dátovú cestu ako výpis (`selectFlaggedByStatus(db,
+ *   isExchangeOrderStatus)`), takže badge == dĺžka výpisu, žiadny duplicitný
+ *   count. NIE je unresolved-filtrovaný — stav "Výmena tovaru" nezakladá
+ *   "vratenie" kartu (`return-status.ts`), takže `unresolved` je preň prakticky
+ *   vždy false; filtrovať by badge navždy skrylo.
+ * - `returned` = počet NEVYBAVENÝCH vrátení (`unresolved`) — nezmenené, "Vratený
+ *   tovar" JE aktívny vrátkový stav s kartami.
+ * - `claims` = počet AKTUÁLNE OZNAČENÝCH (žiadny ďalší "vybavené" koncept). */
 export async function countOrderFlags(db: Database): Promise<OrderFlagCounts> {
   const [exchangeRows, returnedRows, claimRows] = await Promise.all([
     selectFlaggedByStatus(db, isExchangeOrderStatus),
@@ -165,7 +173,7 @@ export async function countOrderFlags(db: Database): Promise<OrderFlagCounts> {
     db.select({ id: orders.id }).from(orders).where(isNotNull(orders.claimMarkedAt)),
   ]);
   return {
-    exchange: exchangeRows.filter((r) => r.unresolved).length,
+    exchange: exchangeRows.length,
     returned: returnedRows.filter((r) => r.unresolved).length,
     claims: claimRows.length,
   };

--- a/apps/api/src/modules/orders/order-flags.test.ts
+++ b/apps/api/src/modules/orders/order-flags.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it } from "vitest";
 import { isExchangeOrderStatus, isReturnedOrderStatus } from "./order-flags.js";
 
-// issue 290: priradenie OVERENÉ NAŽIVO na produkcii (tiket) — "Výmena
-// tovaru" = presne "Vybavená výmena", "Vrátený tovar" = "Vratený tovar" +
-// "Vybavený Dobropis". Rovnaká normalizačná disciplína ako `return-
-// status.test.ts` (NFC + orez, nikdy bajtovo presná zhoda).
+// issue 514 (invertuje issue 290): sekcia „Výmena tovaru" má ukazovať
+// AKTÍVNE výmeny — presne stav "Výmena tovaru", nie hotový "Vybavená výmena"
+// (ten sa z výpisu odstraňuje). Issue 290 pôvodne priradilo "Vybavená
+// výmena", lebo vtedy (7.8.2026) produkcia nemala ani jednu objednávku v
+// stave "Výmena tovaru" — realita sa medzitým zmenila (živo overené na
+// tikete: 1× "Výmena tovaru", 8× "Vybavená výmena"). "Vrátený tovar" =
+// "Vratený tovar" + "Vybavený Dobropis" (nezmenené). Rovnaká normalizačná
+// disciplína ako `return-status.test.ts` (NFC + orez, nikdy bajtovo presná
+// zhoda).
 describe("isExchangeOrderStatus", () => {
-  it("rozpozná jediný priradený stav 'Vybavená výmena'", () => {
-    expect(isExchangeOrderStatus("Vybavená výmena")).toBe(true);
+  it("rozpozná AKTÍVny stav 'Výmena tovaru' (issue 514)", () => {
+    expect(isExchangeOrderStatus("Výmena tovaru")).toBe(true);
   });
 
-  it("'Výmena tovaru' (rozpracovaný stav) NIE JE priradený — dnes nemá žiadnu objednávku", () => {
-    expect(isExchangeOrderStatus("Výmena tovaru")).toBe(false);
+  it("'Vybavená výmena' (vybavená výmena) UŽ NIE JE priradený — issue 514 ho z výpisu odstránilo", () => {
+    expect(isExchangeOrderStatus("Vybavená výmena")).toBe(false);
   });
 
   it("vrátkové/bežné stavy nie sú výmena", () => {
@@ -22,8 +27,8 @@ describe("isExchangeOrderStatus", () => {
   });
 
   it("normalizuje (NFC + orez) rovnako ako order.status_name", () => {
-    expect(isExchangeOrderStatus("  Vybavená výmena  ")).toBe(true);
-    expect(isExchangeOrderStatus("Vybavená výmena".normalize("NFD"))).toBe(true);
+    expect(isExchangeOrderStatus("  Výmena tovaru  ")).toBe(true);
+    expect(isExchangeOrderStatus("Výmena tovaru".normalize("NFD"))).toBe(true);
   });
 });
 

--- a/apps/api/src/modules/orders/order-flags.ts
+++ b/apps/api/src/modules/orders/order-flags.ts
@@ -11,14 +11,17 @@ import { normalizeStatusName } from "./parser.js";
 // prepojený rozsah, keby sa niekedy zmenil dôvod #297's rozdelenia
 // aktívne/hotové), len ROVNAKÚ funkciu (`normalizeStatusName`) na
 // porovnanie, presne ako `open-statuses.ts`.
-const EXCHANGE_STATUS = normalizeStatusName("Vybavená výmena");
+const EXCHANGE_STATUS = normalizeStatusName("Výmena tovaru");
 const RETURNED_GOODS_STATUS = normalizeStatusName("Vratený tovar");
 const RETURNED_CREDIT_STATUS = normalizeStatusName("Vybavený Dobropis");
 
-/** `true`, keď objednávka patrí na stránku "Výmena tovaru" — presne stav
- * "Vybavená výmena" (jediný, čo majiteľ na produkcii reálne má; "Výmena
- * tovaru" — rozpracovaný stav — dnes nemá priradenú žiadnu objednávku,
- * rozhodnuté na tickete). */
+/** `true`, keď objednávka patrí na stránku "Výmena tovaru" — presne AKTÍVny
+ * stav "Výmena tovaru" (issue 514, Štěpán: sekcia má ukazovať len aktívne
+ * výmeny na vybavenie). Vybavená výmena ("Vybavená výmena") sa tu už
+ * NEzobrazuje. Issue 290 pôvodne cielilo "Vybavená výmena", lebo vtedy
+ * (7.8.2026) produkcia nemala ani jednu objednávku v stave "Výmena tovaru";
+ * realita sa medzitým zmenila (živo overené na tikete #514: 1× "Výmena
+ * tovaru", 8× "Vybavená výmena"). */
 export function isExchangeOrderStatus(statusName: string): boolean {
   return normalizeStatusName(statusName) === EXCHANGE_STATUS;
 }

--- a/apps/api/tests/order-flags-http.integration.test.ts
+++ b/apps/api/tests/order-flags-http.integration.test.ts
@@ -63,11 +63,14 @@ async function insertOrder(
 }
 
 describe("GET /api/order-flags/exchange", () => {
-  it("vráti len objednávky v stave 'Vybavená výmena', s nevybavenosťou podľa otvorenej vratenie karty", async () => {
+  it("vráti len AKTÍVne výmeny (stav 'Výmena tovaru'), 'Vybavená výmena' sa už NEzobrazuje (issue 514)", async () => {
     const { app, cookie, db } = await boot("citanie");
-    const vymena = await insertOrder(db, "Vybavená výmena", { comment: "poznámka k výmene" });
+    const vymena = await insertOrder(db, "Výmena tovaru", { comment: "poznámka k výmene" });
+    await insertOrder(db, "Vybavená výmena"); // vybavená výmena — issue 514 ju z výpisu odstránilo
     await insertOrder(db, "Vybavená"); // iný stav — nesmie sa objaviť
     await insertOrder(db, "Vratený tovar"); // iný stav — nesmie sa objaviť
+    // Lingering otvorená vratenie karta (zriedkavý prípad Vratený tovar → Výmena
+    // tovaru) → unresolved: true; zdieľaný `OrderFlagTable` štítok ostáva funkčný.
     await upsertUpozornenie(db, {
       type: "vratenie",
       source: "appka",
@@ -81,14 +84,14 @@ describe("GET /api/order-flags/exchange", () => {
     const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
     expect(body.orders).toHaveLength(1);
     expect(body.orders[0]?.["externalOrderId"]).toBe(vymena.externalOrderId);
-    expect(body.orders[0]?.["statusName"]).toBe("Vybavená výmena");
+    expect(body.orders[0]?.["statusName"]).toBe("Výmena tovaru");
     expect(body.orders[0]?.["comment"]).toBe("poznámka k výmene");
     expect(body.orders[0]?.["unresolved"]).toBe(true);
   });
 
-  it("objednávka bez otvorenej vratenie karty je unresolved: false", async () => {
+  it("aktívna výmena bez otvorenej vratenie karty je unresolved: false", async () => {
     const { app, cookie, db } = await boot("citanie");
-    await insertOrder(db, "Vybavená výmena");
+    await insertOrder(db, "Výmena tovaru");
 
     const res = await app.request("/api/order-flags/exchange", { headers: { cookie } });
     const body = (await res.json()) as { orders: readonly Record<string, unknown>[] };
@@ -98,7 +101,7 @@ describe("GET /api/order-flags/exchange", () => {
 
   it("VYRIEŠENÁ vratenie karta neznamená unresolved — len otvorená karta počíta", async () => {
     const { app, cookie, db, userId } = await boot("citanie");
-    const vymena = await insertOrder(db, "Vybavená výmena");
+    const vymena = await insertOrder(db, "Výmena tovaru");
     const card = await upsertUpozornenie(db, {
       type: "vratenie",
       source: "appka",
@@ -250,17 +253,21 @@ describe("POST /api/order-flags/claims/:id/clear", () => {
 });
 
 describe("GET /api/order-flags/counts", () => {
-  it("spočíta nevybavené výmeny/vrátenia + aktuálne označené reklamácie", async () => {
+  it("exchange = POČET VŠETKÝCH aktívnych výmen (nie unresolved-filtrovaný), returned = nevybavené vrátenia, claims = označené (issue 514)", async () => {
     const { app, cookie, db } = await boot("manazer");
-    const vymena = await insertOrder(db, "Vybavená výmena");
+    // Dve aktívne výmeny: jedna s otvorenou vratenie kartou, jedna bez. Badge
+    // (issue 514) počíta OBE — dôkaz, že to NIE JE unresolved-filtrovaný count.
+    const vymenaSKartou = await insertOrder(db, "Výmena tovaru");
+    await insertOrder(db, "Výmena tovaru");
     await upsertUpozornenie(db, {
       type: "vratenie",
       source: "appka",
       title: "t",
-      dedupKey: returnUpozornenieDedupKey(vymena.externalOrderId),
+      dedupKey: returnUpozornenieDedupKey(vymenaSKartou.externalOrderId),
       now: new Date("2026-07-21T00:00:00Z"),
     });
-    await insertOrder(db, "Vratený tovar"); // bez karty → 0 do returned count
+    await insertOrder(db, "Vybavená výmena"); // vybavená výmena sa NEpočíta (issue 514)
+    await insertOrder(db, "Vratený tovar"); // bez karty → 0 do returned count (nezmenené)
     const reklamacia = await insertOrder(db, "Vybavená");
     await app.request("/api/order-flags/claims", {
       method: "POST",
@@ -270,6 +277,6 @@ describe("GET /api/order-flags/counts", () => {
 
     const res = await app.request("/api/order-flags/counts", { headers: { cookie } });
     const body = (await res.json()) as { exchange: number; returned: number; claims: number };
-    expect(body).toEqual({ exchange: 1, returned: 0, claims: 1 });
+    expect(body).toEqual({ exchange: 2, returned: 0, claims: 1 });
   });
 });

--- a/apps/web/src/components/ExchangeOrdersSection.test.tsx
+++ b/apps/web/src/components/ExchangeOrdersSection.test.tsx
@@ -11,16 +11,20 @@ vi.mock("../orderFlagsApi.js", async (importOriginal) => {
 
 const { OrderFlagsUnauthorizedError } = await import("../orderFlagsApi.js");
 
+// issue 514: sekcia zobrazuje AKTÍVne výmeny (stav "Výmena tovaru"), nie
+// hotové "Vybavená výmena". Štítok "nevybavené" (zdieľaný `OrderFlagTable`)
+// ostáva funkčný pre zriedkavý prípad "Vratený tovar → Výmena tovaru" s
+// lingering otvorenou vratenie kartou.
 const ROW = {
   id: "order-1",
   externalOrderId: "20600001",
   customerName: "Zákazník testovaný",
-  statusName: "Vybavená výmena",
+  statusName: "Výmena tovaru",
   placedAt: "2026-08-01T10:00:00.000Z",
   totalPriceWithVat: "42.00",
   comment: "poznámka",
   adminUrl: "https://www.forestshop.sk/admin/objednavky-detail/?id=1",
-  unresolved: true,
+  unresolved: false,
 };
 
 afterEach(() => {
@@ -34,20 +38,28 @@ it("prázdny zoznam zobrazí informačnú vetu", async () => {
   await screen.findByTestId("exchange-empty");
 });
 
-it("zobrazí riadok objednávky s odkazom aj štítkom 'nevybavené', keď má otvorenú vratenie kartu", async () => {
+it("hlavička popisuje aktívne výmeny (issue 514)", async () => {
+  fetchExchangeOrders.mockResolvedValue([]);
+  const { container } = render(<ExchangeOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId("exchange-empty");
+  expect(container.textContent).toContain("Výmena tovaru");
+  expect(container.textContent).toContain("aktívne výmeny");
+});
+
+it("zobrazí riadok aktívnej výmeny (stav 'Výmena tovaru') s odkazom", async () => {
   fetchExchangeOrders.mockResolvedValue([ROW]);
   render(<ExchangeOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
   const row = await screen.findByTestId("exchange-row-20600001");
   expect(row.textContent).toContain("20600001");
-  expect(row.textContent).toContain("Vybavená výmena");
-  await screen.findByTestId("exchange-row-unresolved-20600001");
+  expect(row.textContent).toContain("Výmena tovaru");
+  expect(screen.queryByTestId("exchange-row-unresolved-20600001")).toBeNull();
 });
 
-it("objednávka bez otvorenej karty NEMÁ štítok 'nevybavené'", async () => {
-  fetchExchangeOrders.mockResolvedValue([{ ...ROW, unresolved: false }]);
+it("štítok 'nevybavené' sa zobrazí pri lingering otvorenej vratenie karte (Vratený tovar → Výmena tovaru)", async () => {
+  fetchExchangeOrders.mockResolvedValue([{ ...ROW, unresolved: true }]);
   render(<ExchangeOrdersSection role="manazer" onSessionExpired={vi.fn()} />);
   await screen.findByTestId("exchange-row-20600001");
-  expect(screen.queryByTestId("exchange-row-unresolved-20600001")).toBeNull();
+  await screen.findByTestId("exchange-row-unresolved-20600001");
 });
 
 it("401 (Unauthorized) volá onSessionExpired namiesto zobrazenia chyby", async () => {

--- a/apps/web/src/components/ExchangeOrdersSection.tsx
+++ b/apps/web/src/components/ExchangeOrdersSection.tsx
@@ -3,11 +3,14 @@ import type { Me } from "../api.js";
 import { fetchExchangeOrders, OrderFlagsUnauthorizedError, type OrderFlagRow } from "../orderFlagsApi.js";
 import { OrderFlagTable } from "./OrderFlagTable.js";
 
-// issue 290: "Eshop → Výmena tovaru" — READ-ONLY zoznam objednávok v stave
-// "Vybavená výmena" (jediný priradený stav, `modules/orders/order-flags
-// .ts`). Žiadna mutácia tu — vybavovanie ostáva výhradne na nástenke
-// Upozornenia (`return-status.ts`/#267/#269/#297), táto obrazovka len
-// ZOBRAZUJE tie isté objednávky + či majú ešte otvorenú kartu.
+// issue 290 → 514: "Eshop → Výmena tovaru" — READ-ONLY zoznam AKTÍVnych
+// výmen (stav "Výmena tovaru", `modules/orders/order-flags.ts`). Issue 514
+// (Štěpán) invertovalo pôvodné priradenie na "Vybavená výmena": sekcia teraz
+// ukazuje len výmeny, ktoré treba vybaviť, vybavené sa nezobrazujú. Žiadna
+// mutácia tu. "Výmena tovaru" nezakladá "vratenie" kartu na Upozorneniach
+// (`return-status.ts`), takže štítok "nevybavené" (zdieľaný `OrderFlagTable`)
+// sa tu bežne nezobrazí — ostáva len pre zriedkavý prípad "Vratený tovar →
+// Výmena tovaru" s lingering otvorenou kartou.
 export function ExchangeOrdersSection({ onSessionExpired }: { readonly role: Me["role"]; readonly onSessionExpired: () => void }): JSX.Element {
   const [rows, setRows] = useState<readonly OrderFlagRow[] | null>(null);
   const [error, setError] = useState("");
@@ -29,7 +32,7 @@ export function ExchangeOrdersSection({ onSessionExpired }: { readonly role: Me[
 
   return (
     <section>
-      <p>Objednávky, ktoré Shoptet eviduje v stave „Vybavená výmena“. Farebný štítok „nevybavené“ znamená, že na nástenke Upozornenia je k tejto objednávke ešte otvorená karta.</p>
+      <p>Objednávky, ktoré Shoptet eviduje v stave „Výmena tovaru“ — aktívne výmeny, ktoré treba vybaviť. Vybavené výmeny („Vybavená výmena“) sa tu už nezobrazujú.</p>
       {rows.length === 0 ? (
         <p data-testid="exchange-empty">Momentálne žiadna objednávka nie je vo výmene.</p>
       ) : (

--- a/apps/web/tests/e2e/order-flags.spec.ts
+++ b/apps/web/tests/e2e/order-flags.spec.ts
@@ -35,13 +35,22 @@ test("Výmena tovaru/Vrátený tovar zobrazia zoznam, Reklamácie umožnia ozna�
   await expect(claimsOdznak).toBeVisible();
   await expect(claimsOdznak).toHaveText(/^\d+$/);
 
+  // issue 514: menu-odznak „Výmena tovaru" = počet AKTÍVnych výmen (stav
+  // „Výmena tovaru"). Fixtúra 9201 garantuje ≥1, takže odznak je viditeľný
+  // hneď po prihlásení (skrytý pri 0). Presné číslo NEasertujeme — badge
+  // počíta VŠETKY „Výmena tovaru" objednávky v zdieľanej seed DB (vzor
+  // issue 445, `nav-badge` disciplína).
+  const vymenaOdznak = page.getByTestId("nav-badge-exchange");
+  await expect(vymenaOdznak).toBeVisible();
+  await expect(vymenaOdznak).toHaveText(/^[1-9]\d*$/);
+
   // Výmena tovaru.
   await page.getByRole("button", { name: "Výmena tovaru" }).click();
   await expect(page.getByRole("heading", { name: "Výmena tovaru" })).toBeVisible();
   const vymenaRiadok = page.getByTestId("exchange-row-9201");
   await expect(vymenaRiadok).toBeVisible();
   await expect(vymenaRiadok).toContainText("E2E Zákazník Výmena");
-  await expect(vymenaRiadok).toContainText("Vybavená výmena");
+  await expect(vymenaRiadok).toContainText("Výmena tovaru");
   await expect(vymenaRiadok).toContainText("30.00 €");
 
   // Vrátený tovar.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.297",
+  "version": "0.3.0-dev.298",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.298",
+  "version": "0.3.0-dev.299",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/scripts/e2e-fixtures-order-flags.ts
+++ b/scripts/e2e-fixtures-order-flags.ts
@@ -36,10 +36,13 @@ export async function seedOrderFlagsFixtures(db: Database, heslo: string): Promi
     role: "manazer",
   });
 
+  // issue 514: AKTÍVna výmena (stav "Výmena tovaru") — sekcia „Výmena tovaru"
+  // teraz zobrazuje len tieto, nie hotové "Vybavená výmena". Táto jediná
+  // fixtúra garantuje viditeľný menu-odznak `nav-badge-exchange` (>0).
   await db.insert(orders).values({
     externalOrderId: "9201",
     customerName: "E2E Zákazník Výmena",
-    statusName: "Vybavená výmena",
+    statusName: "Výmena tovaru",
     placedAt: MINULY_DATUM,
     totalPriceWithVat: "30.00",
   });


### PR DESCRIPTION
## Issue 514 — Výmena tovaru: len aktívne objednávky + badge počtu v menu

Sekcia Výmena tovaru vo FClaude zobrazovala objednávky v stave „Vybavená výmena" (pôvodný dizajn z #290, keď stav „Výmena tovaru" v dátach neexistoval). Štěpán žiada opak: len aktívne „Výmena tovaru", vybavené preč, plus číselný badge v menu.

- Invertovaný jediný zdieľaný predikát `EXCHANGE_STATUS` v `order-flags.ts` — výpis sekcie aj `countOrderFlags.exchange` ho zdieľajú (žiadna duplicitná logika)
- Menu badge „Výmena tovaru" = počet aktívnych výmen, skrytý pri 0 (App.tsx wiring z #290 nezmenený, len sémantika countu)
- Hlavička sekcie zosúladená s novým správaním
- RED→GREEN: c3a4444 (test) → d34dff3 (impl); unit 1029+749 zelené, `pnpm gates:local` exit 0
- Playbook: nový `.claude/rules/order-flags.md`

Tiket #514 ostáva otvorený — zavrie sa ručne po naživo overení po deploy.
