### PR TITLE
Restock: Predobjednávka sa prepína na Skladom (issue 526)

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -281,6 +281,20 @@ paths:
   KAŽDÝ ĎALŠÍ pokus "zjednodušiť" `ORDER BY` odkazom na alias z podobného
   agregátu: over PRIAMO integračným testom proti reálnej DB (nie len že
   `tsc`/`eslint` prejdú) — statická kontrola typov toto nezachytí.
+- **Drizzle `or(...conditions)` / `and(...conditions)` vráti `undefined`, keď je
+  pole podmienok PRÁZDNE — a `undefined` sa vnútri obklopujúceho `and(x,
+  undefined)` TICHO ZAHODÍ, takže dynamicky poskladaný `or(...pole)` nad
+  MOŽNO-prázdnym poľom FAILUJE OPEN (celá vetva zmizne).** Issue 526,
+  bezpečnostne-kritická: `and(eq(state,'sellable'), or(...MARKERS.map(...)))` by
+  pri prázdnom `MARKERS` skolaboval na holé `state='sellable'` (zapnutie VŠETKÉHO
+  predajného v „Vypredané → Skladom"). `tsc` to NEZACHYTÍ (drizzle typuje
+  `or(...)` ako `SQL | undefined`, čo je platný argument `and`-u). Fix pri KAŽDOM
+  dynamickom `or(...pole)`/`and(...pole)` v `WHERE`: buď zabezpeč NEPRÁZDNOSŤ na
+  úrovni TYPU (`readonly [T, ...T[]]` tuple na zdrojovom zozname), ALEBO daj
+  fail-safe default na mieste použitia — `or(...) ?? sql\`false\`` (žiadny match)
+  pre pozitívnu podmienku, `and(...) ?? sql\`true\`` pre reštriktívnu. Nikdy
+  nespoliehaj na to, že pole je „vždy neprázdne" — ak ho niekto raz vyprázdni,
+  chyba je tichá a v nebezpečnom smere.
 - **Nová `pgEnum` hodnota (`ALTER TYPE ... ADD VALUE`, napr. `mail_log_source`)
   je NA LOKÁLNEJ Postgres inštancii neviditeľná, kým nebeží `pnpm --filter
   @forestshop/api db:migrate` — integračné testy/`e2e-setup.ts` proti nej

--- a/.claude/rules/supplier-stock.md
+++ b/.claude/rules/supplier-stock.md
@@ -23,6 +23,35 @@ paths:
   `product_visibility = 'visible'` — bez nej by sa zapli. Každá ďalšia
   automatizácia, ktorá niečo ZAPÍNA, potrebuje tú istú podmienku; `state`
   sám nestačí.
