### PR TITLE
E2e determinizmus pod paralelnymi workermi (issue 521)

### DIFF
--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -250,3 +250,21 @@ paths:
   UPROSTRED práce: over `git log --oneline A..B` NAJPRV (mal by ukázať LEN
   commity tohto tiketu), a ak zoznam obsahuje cudzie SHA, posuň `A` na
   merge commit samotný.
+- **Cielený lokálny e2e beh na `forestshop-dev` môže zlyhať na
+  `http://127.0.0.1:3000/api/version is already used` — port 3000 na tomto
+  ZDIEĽANOM boxe drží CUDZÍ (nie-forestshop) proces, nie appka (issue 521;
+  prod appka je v kontajneri, publikuje 8901→3000, nie host:3000).** Cudzí
+  proces sa NEZABÍJA (`no-destructive-remote-actions.md`). `playwright.config.ts`
+  má porty 3000 (API) a 5173 (vite) NATVRDO. API port je env-prepínateľný
+  (`env.PORT`, default 3000), ALE **vite proxy cieľ je v `vite.config.ts`
+  NATVRDO (`proxy: { "/api": "http://127.0.0.1:3000" }`)**, takže presun API
+  portu vyžaduje aj DOČASNÚ zmenu `vite.config.ts`. Postup (overené #521):
+  DOČASNE (necommitované) `sed -i 's|3000|3001|'` v `vite.config.ts` (proxy)
+  + v `playwright.config.ts` (webServer `url` + do `env` pridaj `PORT: "3001"`),
+  spusti proti VLASTNEJ izolovanej pg (recept vyššie, issue 403), potom
+  `git checkout -- apps/web/vite.config.ts apps/web/playwright.config.ts`
+  (revert PRED akýmkoľvek `git add`). Vite na 5173 ostáva (býva voľný — over
+  `ss -ltn`). Cielené spustenie LEN vybraných spec-ov: `DATABASE_URL=...
+  pnpm --filter @forestshop/web exec playwright test tests/e2e/<a>.spec.ts
+  tests/e2e/<b>.spec.ts` (`exec` + priame cesty, nie `e2e --`, ktoré spustí
+  všetko — `.claude/rules/testing.md`).

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -870,3 +870,22 @@ paths:
   badge `nav-badge-ulohy` už dnes správne overuje len `/^\d+$/`, nie presné
   číslo — zdieľaný počet naprieč účtami). Pri prevode akéhokoľvek ďalšieho
   per-user zoznamu na zdieľaný over toto ako prvé.
+- **Na obrazovke „Na objednanie" je predajňový (floor) riadok súbežného spec-u
+  FLOOR-MUTOVATEĽNÝ NA DVOCH miestach, nielen v čipe — aj v `orders-summary`
+  „N z M" (issue 521).** `OrdersToolbar.tsx` pridáva floor KUSY do total AJ
+  remaining súhrnu (`baseSummary` na l. 36 je iba order riadky, ale `summary` na
+  l. 39 = `baseSummary + floorTotalQty/floorRemainingQty`), a floor riadok padne
+  do skupiny podľa `effectiveSupplier` pripnutého produktu (E2E-PREDAJNA-1/2
+  nemajú `supplier` → „(bez dodávateľa)"). Takže pod paralelnými workermi (CI
+  `workers: undefined`, keď `floor-orders-board`/`floor-notes` drží NEVYBAVENÝ
+  pripnutý zápis) sú NESTÁLE: čip „Všetci (N)", čip „(bez dodávateľa) (N)", a
+  `orders-summary` „ostáva vybaviť N z M" globálne aj po kliku na „(bez
+  dodávateľa)". **Trap:** regexnúť LEN čip a nechať súhrn exact len PRESUNIE flake
+  na súhrn (predtým padal čip PRVÝ a maskoval ho) — regexuj OBE. FLOOR-IMMUNE (a
+  teda smú ostať exact): per-dodávateľské čipy dodávateľov BEZ floor riadkov
+  (DODAVATEL-TEST-1/2), súhrn ZÚŽENÝ na taký čip (DODAVATEL-TEST-1: „0 z 2 · Čaká
+  sa 2"), Σ chip-y (`computeVariantTotals` nad `group.lines`), a ROZPIS
+  „Čaká sa"/„Nedostupné" (iba order riadky, do neho sa floor nemieša) — ten v
+  regexe súhrnu drž exact. Pri KAŽDEJ ďalšej e2e asercii nad orders boardom over,
+  či hodnota nesie floor kusy (čip N, súhrn total/remaining) — ak áno, je
+  floor-mutovateľná; exact drž len na skupine bez floor riadkov alebo na rozpise.

--- a/apps/web/src/components/MailLogSection.test.tsx
+++ b/apps/web/src/components/MailLogSection.test.tsx
@@ -142,6 +142,7 @@ it("zastaraná odpoveď staršieho filtra neprepíše prázdny výsledok najnov�
   });
   await act(async () => {
     deferreds[0]?.({ rows: [RIADOK, DUPLICITA], summary: SUHRN, period: "30" });
+    await Promise.resolve();
   });
   expect(screen.queryByTestId("mail-log-table")).not.toBeNull();
 
