### PR TITLE
Badge predobjednavka/vypredane v zozname Pripravene na prepnutie (issue 527)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -11,6 +11,15 @@ paths:
 
 # Deployment (forestshop-dev — presunuté z dev2, issue 366)
 
+- **Verejná adresa APPKY je `forestshop.newlevel.media` — NIE
+  `forestshop-dev.newlevel.media`.** `forestshop-dev.newlevel.media` je len
+  A záznam (DNS-only, proxied=false) na verejnú IP boxu pre SSH/označenie
+  servera; na boxe na :443 nič nepočúva (appka beží na 127.0.0.1:8901 za
+  Cloudflare tunelom), takže `curl`/Playwright na `forestshop-dev.…` skončí
+  `ERR_CONNECTION_REFUSED` na ÚPLNE ZDRAVEJ appke — nie je to výpadok
+  (falošný poplach 1. 9. 2026 pri live overení issue 531). Live verify,
+  uptime check aj všetky 🌐 odkazy vždy na `https://forestshop.newlevel.media`.
+
 - **Cloudflare Error 1033 / HTTP 530 na oboch verejných adresách = tunel bez
   živého spojenia, NIE appka (issue 357, výpadok 12. 8. 2026 ráno).**
   `cloudflared` sa predvolene pripája protokolom QUIC (UDP 7844); keď QUIC

--- a/apps/api/src/modules/restock/queries.ts
+++ b/apps/api/src/modules/restock/queries.ts
@@ -15,6 +15,15 @@ import {
   SELLABLE_VISIBILITY,
 } from "./constants.js";
 
+/**
+ * Prečo je variant kandidátom (issue 527) — priamo z `variants.state`, nikdy
+ * z novej JS kontroly textu: `allRestockCandidates`'s `WHERE` garantuje, že
+ * jediné dve cesty do výsledku sú `state='out_of_stock'` alebo
+ * `state='sellable' AND isPreorderText`, takže `state` sám jednoznačne
+ * určuje dôvod (viď `reason` v `select`e nižšie).
+ */
+export type RestockCandidateReason = "out_of_stock" | "preorder";
+
 export interface RestockCandidate {
   readonly variantCode: string;
   readonly pairCode: string | null;
@@ -31,6 +40,8 @@ export interface RestockCandidate {
    * vyhľadávanie podľa kódu.
    */
   readonly ourUrl: string | null;
+  /** Vypredaný, alebo predobjednávkový (issue 526/527). */
+  readonly reason: RestockCandidateReason;
 }
 
 export interface RestockCandidates {
@@ -140,6 +151,9 @@ async function allRestockCandidates(db: Database, now: Date): Promise<readonly R
       supplierPrice: supplierStock.price,
       confirmedAt: supplierStock.confirmedAt,
       ourUrl: shopProductUrl.url,
+      // issue 527: jediné dve cesty cez WHERE nižšie sú `out_of_stock` alebo
+      // `sellable`+predobjednávkový text — `state` sám teda dôvod určuje.
+      reason: sql<RestockCandidateReason>`case when ${variants.state} = 'out_of_stock' then 'out_of_stock' else 'preorder' end`,
     })
     .from(variants)
     .innerJoin(products, eq(variants.productKey, products.key))

--- a/apps/api/tests/restock-run.integration.test.ts
+++ b/apps/api/tests/restock-run.integration.test.ts
@@ -238,6 +238,26 @@ describe("prepínanie Vypredané → Skladom", () => {
     expect(zoznam.rows.map((r) => r.variantCode)).toEqual(["P6"]);
   });
 
+  // issue 527: overovací zoznam musí niesť `reason`, aby ho UI vedelo
+  // rozlíšiť badge-om — vypredaný `state` aj predobjednávkový `state`+text
+  // v JEDNOM behu, jednoznačne priamo z `variants.state`.
+  it("overovací zoznam rozlíši dôvod kandidáta (vypredané vs predobjednávka)", async () => {
+    await seedSupplierStock();
+    await seedVariant("P9", { state: "out_of_stock" });
+    await seedSupplierStock({ link: "https://huntingshop.eu/bunda2" });
+    await seedVariant("P10", {
+      state: "sellable",
+      availabilityText: "Predobjednávka",
+      internalNote: "https://huntingshop.eu/bunda2",
+      productKey: "prod-P10",
+    });
+
+    const zoznam = await listRestockWaiting(db, NOW, { limit: 50, offset: 0 });
+    const byCode = new Map(zoznam.rows.map((r) => [r.variantCode, r.reason]));
+    expect(byCode.get("P9")).toBe("out_of_stock");
+    expect(byCode.get("P10")).toBe("preorder");
+  });
+
   // issue 526 review: match je SUBSTRING (`LIKE '%predobjedn%'`), rovnako ako
   // `OUT_OF_STOCK_MARKERS`'s `.includes()` — text s markerom UPROSTRED sa tiež
   // chytí. Pinuje substring sémantiku (mutácia na prefix-match by inak prešla).

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -228,10 +228,10 @@ it("odlíši predobjednávkového kandidáta od vypredaného badge-om", async ()
   fetchRestockStatus.mockResolvedValue(STATUS);
   render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
 
-  const vypredany = await screen.findByTestId("supplier-stock-candidate-type-60542");
+  const vypredany = await screen.findByTestId("restock-waiting-reason-60542");
   expect(vypredany.textContent).toBe("vypredané");
 
-  const predobjednavka = await screen.findByTestId("supplier-stock-candidate-type-15314");
+  const predobjednavka = await screen.findByTestId("restock-waiting-reason-15314");
   expect(predobjednavka.textContent).toBe("predobjednávka");
 });
 

