### PR TITLE
Release: kalendárové upozornenie — písmo +1px (issue 520)

### DIFF
--- a/.claude/rules/calendar.md
+++ b/.claude/rules/calendar.md
@@ -144,3 +144,19 @@ paths:
   udalosťami (dayLimit 2 → 4 udalosti) — výsledky, ktoré `.slice(0,limit)`
   nedokáže vyrobiť; testy len s 1 udalosťou/deň prejdú aj na starom kóde
   (nedokazujú nič nové).
+- **Issue 520 (Štěpán: text kalendárového upozornenia príliš malý, +1px):
+  `--fs-text-xs` (12px) a `--fs-text-sm` (13px, `app.css` §1 typografia)
+  sú NÁHODOU presne 1px od seba** — `.next-calendar-event-row`'s
+  `font-size: var(--fs-text-xs)` (issue 382's pôvodná voľba, zdôvodnená
+  vyššie v tomto súbore výškou karty) sa tak dalo zväčšiť o presne 1px len
+  prepnutím na susedný existujúci token, bez zavedenia novej surovej
+  hodnoty (`.claude/rules/frontend-design.md`'s "reuse tokens" pravidlo).
+  Overené naživo (Playwright, throwaway skript proti lokálnemu dev serveru
+  s prepichnutým `window.fetch` na `/api/upozornenia/next-event` —
+  `.next-calendar-event-card`/-row sa dá takto rendrovať bez reálneho
+  `GOOGLE_CALENDAR_ICS_URL`): `getComputedStyle().fontSize` 12px pred,
+  13px po. Pri KAŽDOM ĎALŠOM "zväčši/zmenši písmo o N px" tickete v tejto
+  appke: NAJPRV skontroluj, či dva susedné `--fs-text-*` tokeny (`app.css`
+  §1) už nie sú presne N px od seba, než zavedieš `font-size: Npx`/nový
+  token — nie je to zaručené (napr. `-sm`→`-base` je len 0.75px), ale keď
+  sedí, je to najlacnejšia a najkonzistentnejšia oprava.

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -807,7 +807,10 @@ tr:last-child td {
 }
 .next-calendar-event-row {
   margin: 0;
-  font-size: var(--fs-text-xs);
+  /* issue 520: Štěpán má problém text prečítať — o 1px väčšie písmo.
+     --fs-text-sm (13px) je presne --fs-text-xs (12px) + 1px, existujúci
+     token, žiadna nová hodnota (`.claude/rules/frontend-design.md`). */
+  font-size: var(--fs-text-sm);
   line-height: 1.2;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.301",
+  "version": "0.3.0-dev.302",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.302",
+  "version": "0.3.0-dev.303",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Kalendárové upozornenie na nástenke: písmo zväčšené o 1px (12px → 13px, existujúci token --fs-text-sm) — issue 520 (zadanie Štěpán, Discord Develop-ÚLOHY 1543233727113601064). Ticket 520 ostáva otvorený do živého overenia po nasadení; zavrie sa ručne.

Dev CI: run 33253149619 zelený (attempt 2 — attempt 1 padol na 3 e2e testoch nesúvisiacich so zmenou; tracked ako samostatný bug ticket o izolácii e2e dát).