@@ -155,12 +156,14 @@ it("zastaraná odpoveď staršieho filtra neprepíše prázdny výsledok najnov�
   // Novší (status=failed) sa vráti PRVÝ → prázdny stav.
   await act(async () => {
     deferreds[2]?.({ rows: [], summary: SUHRN, period: "30" });
+    await Promise.resolve();
   });
   expect(screen.queryByTestId("mail-log-empty")).not.toBeNull();
 
   // Starší (zmena zdroja) sa vráti NESKÔR s riadkami — zastaraný, NESMIE prepísať.
   await act(async () => {
     deferreds[1]?.({ rows: [RIADOK, DUPLICITA], summary: SUHRN, period: "30" });
+    await Promise.resolve();
   });
   expect(screen.queryByTestId("mail-log-empty")).not.toBeNull();
   expect(screen.queryByTestId("mail-log-table")).toBeNull();

--- a/apps/web/src/components/MailLogSection.test.tsx
+++ b/apps/web/src/components/MailLogSection.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { MailLogSection } from "./MailLogSection.js";
 
@@ -118,6 +118,51 @@ it("zmena obdobia znovu načíta prehľad s tým obdobím", async () => {
 it("prázdny prehľad povie, že sa nič neposielalo — nie prázdnu tabuľku", async () => {
   renderSection([]);
   await screen.findByTestId("mail-log-empty");
+  expect(screen.queryByTestId("mail-log-table")).toBeNull();
+});
+
+// issue 521: dve rýchle zmeny filtra za sebou vystrelia DVA fetche naraz; keď
+// sa STARŠÍ (širší) fetch vráti AŽ PO novom (užšom, prázdnom), NESMIE prepísať
+// prázdny výsledok najnovšieho filtra. Rovnaký stale-response guard ako issues
+// 251/254/264. Bez guardu tabuľka „ožije" späť namiesto prázdneho stavu — presne
+// CI flake `mail-log.spec.ts:54` (`mail-log-empty` sa nikdy nevykreslí).
+it("zastaraná odpoveď staršieho filtra neprepíše prázdny výsledok najnovšieho (issue 521)", async () => {
+  const deferreds: Array<(value: unknown) => void> = [];
+  fetchMailLog.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        deferreds.push(resolve);
+      }),
+  );
+  render(<MailLogSection onSessionExpired={vi.fn()} />);
+
+  // Prvé (počiatočné) načítanie vráti riadky → tabuľka + filtre sa vykreslia.
+  await waitFor(() => {
+    expect(deferreds).toHaveLength(1);
+  });
+  await act(async () => {
+    deferreds[0]?.({ rows: [RIADOK, DUPLICITA], summary: SUHRN, period: "30" });
+  });
+  expect(screen.queryByTestId("mail-log-table")).not.toBeNull();
+
+  // Dve rýchle zmeny filtra za sebou → DVA fetche naraz v lete.
+  fireEvent.change(screen.getByTestId("mail-log-filter-source"), { target: { value: "order_reminder" } }); // starší → riadky
+  fireEvent.change(screen.getByTestId("mail-log-filter-status"), { target: { value: "failed" } }); // novší → prázdno
+  await waitFor(() => {
+    expect(deferreds).toHaveLength(3);
+  });
+
+  // Novší (status=failed) sa vráti PRVÝ → prázdny stav.
+  await act(async () => {
+    deferreds[2]?.({ rows: [], summary: SUHRN, period: "30" });
+  });
+  expect(screen.queryByTestId("mail-log-empty")).not.toBeNull();
+
+  // Starší (zmena zdroja) sa vráti NESKÔR s riadkami — zastaraný, NESMIE prepísať.
+  await act(async () => {
+    deferreds[1]?.({ rows: [RIADOK, DUPLICITA], summary: SUHRN, period: "30" });
+  });
+  expect(screen.queryByTestId("mail-log-empty")).not.toBeNull();
   expect(screen.queryByTestId("mail-log-table")).toBeNull();
 });
 

