### PR TITLE
Zdielany useStaleResponseGuard hook (issue 523)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1530,3 +1530,26 @@ paths:
   accessible name — `getByRole` kliky s NEexact menom v e2e ostávajú bezpečné,
   exact-name kliky by sa rozbili. Pri pridávaní badge na existujúci tab netreba
   meniť nav counts logiku, len over e2e selektory tabu.
+- **Zdieľaný "stale-response guard" (ochrana pred prepísaním novšieho výsledku
+  ZASTARANOU odpoveďou staršieho fetchu — "latest ref" trieda vyššie, issue
+  151/251/254/264) je od issue 523 hook `apps/web/src/useStaleResponseGuard.ts`
+  — KAŽDÝ ĎALŠÍ komponent s filter/parametrom-riadeným fetchom ho MÁ POUŽIŤ,
+  nie znova vynachádzať inline `useRef(0)` + `const seq = ++ref.current` +
+  `if (seq !== ref.current) return` vzor** (rovnaká "použi zdieľaný mechanizmus,
+  nevynachádzaj" disciplína ako `useLoadMore.ts` pre stránkovanie). API:
+  `guard.begin()` (nový fetch → vráti seq, znehodnotí staršie prebiehajúce),
+  `guard.isLatest(seq)` (odpoveď sa smie uplatniť — použiteľné aj v `.then`,
+  `.catch`, `.finally` AJ vo vnorenom reťazci ako `UpozorneniaSection`'s
+  classify dopyt), `guard.cancel()` (zahoď prebiehajúci fetch pri zavretí
+  dialógu/panela, bez začatia nového — napr. `useCustomerContactMail.close()`,
+  `PairingReviewCard.closePanel()`). **Komponent s DVOMA nezávislými fetchmi
+  zavolá hook DVAKRÁT** (dva samostatné seq čítače — `SearchSection` search+detail,
+  `PairingSearchFixTab` search+item). Metódy sú `useMemo([])`-STABILNÉ (nad
+  `useRef`), takže sa nemusia dávať do `useCallback`/`useEffect` dependency polí
+  a nikdy nerozbijú memoizáciu volajúceho (repo nemá `react-hooks/exhaustive-deps`,
+  takže nestabilita by bola TICHÝ runtime bug). #523 zmigrovalo 16 inline výskytov
+  v 14 súboroch bez zmeny správania. **NEMIGRUJ ne-guard refy:** `useLoadMore`'s
+  paging `genRef` (vlastný hook), live-value `queryRef`/`stateRef`/`searchedQueryRef`
+  (synchronizované v render tele — iný účel), `mountedRef` (StrictMode unmount
+  guard, ostáva vedľa guardu v kombinovanom `if (!mountedRef.current || !guard.isLatest(seq))`),
+  `EmojiPickerButton`'s `rafRef`.

--- a/apps/web/src/components/CatalogPage.tsx
+++ b/apps/web/src/components/CatalogPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import type { Me } from "../api.js";
 import { formatSkDate, formatSkDateTime } from "../formatDate.js";
 import {
@@ -106,7 +107,7 @@ export function CatalogPage({
   // pomalšie (neindexovaný ILIKE nad celým katalógom), takže staršia, ale
   // širšia odpoveď môže dorásť neskôr než novšia, užšia. Bez tohto poradia
   // dokončenia by sa vykreslil zastaraný výsledok nad novým textom hľadania.
-  const searchSeq = useRef(0);
+  const guard = useStaleResponseGuard();
 
   // issue 254 (súrodenec issue 251's queryRef/stateRef nález, `.claude/
   // rules/frontend-design.md`): `runIngest`u's `.then()` (nižšie) volá
@@ -186,7 +187,7 @@ export function CatalogPage({
 
   const search = useCallback(
     (q: string, s: CatalogState) => {
-      const seq = (searchSeq.current += 1);
+      const seq = guard.begin();
       setSearchError("");
       searchedQueryRef.current = q;
       searchedStateRef.current = s;
@@ -194,14 +195,14 @@ export function CatalogPage({
       searchCatalogVariants({ q, state: s, page: 1 })
         .then((result) => {
           if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
-          if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
+          if (!guard.isLatest(seq)) return; // medzitým prišla novšia požiadavka
           setItems(result.items);
           setTotal(result.total);
           setSearchLoaded(true);
         })
         .catch((err: unknown) => {
           if (!mountedRef.current) return;
-          if (seq !== searchSeq.current) return;
+          if (!guard.isLatest(seq)) return;
           setSearchLoaded(true);
           if (err instanceof CatalogUnauthorizedError) {
             onSessionExpired();

--- a/apps/web/src/components/FloorNoteProductSearch.tsx
+++ b/apps/web/src/components/FloorNoteProductSearch.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState, type JSX } from "react";
+import { useCallback, useState, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import { globalSearch, SearchUnauthorizedError, type ProductSearchHit } from "../searchApi.js";
 
 // issue 410: pripínanie produktu na zápis "Objednávky predajne" — vyhľadáva
@@ -32,23 +33,22 @@ export function FloorNoteProductSearch({
   // môže mať dočasne prázdny), pri pripnutí sa `clampQuantity`-uje na ≥ 1.
   const [quantities, setQuantities] = useState<Record<string, string>>({});
 
-  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký vzor ako
-  // `SearchSection.tsx`'s `searchSeq`.
-  const searchSeq = useRef(0);
+  // Len najnovšia požiadavka smie zapísať výsledok (zdieľaný `useStaleResponseGuard`, issue 523).
+  const guard = useStaleResponseGuard();
 
   const search = useCallback(() => {
     const q = query.trim();
     if (q === "") return;
-    const seq = (searchSeq.current += 1);
+    const seq = guard.begin();
     setError("");
     globalSearch(q)
       .then((r) => {
-        if (seq !== searchSeq.current) return;
+        if (!guard.isLatest(seq)) return;
         setResult(r.products);
         setSearched(true);
       })
       .catch((err: unknown) => {
-        if (seq !== searchSeq.current) return;
+        if (!guard.isLatest(seq)) return;
         setSearched(true);
         if (err instanceof SearchUnauthorizedError) {
           onSessionExpired();

--- a/apps/web/src/components/MailLogSection.tsx
+++ b/apps/web/src/components/MailLogSection.tsx
@@ -1,5 +1,6 @@
-import { Fragment, useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { Fragment, useCallback, useEffect, useState, type JSX } from "react";
 import { formatSkDateTime } from "../formatDate.js";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import {
   fetchMailLog,
   MailLogUnauthorizedError,
@@ -50,24 +51,24 @@ export function MailLogSection({ onSessionExpired }: { readonly onSessionExpired
   // rozbil hustú tabuľku), obsluha si ho vyžiada per riadok.
   const [expandedBodyIds, setExpandedBodyIds] = useState<ReadonlySet<string>>(new Set());
 
-  // issue 521: stale-response guard (rovnaký vzor ako `ThemeColorPicker`/
-  // `SupplierLinksSection`, issues 251/254/264). Dve rýchle zmeny filtra za
+  // issue 521/523: stale-response guard cez zdieľaný `useStaleResponseGuard`
+  // (issues 251/254/264). Dve rýchle zmeny filtra za
   // sebou vystrelia dva fetche naraz; keď sa STARŠÍ vráti AŽ PO novom, jeho
   // (už zastaraný) výsledok NESMIE prepísať to, čo najnovší filter zobrazil —
   // inak sa napr. `mail-log-empty` (status=failed) prepíše späť na tabuľku.
-  const fetchSeqRef = useRef(0);
+  const guard = useStaleResponseGuard();
 
   const load = useCallback(() => {
-    const seq = ++fetchSeqRef.current;
+    const seq = guard.begin();
     fetchMailLog({ source, status, period })
       .then((list) => {
-        if (fetchSeqRef.current !== seq) return; // novší filter už doletel — túto zastaranú odpoveď zahoď
+        if (!guard.isLatest(seq)) return; // novší filter už doletel — túto zastaranú odpoveď zahoď
         setData(list);
         setError("");
         setLoaded(true);
       })
       .catch((err: unknown) => {
-        if (fetchSeqRef.current !== seq) return;
+        if (!guard.isLatest(seq)) return;
         setLoaded(true);
         if (err instanceof MailLogUnauthorizedError) {
           onSessionExpired();

--- a/apps/web/src/components/OrderSearchPanel.tsx
+++ b/apps/web/src/components/OrderSearchPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useCallback, useState, type SyntheticEvent, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import { globalSearch, SearchUnauthorizedError, type OrderSearchHit } from "../searchApi.js";
 
 // issue 289: "Eshop → Vyhľadať" — druhé, NEZÁVISLÉ pole "Objednávka" (vlastný
@@ -21,22 +22,21 @@ export function OrderSearchPanel({
   const [searched, setSearched] = useState(false);
   const [searchError, setSearchError] = useState("");
 
-  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký vzor ako
-  // `SearchSection.tsx`'s `searchSeq`.
-  const searchSeq = useRef(0);
+  // Len najnovšia požiadavka smie zapísať výsledok (zdieľaný `useStaleResponseGuard`, issue 523).
+  const guard = useStaleResponseGuard();
 
   const search = useCallback(
     (q: string) => {
-      const seq = (searchSeq.current += 1);
+      const seq = guard.begin();
       setSearchError("");
       globalSearch(q)
         .then((r) => {
-          if (seq !== searchSeq.current) return;
+          if (!guard.isLatest(seq)) return;
           setResult(r.orders);
           setSearched(true);
         })
         .catch((err: unknown) => {
-          if (seq !== searchSeq.current) return;
+          if (!guard.isLatest(seq)) return;
           setSearched(true);
           if (err instanceof SearchUnauthorizedError) {
             onSessionExpired();

--- a/apps/web/src/components/PairingReviewCard.tsx
+++ b/apps/web/src/components/PairingReviewCard.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import type { Me } from "../api.js";
 import { validateSupplierLinkUrl } from "../ordersApi.js";
 import {
@@ -125,7 +126,7 @@ export function PairingReviewCard({
 
   // "Latest ref" vzor (`.claude/rules/frontend-design.md`) — panel sa môže
   // zavrieť/znovu otvoriť skôr, než dobehne pôvodný `fetchPairingCandidates`.
-  const openSeq = useRef(0);
+  const guard = useStaleResponseGuard();
 
   // issue 398/401 review nález: panel sa ukazuje AJ AUTOMATICKY (bez kliku na
   // "vyber url"), keď karta nemá kandidáta vôbec — pred touto opravou sa v
@@ -136,16 +137,16 @@ export function PairingReviewCard({
   // rules/pairing-search.md`'s E5 sekcia). issue 401 tento stav sprístupnilo
   // OVEĽA ČASTEJŠIE (každý produkt bez adaptéra ho má), preto oprava patrí sem.
   const loadCandidates = useCallback(() => {
-    const seq = (openSeq.current += 1);
+    const seq = guard.begin();
     setCandidatesError("");
     setCandidates(null);
     fetchPairingCandidates(item.productKey)
       .then((result) => {
-        if (seq !== openSeq.current) return;
+        if (!guard.isLatest(seq)) return;
         setCandidates(result);
       })
       .catch((err: unknown) => {
-        if (seq !== openSeq.current) return;
+        if (!guard.isLatest(seq)) return;
         if (err instanceof PairingReviewUnauthorizedError) {
           onSessionExpired();
           return;
@@ -189,7 +190,7 @@ export function PairingReviewCard({
   }, [autoShowsPanel, loadCandidates]);
 
   const closePanel = useCallback(() => {
-    openSeq.current += 1; // zahodí prípadnú ešte-bežiacu odpoveď na kandidátov
+    guard.cancel(); // zahodí prípadnú ešte-bežiacu odpoveď na kandidátov
     setPanelOpen(false);
     setActionError("");
   }, []);

--- a/apps/web/src/components/PairingReviewSection.tsx
+++ b/apps/web/src/components/PairingReviewSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useEffect, useRef, useState, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import type { Me } from "../api.js";
 import {
   PAGE_SIZE,
@@ -83,7 +84,7 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
   // počíta a vetví AŽ v návratovom JSX, nikdy skorším `return`om).
   const [activeTab, setActiveTab] = useState<"prehlad" | "hladat">("prehlad");
 
-  const searchSeq = useRef(0);
+  const guard = useStaleResponseGuard();
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -110,13 +111,13 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
   const loadedFilterRef = useRef(filter);
 
   const load = useCallback((f: PairingReviewFilter) => {
-    const seq = (searchSeq.current += 1);
+    const seq = guard.begin();
     setError("");
     loadedFilterRef.current = f;
     loadMoreState.reset();
     searchPairingReview({ filter: f, page: 1 })
       .then((result) => {
-        if (!mountedRef.current || seq !== searchSeq.current) return;
+        if (!mountedRef.current || !guard.isLatest(seq)) return;
         setItems(result.items);
         setTotal(result.total);
         setGatheredTotal(result.gatheredTotal);
@@ -125,7 +126,7 @@ export function PairingReviewSection({ role, onSessionExpired }: { readonly role
         setLoaded(true);
       })
       .catch((err: unknown) => {
-        if (!mountedRef.current || seq !== searchSeq.current) return;
+        if (!mountedRef.current || !guard.isLatest(seq)) return;
         setLoaded(true);
         if (err instanceof PairingReviewUnauthorizedError) {
           onSessionExpired();

--- a/apps/web/src/components/PairingReviewSplitPanel.tsx
+++ b/apps/web/src/components/PairingReviewSplitPanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import {
   fetchPairingVariantLinks,
   PairingReviewUnauthorizedError,
@@ -153,17 +154,17 @@ export function PairingReviewSplitPanel({
   const [variants, setVariants] = useState<readonly PairingVariantLink[] | null>(null);
   const [variantsError, setVariantsError] = useState("");
   const [busyRowCodes, setBusyRowCodes] = useState<ReadonlySet<string>>(new Set());
-  const loadSeq = useRef(0);
+  const guard = useStaleResponseGuard();
 
   useEffect(() => {
-    const seq = (loadSeq.current += 1);
+    const seq = guard.begin();
     fetchPairingVariantLinks(item.productKey)
       .then((result) => {
-        if (seq !== loadSeq.current) return;
+        if (!guard.isLatest(seq)) return;
         setVariants(result);
       })
       .catch((err: unknown) => {
-        if (seq !== loadSeq.current) return;
+        if (!guard.isLatest(seq)) return;
         if (err instanceof PairingReviewUnauthorizedError) {
           onSessionExpired();
           return;

--- a/apps/web/src/components/PairingSearchFixTab.tsx
+++ b/apps/web/src/components/PairingSearchFixTab.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useCallback, useState, type SyntheticEvent, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import type { Me } from "../api.js";
 import { fetchPairingReviewItem, PairingReviewUnauthorizedError, type PairingReviewItem } from "../pairingReviewApi.js";
 import { globalSearch, SearchUnauthorizedError, type ProductSearchHit } from "../searchApi.js";
@@ -45,26 +46,26 @@ export function PairingSearchFixTab({
   const [hits, setHits] = useState<readonly ProductSearchHit[]>([]);
   const [searched, setSearched] = useState(false);
   const [searchError, setSearchError] = useState("");
-  const searchSeq = useRef(0);
+  const searchGuard = useStaleResponseGuard();
 
   const [selectedProductKey, setSelectedProductKey] = useState<string | null>(null);
   const [item, setItem] = useState<PairingReviewItem | null>(null);
   const [itemLoaded, setItemLoaded] = useState(false);
   const [itemError, setItemError] = useState("");
-  const itemSeq = useRef(0);
+  const itemGuard = useStaleResponseGuard();
 
   const search = useCallback(
     (q: string) => {
-      const seq = (searchSeq.current += 1);
+      const seq = searchGuard.begin();
       setSearchError("");
       globalSearch(q)
         .then((r) => {
-          if (seq !== searchSeq.current) return;
+          if (!searchGuard.isLatest(seq)) return;
           setHits(dedupeByProductKey(r.products));
           setSearched(true);
         })
         .catch((err: unknown) => {
-          if (seq !== searchSeq.current) return;
+          if (!searchGuard.isLatest(seq)) return;
           setSearched(true);
           if (err instanceof SearchUnauthorizedError) {
             onSessionExpired();
@@ -88,15 +89,15 @@ export function PairingSearchFixTab({
       setItem(null);
       setItemLoaded(false);
       setItemError("");
-      const seq = (itemSeq.current += 1);
+      const seq = itemGuard.begin();
       fetchPairingReviewItem(productKey)
         .then((result) => {
-          if (seq !== itemSeq.current) return;
+          if (!itemGuard.isLatest(seq)) return;
           setItem(result);
           setItemLoaded(true);
         })
         .catch((err: unknown) => {
-          if (seq !== itemSeq.current) return;
+          if (!itemGuard.isLatest(seq)) return;
           setItemLoaded(true);
           if (err instanceof PairingReviewUnauthorizedError) {
             onSessionExpired();

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import type { Me } from "../api.js";
 import {
   confirmPairing,
@@ -58,10 +59,10 @@ export function PairingSection({
   const [manuallyOpenedGroups, setManuallyOpenedGroups] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState("");
 
-  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký dôvod ako
-  // `CatalogPage`'s `searchSeq` (neindexovaný ILIKE nad celým katalógom môže
-  // staršiu, širšiu odpoveď doručiť neskôr než novšiu, užšiu).
-  const searchSeq = useRef(0);
+  // Len najnovšia požiadavka smie zapísať výsledok (zdieľaný `useStaleResponseGuard`,
+  // issue 523) — neindexovaný ILIKE nad celým katalógom môže staršiu, širšiu
+  // odpoveď doručiť neskôr než novšiu, užšiu.
+  const guard = useStaleResponseGuard();
 
   // issue 255 (súrodenec issue 251's finding 3 — tento súbor je HIDDEN_TABS
   // komponent, `nav.ts`, odmountuje sa pri prepnutí záložky): rovnaký vzor
@@ -98,7 +99,7 @@ export function PairingSection({
 
   const search = useCallback(
     (q: string, s: PairingState) => {
-      const seq = (searchSeq.current += 1);
+      const seq = guard.begin();
       setSearchError("");
       searchedQueryRef.current = q;
       searchedStateRef.current = s;
@@ -106,14 +107,14 @@ export function PairingSection({
       searchPairings({ q, state: s, page: 1 })
         .then((result) => {
           if (!mountedRef.current) return; // odmountované skôr, než odpoveď doletela
-          if (seq !== searchSeq.current) return; // medzitým prišla novšia požiadavka
+          if (!guard.isLatest(seq)) return; // medzitým prišla novšia požiadavka
           setItems(result.items);
           setTotal(result.total);
           setSearchLoaded(true);
         })
         .catch((err: unknown) => {
           if (!mountedRef.current) return;
-          if (seq !== searchSeq.current) return;
+          if (!guard.isLatest(seq)) return;
           setSearchLoaded(true);
           if (err instanceof PairingUnauthorizedError) {
             onSessionExpired();

--- a/apps/web/src/components/PairingSection.tsx
+++ b/apps/web/src/components/PairingSection.tsx
@@ -154,7 +154,7 @@ export function PairingSection({
   // (typicky v okamihu kliknutia). Ak sa medzitým (kým čaká na serverovú
   // odpoveď) zmení filter/dopyt, `refetch()` volaný z neskoro doručeného
   // `.then()` by aj tak zavolal `search` so STARÝMI hodnotami — a keďže
-  // `searchSeq` prideľuje poradové číslo pri ZAVOLANÍ (nie pri odpovedi),
+  // `guard.begin()` (`useStaleResponseGuard`) prideľuje poradové číslo pri ZAVOLANÍ (nie pri odpovedi),
   // takýto neskorý-no-zastaraný refetch dostane VYŠŠIE číslo než medzitým
   // spustené korektné vyhľadanie a jeho výsledok by ho ticho prepísal.
   // `queryRef`/`stateRef` sa preto syncujú PRIAMO V TELE komponentu (počas

--- a/apps/web/src/components/SearchSection.tsx
+++ b/apps/web/src/components/SearchSection.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState, type SyntheticEvent, type JSX } from "react";
+import { useCallback, useState, type SyntheticEvent, type JSX } from "react";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import type { Me } from "../api.js";
 import { formatSkDateTime } from "../formatDate.js";
 import { validateSupplierLinkUrl } from "../ordersApi.js";
@@ -83,23 +84,23 @@ export function SearchSection({
   const [actionError, setActionError] = useState("");
   const [busy, setBusy] = useState(false);
 
-  // Len najnovšia požiadavka smie zapísať výsledok — rovnaký vzor ako
-  // `CatalogPage.tsx`/`SupplierLinksSection.tsx`'s `searchSeq`.
-  const searchSeq = useRef(0);
-  const detailSeq = useRef(0);
+  // Len najnovšia požiadavka smie zapísať výsledok (zdieľaný `useStaleResponseGuard`,
+  // issue 523) — dva nezávislé fetche (vyhľadávanie + detail), teda dva guardy.
+  const searchGuard = useStaleResponseGuard();
+  const detailGuard = useStaleResponseGuard();
 
   const search = useCallback(
     (q: string) => {
-      const seq = (searchSeq.current += 1);
+      const seq = searchGuard.begin();
       setSearchError("");
       globalSearch(q)
         .then((r) => {
-          if (seq !== searchSeq.current) return;
+          if (!searchGuard.isLatest(seq)) return;
           setResult(r.products);
           setSearched(true);
         })
         .catch((err: unknown) => {
-          if (seq !== searchSeq.current) return;
+          if (!searchGuard.isLatest(seq)) return;
           setSearched(true);
           if (err instanceof SearchUnauthorizedError) {
             onSessionExpired();
@@ -125,15 +126,15 @@ export function SearchSection({
       setDetailError("");
       setEditingLink(false);
       setActionError("");
-      const seq = (detailSeq.current += 1);
+      const seq = detailGuard.begin();
       fetchProductDetail(productKey)
         .then((d) => {
-          if (seq !== detailSeq.current) return;
+          if (!detailGuard.isLatest(seq)) return;
           setDetail(d);
           setDetailLoaded(true);
         })
         .catch((err: unknown) => {
-          if (seq !== detailSeq.current) return;
+          if (!detailGuard.isLatest(seq)) return;
           setDetailLoaded(true);
           if (err instanceof SearchUnauthorizedError) {
             onSessionExpired();

--- a/apps/web/src/components/ThemeColorPicker.tsx
+++ b/apps/web/src/components/ThemeColorPicker.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type JSX, type MouseEvent } f
 import type { Me } from "../api.js";
 import { applyThemeColors } from "../applyThemeColors.js";
 import { fetchThemeColors, resetThemeColors, saveThemeColors, ThemeColorsUnauthorizedError, type ThemeColor } from "../themeColorsApi.js";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 
 // issue 264, majiteľ: "koliesko vpravo hore, vyskakovacie okno, naživo ako
 // bude ťahať farbu po palete tak sa mu to bude meniť na stránke". Viditeľné
@@ -84,7 +85,7 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
   // state with old values (same "latest wins" class of race as issue 151/251,
   // `.claude/rules/frontend-design.md`) — each `openPicker()` bumps this and
   // the `.then()` only applies if it is still the most recent request.
-  const fetchSeqRef = useRef(0);
+  const guard = useStaleResponseGuard();
 
   // Code review finding: closing (Escape/backdrop/Cancel) WHILE a save/reset
   // request is in flight reverted the live CSS preview to `baseline`
@@ -136,10 +137,10 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
     setDraft({});
     setBaseline({});
     setOpen(true);
-    const seq = ++fetchSeqRef.current;
+    const seq = guard.begin();
     fetchThemeColors()
       .then((list) => {
-        if (fetchSeqRef.current !== seq) return; // closed+reopened while this was in flight — a newer fetch already applied its own state
+        if (!guard.isLatest(seq)) return; // closed+reopened while this was in flight — a newer fetch already applied its own state
         setColors(list);
         const values = Object.fromEntries(list.map((c) => [c.key, c.value]));
         setDraft(values);
@@ -147,7 +148,7 @@ export function ThemeColorPicker({ role, onSessionExpired }: { readonly role: Me
         applyThemeColors(values);
       })
       .catch((err: unknown) => {
-        if (fetchSeqRef.current !== seq) return;
+        if (!guard.isLatest(seq)) return;
         if (err instanceof ThemeColorsUnauthorizedError) {
           onSessionExpired();
           return;

--- a/apps/web/src/components/UpozorneniaResolvedList.tsx
+++ b/apps/web/src/components/UpozorneniaResolvedList.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { useCallback, useEffect, useState, type JSX } from "react";
 import { formatSkDateTime } from "../formatDate.js";
 import { fetchResolvedUpozornenia, returnUpozornenieToOpen, UpozorneniaUnauthorizedError, type ResolvedUpozornenieRow } from "../upozorneniaApi.js";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 
 // issue 283 (majiteľ, komentár na tickete): záložka "Vybavené" na nástenke
 // Upozornenia — história vyriešených kariet + tlačidlo na vrátenie späť medzi
@@ -32,21 +33,21 @@ export function UpozorneniaResolvedList({
   const [rows, setRows] = useState<readonly ResolvedUpozornenieRow[] | null>(null);
   const [error, setError] = useState("");
   const [busyId, setBusyId] = useState("");
-  // Rovnaký "latest ref" princíp ako `UpozorneniaSection.tsx`'s `loadSeqRef`
-  // (issue 254/251/151, `.claude/rules/frontend-design.md`) — chráni pred
+  // Zdieľaný `useStaleResponseGuard` (issue 523; "latest ref" princíp,
+  // issue 254/251/151, `.claude/rules/frontend-design.md`) — chráni pred
   // zastaranou odpoveďou z PREDCHÁDZAJÚCEho `load()` volania (mount + refetch
   // po vrátení karty späť môžu bežať tesne po sebe).
-  const loadSeqRef = useRef(0);
+  const guard = useStaleResponseGuard();
 
   const load = useCallback(() => {
-    const seq = ++loadSeqRef.current;
+    const seq = guard.begin();
     fetchResolvedUpozornenia()
       .then((data) => {
-        if (loadSeqRef.current !== seq) return;
+        if (!guard.isLatest(seq)) return;
         setRows(data);
       })
       .catch((err: unknown) => {
-        if (loadSeqRef.current !== seq) return;
+        if (!guard.isLatest(seq)) return;
         if (err instanceof UpozorneniaUnauthorizedError) {
           onSessionExpired();
           return;

--- a/apps/web/src/components/UpozorneniaSection.tsx
+++ b/apps/web/src/components/UpozorneniaSection.tsx
@@ -17,6 +17,7 @@ import {
   UpozorneniaUnauthorizedError,
   type UpozornenieRow,
 } from "../upozorneniaApi.js";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 
 // issue 267: rovnaké dve role, ktoré appka všade inde vyžaduje na zápis
 // (`requireRole("admin", "manazer")`, `upozornenia-routes.ts`) — čítanie
@@ -70,22 +71,22 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
   // žiadnu poistku proti ZASTARANEJ odpovedi — presne tá istá trieda race,
   // akú `.claude/rules/frontend-design.md` rieši "latest ref" vzorom (issue
   // 151/251/264: mikrotaska z PREDCHÁDZAJÚCEHO `load()` volania môže
-  // doraziť AŽ PO novšom a prepísať jeho výsledok zastaraným). `loadSeqRef`
-  // sa inkrementuje na ZAČIATKU každého `load()` volania; oba `.then()` nižšie
-  // sa uplatnia len ak je stále najnovšie.
-  const loadSeqRef = useRef(0);
+  // doraziť AŽ PO novšom a prepísať jeho výsledok zastaraným). Zdieľaný
+  // `useStaleResponseGuard` (issue 523): `guard.begin()` na ZAČIATKU každého
+  // `load()` volania; oba `.then()` nižšie sa uplatnia len ak je stále najnovšie.
+  const guard = useStaleResponseGuard();
   // issue 440: emoji picker vkladá na pozíciu kurzora príslušného poľa formulára.
   const draftTitleRef = useRef<HTMLInputElement>(null);
   const draftDetailsRef = useRef<HTMLTextAreaElement>(null);
 
   const load = useCallback(() => {
-    const seq = ++loadSeqRef.current;
+    const seq = guard.begin();
     // issue 283 (Vybavené záložka nahradila checkbox "aj vybavené"): tento
     // zoznam už NIKDY nesmie ukázať vyriešenú kartu — `includeResolved` je
     // preto vždy `false`, nie ovládané žiadnym filtrom.
     fetchUpozornenia({ includeResolved: false, includePostponed })
       .then((data) => {
-        if (loadSeqRef.current !== seq) return;
+        if (!guard.isLatest(seq)) return;
         setRows(data);
         if (data.length > 0) return;
         // Zoznam je prázdny pod AKTUÁLNYMI (možno užšími) filtrami — treba
@@ -94,14 +95,14 @@ export function UpozorneniaSection({ role, onSessionExpired }: { readonly role: 
         // odložené).
         fetchUpozornenia({ includeResolved: true, includePostponed: true })
           .then((all) => {
-            if (loadSeqRef.current === seq) setEmptyMessage(classifyEmptyMessage(all));
+            if (guard.isLatest(seq)) setEmptyMessage(classifyEmptyMessage(all));
           })
           .catch(() => {
-            if (loadSeqRef.current === seq) setEmptyMessage("Žiadne upozornenia v tomto zobrazení.");
+            if (guard.isLatest(seq)) setEmptyMessage("Žiadne upozornenia v tomto zobrazení.");
           });
       })
       .catch((err: unknown) => {
-        if (loadSeqRef.current !== seq) return;
+        if (!guard.isLatest(seq)) return;
         if (err instanceof UpozorneniaUnauthorizedError) {
           onSessionExpired();
           return;

--- a/apps/web/src/useCustomerContactMail.ts
+++ b/apps/web/src/useCustomerContactMail.ts
@@ -5,6 +5,7 @@ import {
   sendCustomerContactMail,
   type CustomerContactPreview,
 } from "./ordersApi.js";
+import { useStaleResponseGuard } from "./useStaleResponseGuard.js";
 
 // issue 500/502: ručný e-mail zákazníkovi z riadku objednávky (@ tlačidlo).
 // Zdieľané JADRO okna náhľadu — používa ho „Na objednanie" (`OrdersSection`) AJ
@@ -38,27 +39,27 @@ export function useCustomerContactMail(onSessionExpired: () => void): CustomerCo
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const triggerRef = useRef<HTMLElement | null>(null);
-  // issue 500 (review): generation guard — keď obsluha klikne @ na riadku A a
-  // rýchlo potom na B, VYHRÁ najnovší klik, nikdy ten, čo dobehne posledný.
-  // Bez neho by okno mohlo ukázať ZLÚ objednávku (frontend-design.md „latest
-  // ref"/`fetchSeqRef` vzor, issue 251/264). Zavretie okno tiež bumpne, takže
-  // dobiehajúci náhľad po zavretí sa ignoruje.
-  const seqRef = useRef(0);
+  // issue 500/523 (review): stale-response guard cez zdieľaný `useStaleResponseGuard`
+  // — keď obsluha klikne @ na riadku A a rýchlo potom na B, VYHRÁ najnovší klik,
+  // nikdy ten, čo dobehne posledný. Bez neho by okno mohlo ukázať ZLÚ objednávku
+  // (frontend-design.md „latest ref" vzor, issue 251/264). `close()` volá
+  // `guard.cancel()`, takže dobiehajúci náhľad po zavretí sa ignoruje.
+  const guard = useStaleResponseGuard();
 
   const open = useCallback(
     (orderCode: string, trigger: HTMLElement | null) => {
-      const seq = ++seqRef.current;
+      const seq = guard.begin();
       triggerRef.current = trigger;
       setError("");
       setBusy(true);
       fetchCustomerContactPreview(orderCode)
         .then((preview) => {
-          if (seq !== seqRef.current) return;
+          if (!guard.isLatest(seq)) return;
           setPending({ orderCode, preview });
           setBody(preview.text);
         })
         .catch((err: unknown) => {
-          if (seq !== seqRef.current) return;
+          if (!guard.isLatest(seq)) return;
           if (err instanceof OrdersUnauthorizedError) {
             onSessionExpired();
             return;
@@ -66,7 +67,7 @@ export function useCustomerContactMail(onSessionExpired: () => void): CustomerCo
           setError(err instanceof Error ? err.message : "Náhľad e-mailu sa nepodarilo načítať.");
         })
         .finally(() => {
-          if (seq === seqRef.current) setBusy(false);
+          if (guard.isLatest(seq)) setBusy(false);
         });
     },
     [onSessionExpired],
@@ -98,7 +99,7 @@ export function useCustomerContactMail(onSessionExpired: () => void): CustomerCo
   const close = useCallback(() => {
     // Zruší prípadný ešte bežiaci náhľad (generation guard) a VYČISTÍ chybu,
     // aby po zavretí okna neostala visieť ako sekciová `role="alert"` hláška.
-    seqRef.current++;
+    guard.cancel();
     setPending(null);
     setError("");
   }, []);

--- a/apps/web/src/useStaleResponseGuard.test.ts
+++ b/apps/web/src/useStaleResponseGuard.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from "@testing-library/react";
+import { expect, it } from "vitest";
+import { useStaleResponseGuard } from "./useStaleResponseGuard.js";
+
+it("begin() vráti rastúce sekvenčné čísla", () => {
+  const { result } = renderHook(() => useStaleResponseGuard());
+  expect(result.current.begin()).toBe(1);
+  expect(result.current.begin()).toBe(2);
+  expect(result.current.begin()).toBe(3);
+});
+
+it("isLatest je true pre NAJNOVŠÍ begin() a false pre starší (stale vetva)", () => {
+  const { result } = renderHook(() => useStaleResponseGuard());
+  const stary = result.current.begin();
+  const novy = result.current.begin();
+
+  // Odpoveď na starší fetch doletí AŽ po novom → musí sa zahodiť.
+  expect(result.current.isLatest(stary)).toBe(false);
+  // Odpoveď na najnovší fetch sa smie uplatniť.
+  expect(result.current.isLatest(novy)).toBe(true);
+});
+
+it("jediný prebiehajúci fetch je latest, kým nezačne ďalší", () => {
+  const { result } = renderHook(() => useStaleResponseGuard());
+  const seq = result.current.begin();
+  expect(result.current.isLatest(seq)).toBe(true);
+});
+
+it("cancel() znehodnotí prebiehajúci fetch bez začatia nového", () => {
+  const { result } = renderHook(() => useStaleResponseGuard());
+  const seq = result.current.begin();
+  expect(result.current.isLatest(seq)).toBe(true);
+
+  // Napr. dialóg sa zavrel skôr, než odpoveď doletela — jej `.then()` sa
+  // po doručení musí zahodiť.
+  result.current.cancel();
+  expect(result.current.isLatest(seq)).toBe(false);
+
+  // Ďalší begin() po cancel-e pokračuje v číslovaní (žiadny reset na 0).
+  expect(result.current.begin()).toBe(3);
+});
+
+it("metódy sú STABILNÉ medzi rendermi (identita sa nemení)", () => {
+  const { result, rerender } = renderHook(() => useStaleResponseGuard());
+  const prve = result.current;
+  rerender();
+  expect(result.current).toBe(prve);
+  expect(result.current.begin).toBe(prve.begin);
+  expect(result.current.isLatest).toBe(prve.isLatest);
+  expect(result.current.cancel).toBe(prve.cancel);
+});

--- a/apps/web/src/useStaleResponseGuard.ts
+++ b/apps/web/src/useStaleResponseGuard.ts
@@ -1,0 +1,52 @@
+import { useMemo, useRef } from "react";
+
+// issue 523: zdieľaný "stale-response guard" — vyčlenený z ~16 inline kópií
+// naprieč komponentmi (`fetchSeqRef`/`loadSeqRef`/`searchSeq`/… vzor,
+// `.claude/rules/frontend-design.md` issue 151/251/254/264). Chráni pred
+// pretekmi, keď dve rýchle zmeny filtra/dopytu vystrelia dva fetche naraz:
+// keď sa STARŠÍ vráti AŽ PO novom, jeho (už zastaraná) odpoveď NESMIE
+// prepísať to, čo najnovší dopyt zobrazil.
+//
+// Použitie:
+//   const guard = useStaleResponseGuard();
+//   const load = useCallback(() => {
+//     const seq = guard.begin();
+//     fetchX(...)
+//       .then((r) => { if (!guard.isLatest(seq)) return; /* aplikuj r */ })
+//       .catch((e) => { if (!guard.isLatest(seq)) return; /* obsluž e */ });
+//   }, [...]);
+//
+// `cancel()` je pre dialóg/panel, ktorý sa smie zavrieť PRED doletením
+// odpovede — zahodí prebiehajúci fetch bez začatia nového.
+//
+// Komponent s DVOMA nezávislými fetchmi (napr. vyhľadávanie + detail) zavolá
+// hook DVAKRÁT — každý guard má vlastný sekvenčný čítač.
+export interface StaleResponseGuard {
+  /**
+   * Začni nový fetch: zvýš sekvenčné číslo, vráť ho a zároveň znehodnoť každý
+   * skôr začatý (ešte prebiehajúci) fetch tohto guardu.
+   */
+  readonly begin: () => number;
+  /** `true` práve vtedy, keď `seq` je stále NAJNOVŠÍ začatý fetch (jeho odpoveď sa smie uplatniť). */
+  readonly isLatest: (seq: number) => boolean;
+  /** Znehodnoť každý prebiehajúci fetch bez začatia nového (napr. pri zavretí dialógu). */
+  readonly cancel: () => void;
+}
+
+export function useStaleResponseGuard(): StaleResponseGuard {
+  const seqRef = useRef(0);
+  // `useMemo([])` drží objekt AJ jeho metódy stabilné počas celej životnosti
+  // komponentu — inak by zmena ich identity pri každom rendere rozbila
+  // `useCallback` memoizáciu volajúcich (`.claude/rules/frontend-design.md`
+  // issue 147). `seqRef` je stabilné, takže closures nikdy nezastarajú.
+  return useMemo(
+    () => ({
+      begin: (): number => ++seqRef.current,
+      isLatest: (seq: number): boolean => seqRef.current === seq,
+      cancel: (): void => {
+        seqRef.current += 1;
+      },
+    }),
+    [],
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.305",
+  "version": "0.3.0-dev.306",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.306",
+  "version": "0.3.0-dev.307",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súhrn

Issue 523 (tech-debt z review issue 521): opakovaný inline `fetchSeqRef` stale-response guard vyčlenený do zdieľaného hooku `apps/web/src/useStaleResponseGuard.ts` (API begin/isLatest/cancel).

- 16 inline guardov v 14 súboroch zmigrovaných (MailLogSection, SearchSection, PairingSection, Upozornenia*, CatalogPage, …) — správanie nezmenené, sémantická ekvivalencia potvrdená adversarial review-om (0 🔴 0 🟡; 1 🔵 opravený v 8782bbe).
- Hook má vlastný unit test (latest + stale + cancel + stabilita); locknutý RED→GREEN test MailLogSection.test.tsx z issue 521 ostáva zelený bez úprav.
- Playbook: `.claude/rules/frontend-design.md` — hook je odteraz kanonický vzor pre filter/param-riadené fetche.

Verzia: 0.3.0-dev.307.

Issue 523 ostáva otvorené — zavrie sa ručne po nasadení a živom overení.

## Overenie

- Dev CI run 33261985704 (c7e0fcc): completed success — na prvý pokus.
- Lokálne gates (typecheck + lint + 756/756 unit testov): zelené.