+- **Predobjednávka je od issue 526 tiež vstupom do prepnutia, ale kotví sa na
+  `state='sellable'` + TEXTE, nie na novom stave.** Shoptet text „Predobjednávka"
+  necháva `deriveVariantState` na `sellable` (zákazník ho smie objednať), takže
+  katalóg / feed-cross-check / pairing / vyhľadávanie ho vidia presne ako
+  doteraz — vedome sa NEZAVIEDLA nová `variant_state` enum hodnota (bola by to
+  migrácia + owner-viditeľná prekvalifikácia naprieč všetkými konzumentmi
+  `state`, ktorú Štěpán nepýtal). `allRestockCandidates` (`restock/queries.ts`)
+  preto berie `state='out_of_stock' OR (state='sellable' AND
+  lower(availability_text) LIKE '%predobjedn%')`. Marker („predobjedn") žije
+  JEDINE v `availability.ts` (`PREORDER_MARKERS`, vedľa `OUT_OF_STOCK_MARKERS`),
+  odkiaľ ho `restock/queries.ts` importuje — SQL sa nikdy nerozíde s
+  interpretáciou textu. Kotva `state='sellable'` dáva ochrany zadarmo:
+  jednotlivo vypnutá predobjednávková veľkosť je už `discontinued` (`availability.ts`
+  kontroluje vypnutie PRED textom) a `detailOnly` predobjednávku vylúči existujúci
+  `product_visibility='visible'` filter — netreba nič duplikovať. Idempotencia
+  platí rovnako ako pri vypredaných: po prepnutí na „Skladom" je text „Skladom"
+  → LIKE nesedí → variant prestane byť kandidátom. **Feed-guard (issue 226) sa
+  na predobjednávku NEAPLIKUJE** (na rozdiel od vypredanej vetvy, kde feed
+  „in stock" je rozpor s naším `out_of_stock`): predobjednávka je `sellable`,
+  takže feed „in stock" je ZHODA (`compareStateToFeed`), nie rozpor — vylúčiť na
+  ňom kandidáta by ticho zahodilo predobjednávky, ktoré Shoptet vo feede hlási
+  ako „in stock" (naživo 31. 8. 2026 overené na produkte 15741: jeho
+  predobjednávkové varianty majú vo `google.xml` PRÁZDNU `<g:availability>`,
+  takže konkrétne tie prejdú aj so starým guardom — ale sémanticky je guard pre
+  predobjednávku zlý, preto je v `allRestockCandidates` zabalený IBA do
+  `out_of_stock` vetvy: `or(and(out_of_stock, feedNotInStock), and(sellable,
+  predobjednávka-text))`). `PREORDER_MARKERS` je NEPRÁZDNY tuple + `?? sql\`false\``
+  v query = fail-closed (prázdny zoznam nikdy nesmie zapnúť všetko predajné);
+  marker nesie slovenský („predobjedn") aj český („předobjedn") tvar.
 - **`supplier_stock.confirmed_at` je NIEČO INÉ než `checked_at` a
   automatizácia sa smie pozerať LEN naň.** `checked_at` je čas posledného
   POKUSU (aj neúspešného) a riadi preskakovanie čerstvých odkazov;

--- a/apps/api/src/modules/catalog/availability.ts
+++ b/apps/api/src/modules/catalog/availability.ts
@@ -23,6 +23,31 @@ const OUT_OF_STOCK_MARKERS: readonly string[] = [
   "neni skladem",
 ];
 
+// Shoptet text „Predobjednávka" — produkt, ktorý zákazník smie predobjednať,
+// ale u NÁS ešte nie je skladom. ZÁMERNE NIE JE `OUT_OF_STOCK_MARKERS`:
+// `deriveVariantState` ho necháva `sellable` (zákazník ho môže objednať),
+// takže katalóg / feed-cross-check / pairing / vyhľadávanie ho vidia presne
+// ako doteraz. Automatizácia „Vypredané → Skladom" (issue 526) ho však musí
+// sledovať rovnako ako vypredané: keď ho dodávateľ potvrdene má, prepnúť naň
+// „Skladom". Aby interpretácia tohto reťazca ostala v JEDNOM súbore (tu, vedľa
+// ostatných markerov) a nerozišla sa so SQL, `restock/queries.ts` importuje
+// tento zoznam a matchuje ho na `variant.availability_text` (LEN na `sellable`
+// riadkoch — vypnutý/detailOnly predobjednávkový variant je už `discontinued`
+// resp. mimo `visible`, takže sa kotvou `state='sellable'` + `visibility`
+// filtrom vylúči zadarmo). Marker je bez diakritiky (ASCII), preto match beží
+// nad `lower(...)` textom deterministicky, rovnako ako `OUT_OF_STOCK_MARKERS`.
+// Slovenský tvar „Predobjednávka" je overený v dátach (catalog.md); český
+// „Předobjednávka" (ř ≠ r) je INÝ reťazec a `LIKE '%predobjedn%'` ho nechytí —
+// pridaný defenzívne rovnakým precedensom ako `OUT_OF_STOCK_MARKERS`'s dvojica
+// „není/neni skladem" a Skladem/Skladom (tento obchod nesie aj české texty).
+// Marker nič ZLÉ zapnúť nemôže (zhoduje sa len s predobjednávkovým textom),
+// takže je to fail-closed doplnenie pokrytia, nie dohad meniaci správanie.
+// NEPRÁZDNY tuple: prázdny zoznam by cez `or(...[])=undefined` (drizzle) nechal
+// `restock/queries.ts`'s predobjednávkovú vetvu spadnúť na holé `state='sellable'`
+// (zapnutie VŠETKÉHO predajného) — typ to znemožní už pri kompilácii, plus tam
+// je `?? sql\`false\`` runtime poistka.
+export const PREORDER_MARKERS: readonly [string, ...string[]] = ["predobjedn", "předobjedn"];
+
 export interface AvailabilityInput {
   readonly stock: number;
   readonly inStockText: string;

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -7,6 +7,7 @@
 import { and, asc, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../../db/client.js";
 import { pairingDecisions, pairingVariantLinks, products, restockEvents, shopProductUrl, supplierStock, variants } from "../../db/schema.js";
+import { PREORDER_MARKERS } from "../catalog/availability.js";
 import { FEED_IN_STOCK } from "../catalog/feed-cross-check.js";
 import {
   CONFIRMATION_MAX_AGE_HOURS,
@@ -56,21 +57,26 @@ const NO_SUPPLIER_LABEL = "(bez dodávateľa)";
 
 /**
  * Kandidát musí spĺňať VŠETKO naraz:
- *  - náš stav je `out_of_stock` (vypredané) — už predajný variant sa
- *    neprepína, z čoho plynie idempotencia: po prepnutí a ďalšom katalógovom
- *    importe kandidátom nie je;
+ *  - náš stav je `out_of_stock` (vypredané) ALEBO predobjednávka (issue 526:
+ *    `sellable` + `availability_text` obsahuje „Predobjednávka") — už bežne
+ *    predajný variant sa neprepína, z čoho plynie idempotencia: po prepnutí na
+ *    „Skladom" ho ďalší katalógový import odvodí `sellable` bez predobjednávky,
+ *    takže kandidátom prestane byť;
  *  - `product_visibility` je presne `visible` — `detailOnly`/`hidden`/…
  *    je vedomé „nepredávať" a nikdy sa neprebíja;
  *  - variant nechýba z exportu (`missing_since IS NULL`) — zapnúť niečo, čo
  *    Shoptet už nevidí, nedáva zmysel;
  *  - dodávateľská linka má ÚSPEŠNÚ kontrolu (`ok`), dostupnosť `available`
  *    a potvrdenie nie staršie než `CONFIRMATION_MAX_AGE_HOURS`;
- *  - Shoptetov VLASTNÝ feed pre porovnávače (issue 226) NEHOVORÍ "in stock" —
- *    keď feed hlási skladom pre variant, ktorý MY vedieme ako vypredaný, naše
- *    odvodenie je podozrivé (presne trieda chyby z issue 219) a kandidátom sa
- *    nesmie stať, kým sa rozpor nevysvetlí. Chýbajúci feed riadok (626
- *    viditeľných variantov, issue 220) NIE JE rozpor — kandidát sa vyberie
- *    ako predtým.
+ *  - IBA pre VYPREDANÚ vetvu: Shoptetov VLASTNÝ feed pre porovnávače (issue
+ *    226) NEHOVORÍ "in stock" — keď feed hlási skladom pre variant, ktorý MY
+ *    vedieme ako vypredaný, naše odvodenie je podozrivé (presne trieda chyby z
+ *    issue 219) a kandidátom sa nesmie stať, kým sa rozpor nevysvetlí.
+ *    Chýbajúci feed riadok (626 viditeľných variantov, issue 220) NIE JE
+ *    rozpor — kandidát sa vyberie ako predtým. Pre PREDOBJEDNÁVKU sa tento
+ *    guard NEAPLIKUJE (issue 526): sme `sellable`, takže feed „in stock" je
+ *    zhoda, nie rozpor — aplikovať ho by ticho zahodilo feedom-„in stock"
+ *    predobjednávky.
  *
  * `unknown` (stránka sa načítala, ale nič sa z nej nedalo vyčítať) ani
  * zlyhaná kontrola NIKDY neprepnú produkt — to je celý zmysel toho, že sme
@@ -98,6 +104,30 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
   // ignoruje — `coalesce` padne na produktovú.
   const variantLink = sql<string>`trim(both from regexp_replace(substring(${pairingVariantLinks.url} from 'https?://[^[:space:]]+'), '[.,;:)\\]]+$', ''))`;
   const link = sql<string>`coalesce(case when ${pairingDecisions.status} = 'split' then ${variantLink} end, ${productLink})`;
+
+  // issue 526: predobjednávkový produkt ostáva `sellable` (zákazník ho smie
+  // objednať), ale automatizácia ho má sledovať rovnako ako vypredané. Marker
+  // žije v `availability.ts` — jeden zdroj interpretácie textu, aby sa SQL
+  // nikdy nerozišlo s odvodením stavu. Match beží na `lower(...)` texte
+  // (`availability_text` je `notNull`). `?? sql\`false\`` je fail-closed
+  // poistka: keby `PREORDER_MARKERS` bol prázdny, `or(...[])` je v drizzle
+  // `undefined` a `and(state='sellable', undefined)` by skolabovalo na holé
+  // `state='sellable'` (kandidátom by sa stal KAŽDÝ predajný variant). `false`
+  // namiesto toho znamená „žiadny predobjednávkový kandidát", nikdy „všetky".
+  const isPreorderText =
+    or(...PREORDER_MARKERS.map((marker) => sql`lower(${variants.availabilityText}) like ${`%${marker}%`}`)) ??
+    sql`false`;
+
+  // issue 226: krížová kontrola proti Shoptetovmu feedu je relevantná LEN pre
+  // vypredanú vetvu — tam je feed „in stock" skutočný rozpor (naše
+  // `out_of_stock` odvodenie sa vie mýliť, issue 219). Pre predobjednávku sme
+  // `sellable`, takže feed „in stock" je ZHODA (`compareStateToFeed`), nie
+  // rozpor — vylúčiť na ňom kandidáta by ticho zahodilo predobjednávky, ktoré
+  // Shoptet vo feede hlási ako „in stock" (issue 526 review). Preto sa tento
+  // guard aplikuje IBA na `out_of_stock` vetvu nižšie. `IS NULL` musí byť
+  // explicitné — `!= 'in stock'` samo o sebe vyhodnotí NULL (žiadny feed
+  // riadok) na NULL, čo by WHERE ticho zahodilo.
+  const feedNotInStock = or(isNull(shopProductUrl.availability), ne(shopProductUrl.availability, FEED_IN_STOCK));
 
   const rows = await db
     .select({
@@ -141,7 +171,20 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
     .leftJoin(shopProductUrl, eq(shopProductUrl.code, variants.code))
     .where(
       and(
-        eq(variants.state, "out_of_stock"),
+        // issue 526: kandidátom je vypredaný (`out_of_stock`) ALEBO
+        // predobjednávkový (`sellable` + text „Predobjednávka") variant. Kotva
+        // `state='sellable'` zaručuje, že jednotlivo vypnutý predobjednávkový
+        // variant (už `discontinued`, `availability.ts` kontroluje vypnutie
+        // PRED textom) sa nikdy nezapne; `product_visibility='visible'` filter
+        // nižšie vylúči `detailOnly`. Idempotencia: po prepnutí je text
+        // „Skladom" → LIKE nesedí → variant už nie je kandidátom. Feed-guard
+        // (`feedNotInStock`, issue 226) sa aplikuje IBA na vypredanú vetvu —
+        // pre predobjednávku je feed „in stock" zhoda, nie rozpor (viď jeho
+        // definíciu vyššie).
+        or(
+          and(eq(variants.state, "out_of_stock"), feedNotInStock),
+          and(eq(variants.state, "sellable"), isPreorderText),
+        ),
         eq(variants.productVisibility, SELLABLE_VISIBILITY),
         isNull(variants.missingSince),
         eq(supplierStock.ok, true),
@@ -149,11 +192,6 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
         sql`${supplierStock.confirmedAt} is not null`,
         sql`${supplierStock.confirmedAt} >= ${oldestAcceptable}`,
         sql`${supplierStock.confirmedAt} <= ${now}`,
-        // issue 226: kandidát je vždy `out_of_stock` (podmienka vyššie), takže
-        // jediný relevantný smer rozporu je feed hlásiaci "in stock". `IS
-        // NULL` musí byť explicitné — `!= 'in stock'` samo o sebe vyhodnotí
-        // NULL (žiadny feed riadok) na NULL, čo by WHERE ticho zahodilo.
-        or(isNull(shopProductUrl.availability), ne(shopProductUrl.availability, FEED_IN_STOCK)),
       ),
     )
     // Stabilné poradie: najstaršie potvrdenie prvé, potom podľa kódu — pri

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -64,6 +64,9 @@ describe("prepínanie Vypredané → Skladom", () => {
       // každý `code` dostal vlastný produkt s vlastným `internalNote`.
       readonly productKey?: string;
       readonly sizeLabel?: string | null;
+      // issue 526: predobjednávka sa odlíši textom dostupnosti, nie stavom —
+      // predvolený „Vypredané" ostáva pre existujúce testy.
+      readonly availabilityText?: string;
     } = {},
   ): Promise<void> => {
     const productKey = over.productKey ?? `prod-${code}`;
@@ -87,8 +90,8 @@ describe("prepínanie Vypredané → Skladom", () => {
       name: `Produkt ${code}`,
       stock: 0,
       availabilityInStockText: "Skladom",
-      availabilityOutOfStockText: "Vypredané",
-      availabilityText: "Vypredané",
+      availabilityOutOfStockText: over.availabilityText ?? "Vypredané",
+      availabilityText: over.availabilityText ?? "Vypredané",
       productVisibility: over.productVisibility ?? "visible",
       state: over.state ?? "out_of_stock",
       missingSince: over.missingSince ?? null,
@@ -160,6 +163,98 @@ describe("prepínanie Vypredané → Skladom", () => {
     await seedVariant("D1", { state: "discontinued" });
 
     expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  // issue 526 — jadro úlohy: predobjednávka (stav `sellable`, text
+  // „Predobjednávka"), ktorú dodávateľ potvrdene má, sa prepne na „Skladom".
+  it("prepne aj produkt v stave Predobjednávka, ktorý dodávateľ potvrdene má", async () => {
+    await seedSupplierStock();
+    await seedVariant("P1", { state: "sellable", availabilityText: "Predobjednávka" });
+
+    const result = await runRestock({ db, now: NOW, config: CONFIG, importToShoptet: okImport });
+
+    expect(result).toMatchObject({ status: "ok", switched: 1, codes: ["P1"] });
+  });
+
+  // Kontrola rozsahu: bežný predajný produkt (bez predobjednávky) sa NESMIE
+  // stať kandidátom len preto, že je `sellable` — inak by sa zapínalo naprázdno
+  // všetko, čo je v predaji.
+  it("neprepne bežný predajný produkt bez predobjednávky", async () => {
+    await seedSupplierStock();
+    await seedVariant("P2", { state: "sellable", availabilityText: "Skladom" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  // Jednotlivo vypnutá predobjednávková veľkosť je `discontinued` (vypnutie sa
+  // v `availability.ts` kontroluje PRED textom) — kotva `state='sellable'` ju
+  // musí vylúčiť, rovnako ako vypnutú vypredanú.
+  it("neprepne jednotlivo vypnutý predobjednávkový variant (discontinued)", async () => {
+    await seedSupplierStock();
+    await seedVariant("P3", { state: "discontinued", availabilityText: "Predobjednávka" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  // `detailOnly` predobjednávka je `sellable`, ale majiteľ ju vedome nepredáva
+  // v katalógu — `product_visibility` filter ju musí vylúčiť rovnako ako
+  // vypredanú `detailOnly`.
+  it("neprepne detailOnly predobjednávku", async () => {
+    await seedSupplierStock();
+    await seedVariant("P4", {
+      state: "sellable",
+      availabilityText: "Predobjednávka",
+      productVisibility: "detailOnly",
+    });
+
+    expect((await selectRestockCandidates(db, NOW)).picked).toHaveLength(0);
+  });
+
+  // issue 526 review: feed-guard (issue 226) sa NEAPLIKUJE na predobjednávku —
+  // sme `sellable`, takže feed „in stock" je ZHODA, nie rozpor. Predobjednávka
+  // s feedom „in stock" sa preto prepne (inak by feedom-„in stock" predobjednávky
+  // ticho vypadli a úloha by pre ne nič neurobila). Kontrast: vypredaná s
+  // feedom „in stock" sa NAOPAK podrží — to drží existujúci test „Z1".
+  it("prepne predobjednávku aj keď feed hovorí 'in stock' (na rozdiel od vypredanej)", async () => {
+    await seedSupplierStock();
+    await seedVariant("P5", { state: "sellable", availabilityText: "Predobjednávka" });
+    await db.insert(shopProductUrl).values({
+      code: "P5",
+      url: "https://www.forestshop.sk/p5/",
+      availability: "in stock",
+      fetchedAt: NOW,
+    });
+
+    expect((await selectRestockCandidates(db, NOW)).picked.map((c) => c.variantCode)).toEqual(["P5"]);
+  });
+
+  // Overovací zoznam musí ukázať PRESNE to, čo beh prepne — vrátane
+  // predobjednávkových kandidátov (listing = beh, spoločná `allRestockCandidates`).
+  it("overovací zoznam ukáže aj predobjednávkového kandidáta", async () => {
+    await seedSupplierStock();
+    await seedVariant("P6", { state: "sellable", availabilityText: "Predobjednávka" });
+
+    const zoznam = await listRestockWaiting(db, NOW, { limit: 50, offset: 0 });
+    expect(zoznam.rows.map((r) => r.variantCode)).toEqual(["P6"]);
+  });
+
+  // issue 526 review: match je SUBSTRING (`LIKE '%predobjedn%'`), rovnako ako
+  // `OUT_OF_STOCK_MARKERS`'s `.includes()` — text s markerom UPROSTRED sa tiež
+  // chytí. Pinuje substring sémantiku (mutácia na prefix-match by inak prešla).
+  it("prepne aj predobjednávkový text s markerom uprostred (substring, nie presná zhoda)", async () => {
+    await seedSupplierStock();
+    await seedVariant("P7", { state: "sellable", availabilityText: "Tovar na predobjednávku" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked.map((c) => c.variantCode)).toEqual(["P7"]);
+  });
+
+  // issue 526 review: český tvar „Předobjednávka" (ř ≠ r) má vlastný marker
+  // („předobjedn") — bez neho by ho `LIKE '%predobjedn%'` nechytil.
+  it("prepne aj český tvar Předobjednávka", async () => {
+    await seedSupplierStock();
+    await seedVariant("P8", { state: "sellable", availabilityText: "Předobjednávka" });
+
+    expect((await selectRestockCandidates(db, NOW)).picked.map((c) => c.variantCode)).toEqual(["P8"]);
   });
 
   it("neprepne variant, ktorý zmizol z exportu", async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.307",
+  "version": "0.3.0-dev.308",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Súhrn

Issue 526 (zadanie od Štěpána, Discord 31. 8.): automatizácia Vypredané → Skladom sleduje okrem vypredaných produktov aj produkty s dostupnosťou **„Predobjednávka"** — keď je taký produkt skladom u dodávateľa, prepne sa rovnakou zápisovou cestou na „Skladom".

- Kandidátsky dopyt rozšírený: `state='out_of_stock' OR (state='sellable' AND lower(availability_text) LIKE '%predobjedn%')` — markery (`predobjedn`, `předobjedn`) žijú len v `availability.ts` (`PREORDER_MARKERS`), SQL sa neodchyľuje od textovej interpretácie.
- Feed-guard („Rozpory nášho stavu s feedom") scoped len na vetvu `out_of_stock` — feed „in stock" pri predobjednávke nie je rozpor, ale zhoda; správanie vypredaných nezmenené.
- Žiadna zmena enumu/schémy — predobjednávka ostáva `sellable`, dedí ochrany (skryté produkty, detailOnly, ukončený predaj).
- Testy: nová integračná sada pre Predobjednávku + existujúce restock testy; unit 1030 (api) + 756 (web) zelené lokálne.
- Playbook: `.claude/rules/supplier-stock.md` + `.claude/rules/database.md` (drizzle `or()` fail-open pasca).
- Review: 0 🔴 0 🟡 0 🔵 v diffe (1 🟡 + 3 🔵 opravené vo vetve; 1 🔵 UX badge vyčlenený ako issue 527, needs-user-decision).

Verzia: 0.3.0-dev.308.

Issue 526 ostáva otvorené — zavrie sa ručne po nasadení a živom overení.

## Overenie

- Dev CI run 33380525196 (0e3d2a6): completed success — na prvý pokus.
- Lokálne gates (typecheck + lint + unit): zelené.