--- a/apps/web/src/components/MailLogSection.tsx
+++ b/apps/web/src/components/MailLogSection.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useState, type JSX } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState, type JSX } from "react";
 import { formatSkDateTime } from "../formatDate.js";
 import {
   fetchMailLog,
@@ -50,14 +50,24 @@ export function MailLogSection({ onSessionExpired }: { readonly onSessionExpired
   // rozbil hustú tabuľku), obsluha si ho vyžiada per riadok.
   const [expandedBodyIds, setExpandedBodyIds] = useState<ReadonlySet<string>>(new Set());
 
+  // issue 521: stale-response guard (rovnaký vzor ako `ThemeColorPicker`/
+  // `SupplierLinksSection`, issues 251/254/264). Dve rýchle zmeny filtra za
+  // sebou vystrelia dva fetche naraz; keď sa STARŠÍ vráti AŽ PO novom, jeho
+  // (už zastaraný) výsledok NESMIE prepísať to, čo najnovší filter zobrazil —
+  // inak sa napr. `mail-log-empty` (status=failed) prepíše späť na tabuľku.
+  const fetchSeqRef = useRef(0);
+
   const load = useCallback(() => {
+    const seq = ++fetchSeqRef.current;
     fetchMailLog({ source, status, period })
       .then((list) => {
+        if (fetchSeqRef.current !== seq) return; // novší filter už doletel — túto zastaranú odpoveď zahoď
         setData(list);
         setError("");
         setLoaded(true);
       })
       .catch((err: unknown) => {
+        if (fetchSeqRef.current !== seq) return;
         setLoaded(true);
         if (err instanceof MailLogUnauthorizedError) {
           onSessionExpired();

--- a/apps/web/tests/e2e/floor-orders-board.spec.ts
+++ b/apps/web/tests/e2e/floor-orders-board.spec.ts
@@ -49,10 +49,15 @@ test("predajňový produkt sa objaví v Na objednanie, dá sa objednať, zápis 
   // 🛍️ odkaz na mieste čísla objednávky vedie na zápis v „Objednávky predajňa".
   await expect(page.getByTestId(`floor-order-link-${noteId}-E2E-PREDAJNA-1`)).toHaveAttribute("href", "?tab=floor-orders");
 
-  // Označiť predajňový riadok ako objednaný.
+  // Označiť predajňový riadok ako objednaný. issue 521: `.click()` + neskoršie
+  // `expect().toBeChecked()`, NIKDY `.check()` — checkboxov `onChange` robí ASYNC
+  // serverový zápis a `.check()` si stav overí OKAMŽITE po kliku, takže pod
+  // 2-worker CI záťažou prehrá závod s optimistickým update-om ("Clicking the
+  // checkbox did not change its state"). Zdokumentovaný vzor `.claude/rules/testing.md`
+  // (issue 60) — `toBeChecked()` nižšie auto-retryuje, kým sa zápis potvrdí.
   const checkbox = page.getByTestId(`floor-ordered-checkbox-${noteId}-E2E-PREDAJNA-1`);
   await expect(checkbox).not.toBeChecked();
-  await checkbox.check();
+  await checkbox.click();
   await expect(checkbox).toBeChecked();
   await expect(boardRow).toHaveClass(/ordered/);
 

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -45,10 +45,23 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   // 5, "Všetci" 8, a súhrn dostal novú vetvu "Nedostupné 1".
   // issue 443: fixtúra pridala DRUHÚ nedostupnú objednávku "9099" (znova "40287"
   // bez dodávateľa) — aby "Nedostupné tovary" mala skupinu s 2 objednávkami pre
-  // súčtový odznak — takže "(bez dodávateľa)" má 6, "Všetci" 9 a "Nedostupné 2".
-  await expect(page.getByTestId("supplier-chip-all")).toHaveText("Všetci (9)");
+  // súčtový odznak — takže "(bez dodávateľa)" má 6 objednávkových riadkov,
+  // "Všetci" 9 a "Nedostupné 2".
+  // issue 521: čip "Všetci" a "(bez dodávateľa)" počítajú `objednávkové_riadky +
+  // predajňové (floor) riadky` (`OrdersToolbar.tsx`) — a súbežný spec
+  // (`floor-orders-board.spec`/`floor-notes.spec`) môže mať v CI (`workers:
+  // undefined`) v tom istom čase NEVYBAVENÝ floor_note s pripnutým E2E-PREDAJNA
+  // produktom (bez dodávateľa → padá do "(bez dodávateľa)"), čo tieto DVA počty
+  // prechodne o 1 zvýši. Preto sa asertuje len FORMÁT (regex), nie presné číslo
+  // (vzor issue 445/185 pre zdieľanú/súbežne-mutovateľnú hodnotu). PRESNÉ
+  // objednávkové počty ostávajú overené FLOOR-IMMUNE: DODAVATEL-TEST-1 (1) a
+  // DODAVATEL-TEST-2 (2) nižšie (floor riadky nikdy nepatria reálnemu
+  // dodávateľovi), a "(bez dodávateľa)" 6 cez `orders-summary` ("ostáva vybaviť
+  // 4 z 6", `summarizeOrderLines` počíta LEN objednávkové riadky).
+  await expect(page.getByTestId("supplier-chip-all")).toHaveText(/^Všetci \(\d+\)$/);
   await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-1")).toHaveText("DODAVATEL-TEST-1 (1)");
-  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText("(bez dodávateľa) (6)");
+  await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-2")).toHaveText("DODAVATEL-TEST-2 (2)");
+  await expect(page.getByTestId("supplier-chip-(bez dodávateľa)")).toHaveText(/^\(bez dodávateľa\) \(\d+\)$/);
 
   // issue 452: čipy dodávateľov idú ABECEDNE (case-insensitive, slovenské
   // locale), "Všetci" prvý, "(bez dodávateľa)" naposledy — over skutočné

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -92,9 +92,7 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   // issue 187: objednaná veľkosť musí byť na riadku VIDIEŤ — obsluha podľa
   // nej objednáva u dodávateľa. Fixtúrový variant "4859/46" má veľkosť "46"
   // (`sizeLabel` sa odvodzuje z časti kódu za lomkou, `map-row.ts`).
-  await expect(
-    page.getByTestId("supplier-DODAVATEL-TEST-1").locator(".ord-size"),
-  ).toHaveText("46");
+  await expect(page.getByTestId("supplier-DODAVATEL-TEST-1").locator(".ord-size")).toHaveText("46");
 
   // Klik na "(bez dodávateľa)" prepne filter na druhého dodávateľa.
   await page.getByTestId("supplier-chip-(bez dodávateľa)").click();

--- a/apps/web/tests/e2e/orders.spec.ts
+++ b/apps/web/tests/e2e/orders.spec.ts
@@ -53,11 +53,15 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   // undefined`) v tom istom čase NEVYBAVENÝ floor_note s pripnutým E2E-PREDAJNA
   // produktom (bez dodávateľa → padá do "(bez dodávateľa)"), čo tieto DVA počty
   // prechodne o 1 zvýši. Preto sa asertuje len FORMÁT (regex), nie presné číslo
-  // (vzor issue 445/185 pre zdieľanú/súbežne-mutovateľnú hodnotu). PRESNÉ
-  // objednávkové počty ostávajú overené FLOOR-IMMUNE: DODAVATEL-TEST-1 (1) a
-  // DODAVATEL-TEST-2 (2) nižšie (floor riadky nikdy nepatria reálnemu
-  // dodávateľovi), a "(bez dodávateľa)" 6 cez `orders-summary` ("ostáva vybaviť
-  // 4 z 6", `summarizeOrderLines` počíta LEN objednávkové riadky).
+  // (vzor issue 445/185 pre zdieľanú/súbežne-mutovateľnú hodnotu). POZOR: aj
+  // `orders-summary` "ostáva vybaviť N z M" nižšie SČÍTAVA floor KUSY do
+  // total/remaining (`OrdersToolbar.tsx:39`), takže je rovnako floor-mutovateľné
+  // a tiež sa regexuje. FLOOR-IMMUNE (a preto exact) ostáva: per-dodávateľské
+  // čipy DODAVATEL-TEST-1 (1) a DODAVATEL-TEST-2 (2) (floor riadky nikdy
+  // nepatria reálnemu dodávateľovi), súhrn zúžený na DODAVATEL-TEST-1
+  // ("0 z 2 · Čaká sa 2" — jeho skupina nemá floor riadky), a rozpis
+  // "Čaká sa"/"Nedostupné" (`OrdersToolbar.tsx:36` baseSummary = LEN order riadky,
+  // floor sa doň nemieša), ktorý v regexoch nižšie ostáva exact.
   await expect(page.getByTestId("supplier-chip-all")).toHaveText(/^Všetci \(\d+\)$/);
   await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-1")).toHaveText("DODAVATEL-TEST-1 (1)");
   await expect(page.getByTestId("supplier-chip-DODAVATEL-TEST-2")).toHaveText("DODAVATEL-TEST-2 (2)");
@@ -79,7 +83,10 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   // 278=1, 40287(9008) nedostupne=1, 40287(9099) nedostupne=1 (issue 443) →
   // total 13, z toho nevybavené (všetky okrem caka_sa aj nedostupne)
   // 1+3+2+1+1+1 = 9, "Čaká sa" 2 (caka_sa kus), "Nedostupné" 2.
-  await expect(summary).toHaveText("Ostáva vybaviť 9 z 13 · Čaká sa 2 · Nedostupné 2");
+  // issue 521: "N z M" je floor-mutovateľné (súbežný E2E-PREDAJNA floor riadok
+  // pridá svoje kusy do total aj remaining) → regex; "Čaká sa 2 · Nedostupné 2"
+  // (iba order riadky) ostáva exact.
+  await expect(summary).toHaveText(/^Ostáva vybaviť \d+ z \d+ · Čaká sa 2 · Nedostupné 2$/);
 
   // Klik na chip DODAVATEL-TEST-1 zúži zoznam len na jeho skupinu.
   await page.getByTestId("supplier-chip-DODAVATEL-TEST-1").click();
@@ -99,10 +106,12 @@ test("manažér filtruje podľa dodávateľa, vidí súhrn ostáva vybaviť a sk
   await expect(page.getByTestId("supplier-(bez dodávateľa)")).toBeVisible();
   await expect(page.getByTestId("supplier-DODAVATEL-TEST-1")).not.toBeVisible();
   // issue 176/443: dve 'nedostupne' objednávky "9008"+"9099" patria do "(bez
-  // dodávateľa)" (variant "40287" nemá dodávateľa) — celkový počet stúpne na
-  // 6, "Nedostupné 2", "ostáva vybaviť" ostáva 4 (nedostupné riadky sú už
-  // vybavené).
-  await expect(summary).toHaveText("(bez dodávateľa): ostáva vybaviť 4 z 6 · Nedostupné 2");
+  // dodávateľa)" (variant "40287" nemá dodávateľa) — celkový počet order riadkov
+  // je 6, "Nedostupné 2", "ostáva vybaviť" 4 (nedostupné riadky sú už vybavené).
+  // issue 521: "(bez dodávateľa)" je práve tá skupina, do ktorej padajú súbežné
+  // E2E-PREDAJNA floor riadky, takže "N z M" tu je floor-mutovateľné → regex;
+  // "Nedostupné 2" (iba order riadky) ostáva exact.
+  await expect(summary).toHaveText(/^\(bez dodávateľa\): ostáva vybaviť \d+ z \d+ · Nedostupné 2$/);
 
   // Späť na "Všetci" — obe skupiny opäť viditeľné.
   await page.getByTestId("supplier-chip-all").click();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.303",
+  "version": "0.3.0-dev.305",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.303",
+  "version": "0.3.0-dev.304",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súhrn

Issue 521 (e2e determinizmus pod paralelnými workermi) — tri korenové príčiny nedeterministických e2e pádov opravené:

1. **floor-orders-board.spec.ts** — `locator.check()` závod s async zápisom stavu checkboxu; nahradené `.click()` + `await expect(...).toBeChecked()` (zavedený repo vzor).
2. **MailLogSection.tsx** — chýbal stale-response guard pri rýchlom prepínaní filtrov; pridaný `fetchSeqRef` (RED→GREEN unit test v MailLogSection.test.tsx, commity 5ef0866 → 4b14e57).
3. **orders.spec.ts** — count asserty („Všetci (N)", „(bez dodávateľa)", orders-summary „N z M") mutovateľné paralelným floor-orders specom; prepísané na regex tvar + fixture DODAVATEL-TEST-2; floor-imúnne skupiny ostávajú exact.

Adversarial review našiel a opravil 1 🔴 v tej istej vetve (orders-summary tiež floor-mutabilný, 4195db3). Cross-cutting návrh zdieľaného fetchSeqRef hooku vyčlenený ako issue 523.

Verzia: 0.3.0-dev.305.

Issue 521 ostáva otvorené — zavrie sa ručne po nasadení a živom overení.

## Overenie

- Dev CI run 33257037111 (255e2c7): completed success — e2e zelené na prvý pokus pod 2 paralelnými workermi.
- Playbook aktualizovaný: `.claude/rules/testing.md` + `.claude/rules/local-dev.md`.
