### PR TITLE
Stale-response guard v NedostupneSection — oprava race checkboxu vyriesene

### DIFF
--- a/apps/web/src/components/NedostupneResolvedCheckbox.tsx
+++ b/apps/web/src/components/NedostupneResolvedCheckbox.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from "react";
+
+// issue 531: checkbox „vyriešené" pri karte produktu — vyčlenené z
+// `NedostupneSection.tsx` (eslint `max-lines`), rovnaká extrakčná disciplína
+// ako `NedostupneOrderNote`. Čisto prezentačné: stav (`resolved`/`disabled`)
+// aj optimistický toggle žijú v rodičovi (`useNedostupneResolved`).
+export function NedostupneResolvedCheckbox({
+  variantCode,
+  itemLabel,
+  resolved,
+  disabled,
+  onToggle,
+}: {
+  readonly variantCode: string;
+  readonly itemLabel: string;
+  readonly resolved: boolean;
+  readonly disabled: boolean;
+  readonly onToggle: (variantCode: string, resolved: boolean) => void;
+}): JSX.Element {
+  return (
+    <input
+      type="checkbox"
+      className="nedostupne-resolved-checkbox"
+      data-testid={`nedostupne-resolved-checkbox-${variantCode}`}
+      aria-label={`Označiť ${itemLabel} ako vyriešené`}
+      title="Vyriešené"
+      checked={resolved}
+      disabled={disabled}
+      onChange={(e) => {
+        onToggle(variantCode, e.target.checked);
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/NedostupneSection.resolved.test.tsx
+++ b/apps/web/src/components/NedostupneSection.resolved.test.tsx
@@ -1,6 +1,8 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { NedostupneSection } from "./NedostupneSection.js";
+import type { NedostupneList } from "../nedostupneApi.js";
 
 // issue 531: testy checkboxu „vyriešené" — vyčlenené z `NedostupneSection.test.tsx`
 // (eslint `max-lines: 400`), rovnaký split vzor ako `orders-http*.integration.test.ts`.
@@ -107,6 +109,59 @@ it("zlyhaný zápis vráti checkbox späť a zobrazí hlášku", async () => {
     expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(false);
   });
   await screen.findByText("Označenie sa nepodarilo uložiť.");
+});
+
+it("zastaraná odpoveď zoznamu (StrictMode duplicitný GET) nesmie prepísať optimistické odznačenie", async () => {
+  // issue 531 flake (main CI 33557805594, nedostupne.spec.ts checkbox toggle):
+  // appka beží pod `<StrictMode>` (main.tsx) a vo vývojovom móde (aj `pnpm
+  // e2e` cez vite dev) sa mount efekt `useEffect(load)` spustí DVAKRÁT → dva
+  // GET-y zoznamu. `load()` bez stale-response guardu (issue 251/523 trieda)
+  // aplikuje KAŽDÚ odpoveď na `setList` — takže pomalší duplicitný GET doletí
+  // AŽ PO optimistickom odznačení a prepíše ho späť na zaškrtnuté.
+  //
+  // Reprodukcia: PRVÝ (skorší) GET je zdržaný a zastaraný, DRUHÝ okamžitý —
+  // takže checkbox sa v OBOCH (rozbitej aj opravenej) verzii vykreslí z toho
+  // najnovšieho GET-u, a klobber pochádza zo zastaraného skoršieho GET-u
+  // (bez guardu ho aplikuje, s guardom ho zahodí).
+  const CHECKED: NedostupneList = { groups: [{ ...GROUP, resolved: true }], bccMissing: false, mailNotConfigured: false };
+  let resolveStale!: (value: NedostupneList) => void;
+  const stale = new Promise<NedostupneList>((r) => {
+    resolveStale = r;
+  });
+  fetchNedostupneList.mockReturnValueOnce(stale).mockResolvedValueOnce(CHECKED);
+  setNedostupneResolved.mockResolvedValue(undefined);
+
+  render(
+    <StrictMode>
+      <NedostupneSection role="manazer" onSessionExpired={vi.fn()} />
+    </StrictMode>,
+  );
+
+  // Checkbox sa vykreslí z NAJNOVŠIEHO (druhého, okamžitého) GET-u — zaškrtnutý.
+  const checkbox = await screen.findByTestId<HTMLInputElement>(CHECKBOX);
+  expect(checkbox.checked).toBe(true);
+
+  // Odznač (toggle) — optimisticky HNEĎ odznačené, PUT odletí.
+  fireEvent.click(checkbox);
+  expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(false);
+  await waitFor(() => {
+    expect(setNedostupneResolved).toHaveBeenCalledWith("40237/L", false);
+  });
+
+  // Doruč ZASTARANÚ odpoveď skoršieho GET-u (resolved=true) a POČKAJ, kým ju
+  // komponent CELÚ spracuje (`.then` mikrotaska + React re-render pod `act`) —
+  // deterministicky, žiadne pevné oneskorenie. Až POTOM plochá asercia: keby
+  // sa použil retrying `waitFor(false)`, prešiel by na PRVEJ (pred-klobber)
+  // kontrole aj proti rozbitému kódu (`.claude/rules/testing.md` — „čakanie
+  // urobí test zeleným zo zlého dôvodu").
+  await act(async () => {
+    resolveStale(CHECKED);
+    await stale;
+    await Promise.resolve();
+  });
+
+  // Musí ostať ODZNAČENÉ — zastaraná odpoveď nesmie prepísať optimistickú zmenu.
+  expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(false);
 });
 
 it("rola citanie vidí checkbox, ale nesmie ho prepnúť (disabled)", async () => {

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -13,6 +13,7 @@ import {
   type NedostupnePreview,
 } from "../nedostupneApi.js";
 import { useNedostupneResolved } from "../useNedostupneResolved.js";
+import { useStaleResponseGuard } from "../useStaleResponseGuard.js";
 import { formatNedostupneTotalChip } from "../nedostupneSummary.js";
 // issue 529: poznámka do eshopu — ZDIEĽANÁ zapisovacia cesta so stĺpcom POZNÁMKY
 // v „Na objednanie" (`updateOrderComment` → `PUT /api/orders/:id/comment` →
@@ -20,6 +21,7 @@ import { formatNedostupneTotalChip } from "../nedostupneSummary.js";
 import { updateOrderComment, OrdersUnauthorizedError } from "../ordersApi.js";
 import { MailPreviewDialog } from "./MailPreviewDialog.js";
 import { NedostupneOrderNote } from "./NedostupneOrderNote.js";
+import { NedostupneResolvedCheckbox } from "./NedostupneResolvedCheckbox.js";
 
 // Rovnaké dve role, ktoré server vyžaduje na odoslanie (`requireRole("admin",
 // "manazer")`, `nedostupne-routes.ts`) — čítanie (zoznam) smie vidieť KAŽDÝ
@@ -70,14 +72,22 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
   // vlastnom hooku (eslint `max-lines`), rovnaká „lift do hooku" disciplína ako
   // `useLoadMore`/`useStaleResponseGuard`.
   const { resolvedBusy, toggleResolved } = useNedostupneResolved({ setList, setActionError, onSessionExpired });
+  // issue 251/523: stale-response guard — pod `<StrictMode>` sa mount `load()`
+  // spustí dvakrát; pomalší duplicitný GET zoznamu inak doletí AŽ PO
+  // optimistickom (od)označení checkboxu „vyriešené" (issue 531, žiadny refetch)
+  // a prepíše ho späť. Uplatní sa len NAJNOVŠÍ `load()` (vzor `UpozorneniaSection`).
+  const guard = useStaleResponseGuard();
 
   const load = useCallback(() => {
+    const seq = guard.begin();
     fetchNedostupneList()
       .then((l) => {
+        if (!guard.isLatest(seq)) return;
         setList(l);
         setLoaded(true);
       })
       .catch((err: unknown) => {
+        if (!guard.isLatest(seq)) return;
         setLoaded(true);
         if (err instanceof NedostupneUnauthorizedError) {
           onSessionExpired();
@@ -85,7 +95,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
         }
         setError("Nedostupné tovary sa nepodarilo načítať.");
       });
-  }, [onSessionExpired]);
+  }, [guard, onSessionExpired]);
 
   useEffect(load, [load]);
 
@@ -301,21 +311,16 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
                   </a>
                   {/* issue 531: ručné označenie „vyriešené" — štvorček HNEĎ ZA
                       📦 (per Štěpánov nákres), vizuál konzistentný s checkboxom
-                      „Objednané" v „Na objednanie" (`.nedostupne-group-header
-                      input[type=checkbox]`). Viditeľný VŠETKÝM (ako 📦),
+                      „Objednané" v „Na objednanie". Viditeľný VŠETKÝM (ako 📦),
                       prepnúť smie len admin/manazer (`canControl`, server zápis
-                      aj tak gated). „Nič ďalšie sa nestane, len sa to označí." */}
-                  <input
-                    type="checkbox"
-                    className="nedostupne-resolved-checkbox"
-                    data-testid={`nedostupne-resolved-checkbox-${group.variantCode}`}
-                    aria-label={`Označiť ${itemLabel(group)} ako vyriešené`}
-                    title="Vyriešené"
-                    checked={group.resolved}
+                      aj tak gated). Vykreslenie vyčlenené do
+                      `NedostupneResolvedCheckbox` (eslint `max-lines`). */}
+                  <NedostupneResolvedCheckbox
+                    variantCode={group.variantCode}
+                    itemLabel={itemLabel(group)}
+                    resolved={group.resolved}
                     disabled={!canControl || resolvedBusy === group.variantCode}
