### PR TITLE
Oprava race v floor-notes e2e teste (waitForResponse na PATCH mnozstva)

### DIFF
--- a/apps/web/tests/e2e/floor-notes.spec.ts
+++ b/apps/web/tests/e2e/floor-notes.spec.ts
@@ -82,9 +82,25 @@ test("napísať zápis, pripnúť produkt (priama aj náhradná adresa), prepnú
 
   // issue 453: upraviť počet produktu 1 z 2 na 3 (Enter commit), potom RELOAD
   // dokáže, že sa hodnota naozaj uložila do DB (nie len lokálny draft).
+  // Vstup je kontrolovaný lokálnym draftom, takže `toHaveValue("3")` je "3" v
+  // DOM-e OKAMŽITE po fill (`onChange` synchrónne), NEČAKÁ na async PATCH, čo
+  // Enter (→ blur → `commitQty` → `onUpdateQuantity`) spúšťa. Bez explicitného
+  // čakania na dokončenie zápisu `page.reload()` na pomalom CI runneri predbehne
+  // PATCH a po reloade je stará hodnota "2" (flaky race, ktorý zhodil main
+  // CI 33553887182, kým identický strom prešiel na dev 33552779623). Počkaj
+  // preto na 200 odpoveď PATCH endpointu množstva PRED reloadom — dôkazová sila
+  // testu ostáva (reload + asercie z DB nižšie sa nemenia), len sa odstraňuje
+  // závod medzi commitom a reloadom.
   await pocet1.fill("3");
+  const pocetUlozeny = page.waitForResponse(
+    (r) =>
+      r.request().method() === "PATCH" &&
+      /\/api\/floor-notes\/.+\/products\/.+\/quantity$/.test(r.url()) &&
+      r.status() === 200,
+  );
   await pocet1.press("Enter");
   await expect(pocet1).toHaveValue("3");
+  await pocetUlozeny;
   await page.reload();
   await expect(page.getByTestId("floor-notes-list")).toBeVisible();
   await expect(page.getByTestId(`floor-note-product-qty-input-${noteId}-E2E-PREDAJNA-1`)).toHaveValue("3");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.311",
+  "version": "0.3.0-dev.312",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo prináša

Oprava flaky race v e2e teste `floor-notes.spec.ts`, ktorá zhodila main CI run 33553887182 (job e2e) po merge PR #533 — identický strom prešiel na dev CI, takže išlo o závod v teste, nie o regresiu.

## Root cause + fix

`FloorNoteProductChip` drží množstvo v lokálnom drafte (onChange synchrónne), takže `fill("3")` + Enter → `toHaveValue("3")` prejde okamžite BEZ čakania na async PATCH zápis; `page.reload()` na pomalom runneri predbehne zápis a po reloade je stará hodnota. Fix: `page.waitForResponse` na PATCH `…/quantity` (status 200) medzi Enter a reloadom — reload + obe post-reload DB asercie (jadro dôkazu „uložené v DB") ostávajú nezmenené. Žiadny timeout/sleep/retry, žiadny dotyk produkčného kódu.

## Kvalita

- `floor-notes.spec.ts` lokálne 1/1 (3.8 s — rýchly pass dokazuje, že guard reálne chytil PATCH, chybný predikát by visel 30 s)
- `pnpm gates:local` zelené (api 1038/1038, web 786/786); dev CI run 33556574642 success
- Verzia 0.3.0-dev.312