--- a/apps/web/src/components/RestockSection.test.tsx
+++ b/apps/web/src/components/RestockSection.test.tsx
@@ -29,6 +29,7 @@ const WAITING = {
       supplierPrice: "24.00",
       confirmedAt: "2026-08-04T04:20:00.000Z",
       ourUrl: "https://www.forestshop.sk/ladvinka-swedteam-green/?variantId=4211",
+      reason: "out_of_stock" as const,
     },
     {
       // Kód, ktorý vo feede pre porovnávače NIE JE (issue 220) — dnes je
@@ -43,6 +44,8 @@ const WAITING = {
       supplierPrice: "59.00",
       confirmedAt: "2026-08-04T04:21:00.000Z",
       ourUrl: null,
+      // issue 527: druhý riadok je predobjednávkový kandidát (issue 526).
+      reason: "preorder" as const,
     },
   ],
   suppliers: [
@@ -216,6 +219,20 @@ it("pri každom čakajúcom produkte ponúkne odkaz na náš eshop aj k dodávat
   expect([...riadok.querySelectorAll("a")].every((a) => a.getAttribute("target") === "_blank")).toBe(
     true,
   );
+});
+
+// issue 527: majiteľ overuje "Pripravené na prepnutie" v domnienke, že ide
+// vždy o vypredaný produkt — badge musí odlíšiť predobjednávkového
+// kandidáta (issue 526) od skutočne vypredaného, priamo z API poľa `reason`.
+it("odlíši predobjednávkového kandidáta od vypredaného badge-om", async () => {
+  fetchRestockStatus.mockResolvedValue(STATUS);
+  render(<RestockSection role="admin" onSessionExpired={vi.fn()} />);
+
+  const vypredany = await screen.findByTestId("supplier-stock-candidate-type-60542");
+  expect(vypredany.textContent).toBe("vypredané");
+
+  const predobjednavka = await screen.findByTestId("supplier-stock-candidate-type-15314");
+  expect(predobjednavka.textContent).toBe("predobjednávka");
 });
 
 it("filter podľa dodávateľa načíta zoznam odznova od prvej stránky", async () => {

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -384,7 +384,7 @@ export function RestockSection({
                       {row.variantCode}
                       <span
                         className="pill"
-                        data-testid={`supplier-stock-candidate-type-${row.variantCode}`}
+                        data-testid={`restock-waiting-reason-${row.variantCode}`}
                       >
                         {RESTOCK_REASON_LABEL[row.reason]}
                       </span>

--- a/apps/web/src/components/RestockSection.tsx
+++ b/apps/web/src/components/RestockSection.tsx
@@ -28,6 +28,13 @@ const STATE_LABEL: Readonly<Record<"sellable" | "out_of_stock" | "discontinued",
   discontinued: "ukončený predaj",
 };
 
+// issue 527: majiteľ overuje "Pripravené na prepnutie" v domnienke, že ide o
+// vypredaný produkt — odznak odlíši predobjednávkového kandidáta (issue 526).
+const RESTOCK_REASON_LABEL: Readonly<Record<"out_of_stock" | "preorder", string>> = {
+  out_of_stock: "vypredané",
+  preorder: "predobjednávka",
+};
+
 export function RestockSection({
   role,
   onSessionExpired,
@@ -373,7 +380,15 @@ export function RestockSection({
               <tbody>
                 {waitingList.rows.map((row) => (
                   <tr key={row.variantCode} data-testid={`restock-waiting-${row.variantCode}`}>
-                    <td>{row.variantCode}</td>
+                    <td>
+                      {row.variantCode}
+                      <span
+                        className="pill"
+                        data-testid={`supplier-stock-candidate-type-${row.variantCode}`}
+                      >
+                        {RESTOCK_REASON_LABEL[row.reason]}
+                      </span>
+                    </td>
                     <td>{row.productName}</td>
                     <td>{row.supplier ?? "—"}</td>
                     <td>

--- a/apps/web/src/restockApi.ts
+++ b/apps/web/src/restockApi.ts
@@ -124,6 +124,8 @@ const waitingSchema = z.object({
       // Priama adresa detailu z feedu (issue 220). `null` = kód vo feede nie
       // je; odkaz vtedy padne späť na vyhľadávanie podľa kódu.
       ourUrl: z.string().nullable(),
+      // issue 527: vypredaný, alebo predobjednávkový kandidát — badge v UI.
+      reason: z.enum(["out_of_stock", "preorder"]),
     }),
   ),
   suppliers: z.array(z.object({ name: z.string(), count: z.number() })),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.310",
+  "version": "0.3.0-dev.311",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo prináša

Issue 527 — v overovacom zozname „Pripravené na prepnutie“ (Vypredané → Skladom) má každý riadok malý štítok **predobjednávka** / **vypredané**, takže je na prvý pohľad jasné, o aký typ kandidáta ide (majiteľ rozhodol možnosť 1, komentár 5499347349).

## Zmeny

- `apps/api/src/modules/restock/queries.ts` — nové pole `reason` v RestockCandidate (SQL `case` odvodený z `variants.state`)
- `apps/web/src/restockApi.ts` — zod schéma doplnená o `reason`
- `apps/web/src/components/RestockSection.tsx` — badge render len v zozname „Pripravené na prepnutie“, testid s riadkovým prefixom
- Testy: `RestockSection.test.tsx` (13/13, nový badge test), `restock-run.integration.test.ts` (29/29, nový reason test)

## Kvalita

- Review: 0 🔴 0 🟡 0 🔵 (1 🔵 testid nit opravený v 4b681d6)
- `pnpm gates:local` + integračné testy zelené; dev CI (run 33552779623) success
- Verzia 0.3.0-dev.311

Issue 527 ostáva otvorené — zavrie sa ručne po nasadení a živom overení.