-                    onChange={(e) => {
-                      toggleResolved(group.variantCode, e.target.checked);
-                    }}
+                    onToggle={toggleResolved}
                   />
                 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.312",
+  "version": "0.3.0-dev.313",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Čo prináša

Oprava reálneho bugu za flaky e2e testom checkboxu „vyriešené“ (main CI run 33557805594, `nedostupne.spec.ts:239` — checkbox po odškrtnutí a 200 odpovedi ostal zaškrtnutý).

## Root cause + fix

`NedostupneSection.load()` (GET `/api/nedostupne`) nemal stale-response guard. Pod `<StrictMode>` sa `useEffect(load)` spúšťa dvakrát → dva GET-y; pomalší duplicitný GET doletí až PO optimistickom odškrtnutí a nepodmienene ho prepíše späť. Deterministicky reprodukované RED unit testom pod StrictMode (commit da5b93e), opravené zdieľaným `useStaleResponseGuard` v `load()` (commit 2d06fc5 — uplatní sa len najnovšia odpoveď). Checkbox vyčlenený do `NedostupneResolvedCheckbox.tsx` (eslint max-lines).

Latentný sesterský race (akciou spustený refetch vs. optimistický toggle, predexistujúci, mimo diffu) je založený ako #535 (návrh riešenia potrebuje dizajn).

## Kvalita

- RED→GREEN: da5b93e (test padá bez fixu, 3/3) → 2d06fc5 (zelený s fixom)
- Review (/review + requesting-code-review): 0 🔴 0 🟡 0 🔵 na diffe
- `pnpm gates:local` zelené (787 web unit testov); `nedostupne.spec.ts` e2e 4/4; dev CI run 33562190122 success
- Verzia 0.3.0-dev.313

Súvisí s issue 531 (checkbox vznikol tam) — issue 531 je už zavreté a ostáva zavreté.
