### PR TITLE
Nedostupne: reconcileResolved — optimisticke oznacenie vyriesene prezije akciou-spusteny refetch (issue 535)

### DIFF
--- a/.claude/rules/nedostupne.md
+++ b/.claude/rules/nedostupne.md
@@ -201,3 +201,22 @@ paths:
   tabuľka → doplnená do OBOCH TRUNCATE zoznamov (`tests/helpers/db.ts` +
   `scripts/e2e-setup.ts`, `truncate-list-completeness.test.ts` to vynucuje).
   Migrácia 0063 je plain CREATE TABLE + index (žiadny enum → žiadny #399 risk).
+- **issue 535: optimistický toggle „vyriešené", ktorého zoznam refetchujú INÉ
+  akcie (`saveNote`/`addLink`/`removeLink`/`confirmSend` volajú `load()`),
+  potrebuje aby `load()` REKONCILIOVAL nevyrovnané optimistické zmeny —
+  `useStaleResponseGuard` (PR #536) rieši len load-vs-load, NIE
+  load-vs-optimistický-zápis.** `useNedostupneResolved` vedie
+  `pendingResolvedRef: Map<variantCode, {desired, committed}>` (zapíše sa pri
+  toggle, zmaže pri chybe PUT + revert) a vystaví STABILNÝ `reconcileResolved(list)`
+  (`useCallback([])` nad refom — inak by refiroval `useEffect(load)`), ktorý
+  `load().then` zavolá PRED `setList`. Rekonciliácia je self-cleaning s
+  OHRANIČENOU životnosťou (code review nález, inak by nezhodný záznam maskoval
+  súbežnú CUDZIU zmenu donekonečna): server sa zhoduje → zmaž; nezhoduje +
+  necommitnutý → drž optimistickú hodnotu; nezhoduje + commitnutý (PUT `.then`
+  označí `committed`, len ak ho neprebil novší toggle) → ochráň JEDEN zastaraný
+  in-flight load a zmaž. **Toto je TRETÍ tvar „latest ref"/stale-response triedy
+  (`.claude/rules/frontend-design.md` issue 251/523: load-vs-load) — pri KAŽDOM
+  ďalšom optimistickom zápise, ktorého zoznam refetchuje iná akcia, over túto os,
+  nie len guard.** Pridružený nález: `setResolvedBusy("")` vo `.finally()` musí
+  byť FUNKČNÝ clear (`(cur) => cur === variantCode ? "" : cur`) — jediný skalár,
+  súbežný toggle iného variantu ho inak vyčistí mid-PUT.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,6 +14,17 @@ paths:
 
 # Tests
 
+- **`<StrictMode>` dvojitý mount = dvojitý GET v `useEffect(load)` — pomalší
+  duplicitný GET doletí až PO používateľskej akcii a prepíše optimistický
+  stav späť** (flaky e2e „po odškrtnutí ostalo zaškrtnuté", main run
+  33557805594, `nedostupne.spec.ts`). Nie race testu — reálny bug: každý
+  load/refetch nad dátami mutovateľnými optimistickým toggle-om potrebuje
+  `useStaleResponseGuard` (vzor `NedostupneSection.load()`, fix 2d06fc5;
+  RED dôkaz da5b93e — unit test pod StrictMode). Na dev CI prechádzalo,
+  padlo až pod pomalším main behom. Pri „optimistický zápis + refetch bez
+  guardu" over TÚTO triedu pred hľadaním chyby v teste; sesterský tvar
+  (refetch po akcii) je #535.
+
 - **`test:integration` a `e2e` sa lokálne na dev1 default NESPÚŠŤAJÚ (issue
   351)** — bežia bezpodmienečne v `ci.yml` (`.claude/rules/ci.md`), lokálne
   ostáva len `pnpm gates:local` (typecheck+lint+unit testy). Spusti tú

--- a/apps/web/src/components/NedostupneSection.resolved.test.tsx
+++ b/apps/web/src/components/NedostupneSection.resolved.test.tsx
@@ -7,15 +7,16 @@ import type { NedostupneList } from "../nedostupneApi.js";
 // issue 531: testy checkboxu „vyriešené" — vyčlenené z `NedostupneSection.test.tsx`
 // (eslint `max-lines: 400`), rovnaký split vzor ako `orders-http*.integration.test.ts`.
 
-const { fetchNedostupneList, setNedostupneResolved } = vi.hoisted(() => ({
+const { fetchNedostupneList, setNedostupneResolved, removeReplacementLink } = vi.hoisted(() => ({
   fetchNedostupneList: vi.fn(),
   setNedostupneResolved: vi.fn(),
+  removeReplacementLink: vi.fn(),
 }));
 
 // `NedostupneUnauthorizedError` ostáva SKUTOČNÁ trieda (`instanceof` v hooku).
 vi.mock("../nedostupneApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../nedostupneApi.js")>();
-  return { ...actual, fetchNedostupneList, setNedostupneResolved };
+  return { ...actual, fetchNedostupneList, setNedostupneResolved, removeReplacementLink };
 });
 
 const GROUP = {
@@ -162,6 +163,57 @@ it("zastaraná odpoveď zoznamu (StrictMode duplicitný GET) nesmie prepísať o
 
   // Musí ostať ODZNAČENÉ — zastaraná odpoveď nesmie prepísať optimistickú zmenu.
   expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(false);
+});
+
+it("akciou-spustený refetch nesmie prepísať optimistické označenie vyriešené (issue 535)", async () => {
+  // issue 535 (sesterský race k #536): akcia (tu odstránenie odkazu náhrady)
+  // po úspechu volá `load()` (plný GET zoznamu). Kým GET letí, obsluha prepne
+  // checkbox „vyriešené" — optimistický `setList`, ŽIADNY `guard.begin()` (nie
+  // je to load). GET tak ostáva NAJNOVŠÍ load (prejde `isLatest`) a jeho
+  // snímka `resolved` (odfotená PRED tým, ako toggle PUT commitol) by
+  // optimistickú zmenu prepísala späť. Guard (load-vs-load) to nechytí — je to
+  // load-vs-optimistický-zápis, inú os rieši `reconcileResolved`.
+  const LINK = { id: "link-1", url: "https://example.sk/nahrada", createdAt: "2026-08-01T00:00:00.000Z" };
+  const WITH_LINK: NedostupneList = { groups: [{ ...GROUP, replacementLinks: [LINK] }], bccMissing: false, mailNotConfigured: false };
+  // GET#2 (refetch po odstránení odkazu) je ZASTARANÝ: odkaz už preč, ale
+  // `resolved=false` je snímka spred toggle-u.
+  const STALE: NedostupneList = { groups: [{ ...GROUP, replacementLinks: [], resolved: false }], bccMissing: false, mailNotConfigured: false };
+
+  let resolveRefetch!: (value: NedostupneList) => void;
+  const refetch = new Promise<NedostupneList>((r) => {
+    resolveRefetch = r;
+  });
+  fetchNedostupneList.mockResolvedValueOnce(WITH_LINK).mockReturnValueOnce(refetch);
+  removeReplacementLink.mockResolvedValue(undefined);
+  setNedostupneResolved.mockResolvedValue(undefined);
+
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId(CHECKBOX);
+
+  // Akcia: odstráň odkaz náhrady → jej `.then(load)` spustí GET#2 (zdržaný).
+  fireEvent.click(screen.getByTestId(`nedostupne-replacement-link-remove-${LINK.id}`));
+  await waitFor(() => {
+    expect(fetchNedostupneList).toHaveBeenCalledTimes(2);
+  });
+
+  // Počas letu GET#2 obsluha OZNAČÍ „vyriešené" — optimisticky HNEĎ zaškrtnuté.
+  fireEvent.click(screen.getByTestId<HTMLInputElement>(CHECKBOX));
+  expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(true);
+  await waitFor(() => {
+    expect(setNedostupneResolved).toHaveBeenCalledWith("40237/L", true);
+  });
+
+  // Doruč ZASTARANÝ refetch (resolved=false) a počkaj, kým ho komponent CELÝ
+  // spracuje — deterministicky, nie retrying `waitFor(false)` (ten by prešiel
+  // na pred-klobber kontrole aj proti rozbitému kódu, `.claude/rules/testing.md`).
+  await act(async () => {
+    resolveRefetch(STALE);
+    await refetch;
+    await Promise.resolve();
+  });
+
+  // Musí ostať ZAŠKRTNUTÉ — akciou-spustený refetch nesmie prepísať optimistickú zmenu.
+  expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(true);
 });
 
 it("rola citanie vidí checkbox, ale nesmie ho prepnúť (disabled)", async () => {

--- a/apps/web/src/components/NedostupneSection.resolved.test.tsx
+++ b/apps/web/src/components/NedostupneSection.resolved.test.tsx
@@ -7,16 +7,17 @@ import type { NedostupneList } from "../nedostupneApi.js";
 // issue 531: testy checkboxu „vyriešené" — vyčlenené z `NedostupneSection.test.tsx`
 // (eslint `max-lines: 400`), rovnaký split vzor ako `orders-http*.integration.test.ts`.
 
-const { fetchNedostupneList, setNedostupneResolved, removeReplacementLink } = vi.hoisted(() => ({
+const { fetchNedostupneList, setNedostupneResolved, removeReplacementLink, addReplacementLink } = vi.hoisted(() => ({
   fetchNedostupneList: vi.fn(),
   setNedostupneResolved: vi.fn(),
   removeReplacementLink: vi.fn(),
+  addReplacementLink: vi.fn(),
 }));
 
 // `NedostupneUnauthorizedError` ostáva SKUTOČNÁ trieda (`instanceof` v hooku).
 vi.mock("../nedostupneApi.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../nedostupneApi.js")>();
-  return { ...actual, fetchNedostupneList, setNedostupneResolved, removeReplacementLink };
+  return { ...actual, fetchNedostupneList, setNedostupneResolved, removeReplacementLink, addReplacementLink };
 });
 
 const GROUP = {
@@ -214,6 +215,58 @@ it("akciou-spustený refetch nesmie prepísať optimistické označenie vyrieše
 
   // Musí ostať ZAŠKRTNUTÉ — akciou-spustený refetch nesmie prepísať optimistickú zmenu.
   expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(true);
+});
+
+it("po commitnutom zápise ochráni JEDEN zastaraný load, potom ustúpi serveru (issue 535 — ohraničená životnosť)", async () => {
+  // Code review issue 535: „drž optimistickú hodnotu, kým sa server nezhodne" by
+  // po ÚSPEŠNOM PUT maskovalo súbežnú CUDZIU zmenu toho istého variantu
+  // donekonečna. Ohraničenie: commitnutý záznam ochráni JEDEN zastaraný in-flight
+  // load a zmaže sa → ďalší load už serveru ustúpi (skutočná externá zmena vyhrá).
+  const LINK = { id: "link-1", url: "https://example.sk/nahrada", createdAt: "2026-08-01T00:00:00.000Z" };
+  const WITH_LINK: NedostupneList = { groups: [{ ...GROUP, replacementLinks: [LINK] }], bccMissing: false, mailNotConfigured: false };
+  const SERVER_FALSE: NedostupneList = { groups: [{ ...GROUP, replacementLinks: [], resolved: false }], bccMissing: false, mailNotConfigured: false };
+
+  fetchNedostupneList
+    .mockResolvedValueOnce(WITH_LINK) // mount
+    .mockResolvedValueOnce(SERVER_FALSE) // GET po removeLink — zastaraný/externý
+    .mockResolvedValueOnce(SERVER_FALSE); // GET po addLink — externá zmena teraz vyhrá
+  removeReplacementLink.mockResolvedValue(undefined);
+  addReplacementLink.mockResolvedValue({ ...LINK, id: "link-2" });
+  setNedostupneResolved.mockResolvedValue(undefined);
+
+  render(<NedostupneSection role="manazer" onSessionExpired={vi.fn()} />);
+  await screen.findByTestId(CHECKBOX);
+
+  // Označ „vyriešené" a počkaj, kým PUT prejde (commitne záznam).
+  fireEvent.click(screen.getByTestId<HTMLInputElement>(CHECKBOX));
+  await waitFor(() => {
+    expect(setNedostupneResolved).toHaveBeenCalledWith("40237/L", true);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  // Akcia 1 (removeLink) → GET vráti resolved=false. Commitnutý záznam ochráni
+  // TENTO jeden zastaraný load — checkbox ostáva zaškrtnutý.
+  fireEvent.click(screen.getByTestId(`nedostupne-replacement-link-remove-${LINK.id}`));
+  await waitFor(() => {
+    expect(fetchNedostupneList).toHaveBeenCalledTimes(2);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(true);
+  });
+
+  // Akcia 2 (addLink) → GET opäť resolved=false. Záznam už zmazaný po akcii 1,
+  // takže server (externá zmena) teraz vyhrá — checkbox sa odznačí.
+  fireEvent.change(screen.getByTestId(`nedostupne-replacement-link-input-40237/L`), { target: { value: "https://example.sk/dalsia" } });
+  fireEvent.click(screen.getByTestId(`nedostupne-replacement-link-add-40237/L`));
+  await waitFor(() => {
+    expect(fetchNedostupneList).toHaveBeenCalledTimes(3);
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId<HTMLInputElement>(CHECKBOX).checked).toBe(false);
+  });
 });
 
 it("rola citanie vidí checkbox, ale nesmie ho prepnúť (disabled)", async () => {

--- a/apps/web/src/components/NedostupneSection.tsx
+++ b/apps/web/src/components/NedostupneSection.tsx
@@ -71,7 +71,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
   // issue 531: ručné označenie „vyriešené" — stav + optimistický toggle žije vo
   // vlastnom hooku (eslint `max-lines`), rovnaká „lift do hooku" disciplína ako
   // `useLoadMore`/`useStaleResponseGuard`.
-  const { resolvedBusy, toggleResolved } = useNedostupneResolved({ setList, setActionError, onSessionExpired });
+  const { resolvedBusy, toggleResolved, reconcileResolved } = useNedostupneResolved({ setList, setActionError, onSessionExpired });
   // issue 251/523: stale-response guard — pod `<StrictMode>` sa mount `load()`
   // spustí dvakrát; pomalší duplicitný GET zoznamu inak doletí AŽ PO
   // optimistickom (od)označení checkboxu „vyriešené" (issue 531, žiadny refetch)
@@ -83,7 +83,9 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
     fetchNedostupneList()
       .then((l) => {
         if (!guard.isLatest(seq)) return;
-        setList(l);
+        // issue 535: re-aplikuj nevyrovnané optimistické (od)označenia — akciou-
+        // spustený refetch môže niesť snímku spred práve prebiehajúceho toggle PUT.
+        setList(reconcileResolved(l));
         setLoaded(true);
       })
       .catch((err: unknown) => {
@@ -95,7 +97,7 @@ export function NedostupneSection({ role, onSessionExpired }: { readonly role: M
         }
         setError("Nedostupné tovary sa nepodarilo načítať.");
       });
-  }, [guard, onSessionExpired]);
+  }, [guard, reconcileResolved, onSessionExpired]);
 
   useEffect(load, [load]);
 

--- a/apps/web/src/useNedostupneResolved.ts
+++ b/apps/web/src/useNedostupneResolved.ts
@@ -20,15 +20,16 @@ export function useNedostupneResolved(deps: {
   // Prebiehajúci zápis pre daný variant — checkbox je počas neho `disabled`,
   // aby dvojklik nespustil dva protichodné zápisy.
   const [resolvedBusy, setResolvedBusy] = useState("");
-  // issue 535: nevyrovnané optimistické (od)označenia — `variantCode` → želaná
-  // hodnota `resolved`. Akciou-spustený `load()` (`saveNote`/`addLink`/…) vráti
-  // serverovú snímku odfotenú PRED tým, ako tu prebiehajúci toggle PUT commitol;
-  // `reconcileResolved` (volaný v `load().then` pred `setList`) na ňu tieto
-  // optimistické hodnoty re-aplikuje, aby ju nezastaraná snímka neprepísala späť.
-  // `useStaleResponseGuard` (PR #536) rieši INÚ os (load-vs-load), túto (load-
-  // vs-optimistický-zápis) nepokrýva. Ref, nie state — číta ho `.then` mikrotaska
-  // a nesmie refirovať `useEffect(load)` (issue 251/254 „latest ref" trieda).
-  const pendingResolvedRef = useRef<Map<string, boolean>>(new Map());
+  // issue 535: nevyrovnané optimistické (od)označenia — `variantCode` → { želaná
+  // hodnota `resolved`, či už PUT commitol (`committed`) }. Akciou-spustený
+  // `load()` (`saveNote`/`addLink`/…) vráti serverovú snímku odfotenú PRED tým,
+  // ako tu prebiehajúci toggle PUT commitol; `reconcileResolved` (volaný v
+  // `load().then` pred `setList`) na ňu tieto optimistické hodnoty re-aplikuje,
+  // aby ju nezastaraná snímka neprepísala späť. `useStaleResponseGuard` (PR #536)
+  // rieši INÚ os (load-vs-load), túto (load-vs-optimistický-zápis) nepokrýva. Ref,
+  // nie state — číta ho `.then` mikrotaska a nesmie refirovať `useEffect(load)`
+  // (issue 251/254 „latest ref" trieda).
+  const pendingResolvedRef = useRef<Map<string, { readonly desired: boolean; committed: boolean }>>(new Map());
 
   const setGroupResolved = useCallback(
     (variantCode: string, resolved: boolean) => {
@@ -43,9 +44,18 @@ export function useNedostupneResolved(deps: {
       setResolvedBusy(variantCode);
       // Zaznač želanú hodnotu ešte pred PUT — kým ju server nepotvrdí, drží ju
       // `reconcileResolved` proti zastaranej snímke akciou-spusteného loadu.
-      pendingResolvedRef.current.set(variantCode, resolved);
+      pendingResolvedRef.current.set(variantCode, { desired: resolved, committed: false });
       setGroupResolved(variantCode, resolved);
       setNedostupneResolved(variantCode, resolved)
+        .then(() => {
+          // Zápis prešiel — server má odteraz našu hodnotu. Označ záznam ako
+          // commitnutý (LEN ak ho medzitým neprebil novší toggle iného smeru),
+          // aby `reconcileResolved` po commite ešte ochránil zastaranú snímku
+          // JEDNÉHO in-flight loadu, no ďalej už serveru ustúpil — inak by
+          // záznam maskoval prípadnú súbežnú CUDZIU zmenu donekonečna.
+          const entry = pendingResolvedRef.current.get(variantCode);
+          if (entry !== undefined && entry.desired === resolved) entry.committed = true;
+        })
         .catch((err: unknown) => {
           // Vráť optimistickú zmenu späť — server je zdroj pravdy. Zahoď aj
           // nevyrovnaný záznam, inak by `reconcileResolved` re-aplikoval hodnotu,
@@ -59,29 +69,39 @@ export function useNedostupneResolved(deps: {
           setActionError(err instanceof Error ? err.message : "Označenie sa nepodarilo uložiť.");
         })
         .finally(() => {
-          setResolvedBusy("");
+          // Vyčisti busy LEN pre TENTO variant — súbežný toggle iného variantu
+          // medzitým prepísal `resolvedBusy` a jeho vlastný PUT ešte beží (jediný
+          // skalár, code review issue 535). Rovnaký funkčný-clear vzor ako pri
+          // busy-guard pároch inde v appke.
+          setResolvedBusy((current) => (current === variantCode ? "" : current));
         });
     },
     [setGroupResolved, setActionError, onSessionExpired],
   );
 
   // issue 535: re-aplikuj nevyrovnané optimistické (od)označenia na serverovú
-  // odpoveď loadu. Self-cleaning: keď sa server so želanou hodnotou ZHODUJE,
-  // zápis je premietnutý → záznam sa zmaže (a použije sa server); keď sa
-  // NEzhoduje (snímka je zastaraná, predchádza náš zápis) → drží sa optimistická
-  // hodnota. Stabilná identita (`useCallback([])`, číta ref) — rovnaký dôvod ako
+  // odpoveď loadu. Self-cleaning s ohraničenou životnosťou:
+  //  • server sa so želanou hodnotou ZHODUJE → zápis je premietnutý, záznam zmaž
+  //    (a použi server);
+  //  • NEZHODUJE sa a PUT ešte NEcommitol → snímka predchádza náš zápis, drž
+  //    optimistickú hodnotu (a záznam nechaj);
+  //  • NEZHODUJE sa a PUT UŽ commitol → ochráň JEDEN zastaraný in-flight load
+  //    (aplikuj želanú hodnotu) a záznam zmaž — ďalší load už serveru ustúpi,
+  //    takže súbežná CUDZIA zmena toho istého variantu sa nemaskuje donekonečna.
+  // Stabilná identita (`useCallback([])`, číta ref) — rovnaký dôvod ako
   // `useStaleResponseGuard`: nesmie rozbiť `load` memoizáciu / refirovať efekt.
   const reconcileResolved = useCallback((list: NedostupneList): NedostupneList => {
     const pending = pendingResolvedRef.current;
     if (pending.size === 0) return list;
     const groups = list.groups.map((g) => {
-      const desired = pending.get(g.variantCode);
-      if (desired === undefined) return g;
-      if (g.resolved === desired) {
+      const entry = pending.get(g.variantCode);
+      if (entry === undefined) return g;
+      if (g.resolved === entry.desired) {
         pending.delete(g.variantCode);
         return g;
       }
-      return { ...g, resolved: desired };
+      if (entry.committed) pending.delete(g.variantCode);
+      return { ...g, resolved: entry.desired };
     });
     return { ...list, groups };
   }, []);

--- a/apps/web/src/useNedostupneResolved.ts
+++ b/apps/web/src/useNedostupneResolved.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from "react";
+import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { NedostupneUnauthorizedError, setNedostupneResolved, type NedostupneList } from "./nedostupneApi.js";
 
 // issue 531: ručné označenie „vyriešené" pri karte produktu — vyčlenené z
@@ -11,11 +11,24 @@ export function useNedostupneResolved(deps: {
   readonly setList: Dispatch<SetStateAction<NedostupneList | null>>;
   readonly setActionError: (message: string) => void;
   readonly onSessionExpired: () => void;
-}): { readonly resolvedBusy: string; readonly toggleResolved: (variantCode: string, resolved: boolean) => void } {
+}): {
+  readonly resolvedBusy: string;
+  readonly toggleResolved: (variantCode: string, resolved: boolean) => void;
+  readonly reconcileResolved: (list: NedostupneList) => NedostupneList;
+} {
   const { setList, setActionError, onSessionExpired } = deps;
   // Prebiehajúci zápis pre daný variant — checkbox je počas neho `disabled`,
   // aby dvojklik nespustil dva protichodné zápisy.
   const [resolvedBusy, setResolvedBusy] = useState("");
+  // issue 535: nevyrovnané optimistické (od)označenia — `variantCode` → želaná
+  // hodnota `resolved`. Akciou-spustený `load()` (`saveNote`/`addLink`/…) vráti
+  // serverovú snímku odfotenú PRED tým, ako tu prebiehajúci toggle PUT commitol;
+  // `reconcileResolved` (volaný v `load().then` pred `setList`) na ňu tieto
+  // optimistické hodnoty re-aplikuje, aby ju nezastaraná snímka neprepísala späť.
+  // `useStaleResponseGuard` (PR #536) rieši INÚ os (load-vs-load), túto (load-
+  // vs-optimistický-zápis) nepokrýva. Ref, nie state — číta ho `.then` mikrotaska
+  // a nesmie refirovať `useEffect(load)` (issue 251/254 „latest ref" trieda).
+  const pendingResolvedRef = useRef<Map<string, boolean>>(new Map());
 
   const setGroupResolved = useCallback(
     (variantCode: string, resolved: boolean) => {
@@ -28,10 +41,16 @@ export function useNedostupneResolved(deps: {
     (variantCode: string, resolved: boolean) => {
       setActionError("");
       setResolvedBusy(variantCode);
+      // Zaznač želanú hodnotu ešte pred PUT — kým ju server nepotvrdí, drží ju
+      // `reconcileResolved` proti zastaranej snímke akciou-spusteného loadu.
+      pendingResolvedRef.current.set(variantCode, resolved);
       setGroupResolved(variantCode, resolved);
       setNedostupneResolved(variantCode, resolved)
         .catch((err: unknown) => {
-          // Vráť optimistickú zmenu späť — server je zdroj pravdy.
+          // Vráť optimistickú zmenu späť — server je zdroj pravdy. Zahoď aj
+          // nevyrovnaný záznam, inak by `reconcileResolved` re-aplikoval hodnotu,
+          // ktorá sa neuložila.
+          pendingResolvedRef.current.delete(variantCode);
           setGroupResolved(variantCode, !resolved);
           if (err instanceof NedostupneUnauthorizedError) {
             onSessionExpired();
@@ -46,5 +65,26 @@ export function useNedostupneResolved(deps: {
     [setGroupResolved, setActionError, onSessionExpired],
   );
 
-  return { resolvedBusy, toggleResolved };
+  // issue 535: re-aplikuj nevyrovnané optimistické (od)označenia na serverovú
+  // odpoveď loadu. Self-cleaning: keď sa server so želanou hodnotou ZHODUJE,
+  // zápis je premietnutý → záznam sa zmaže (a použije sa server); keď sa
+  // NEzhoduje (snímka je zastaraná, predchádza náš zápis) → drží sa optimistická
+  // hodnota. Stabilná identita (`useCallback([])`, číta ref) — rovnaký dôvod ako
+  // `useStaleResponseGuard`: nesmie rozbiť `load` memoizáciu / refirovať efekt.
+  const reconcileResolved = useCallback((list: NedostupneList): NedostupneList => {
+    const pending = pendingResolvedRef.current;
+    if (pending.size === 0) return list;
+    const groups = list.groups.map((g) => {
+      const desired = pending.get(g.variantCode);
+      if (desired === undefined) return g;
+      if (g.resolved === desired) {
+        pending.delete(g.variantCode);
+        return g;
+      }
+      return { ...g, resolved: desired };
+    });
+    return { ...list, groups };
+  }, []);
+
+  return { resolvedBusy, toggleResolved, reconcileResolved };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.313",
+  "version": "0.3.0-dev.314",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.314",
+  "version": "0.3.0-dev.315",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Oprava latentného race v Nedostupných tovaroch (issue 535)

Akciou spustený refetch zoznamu (uloženie poznámky, pridanie/odobratie odkazu, potvrdenie odoslania) mohol prepísať optimistické (od)označenie checkboxu „vyriešené", ak GET letel súčasne s toggle PUT-om — server-snímka spred PUT-u prešla `isLatest` kontrolou a vrátila UI späť.

**Riešenie:** `reconcileResolved` — `useNedostupneResolved` eviduje pending/committed optimistické resolved hodnoty a `load()` ich pri prijatí odpovede znovu aplikuje na server-snímku. Životnosť záznamu ohraničená committed-flagom; busy skalár sa čistí funkčne (review-fixy v 93c22a7).

- RED 24c39ab (deterministická reprodukcia clobberu) → GREEN fb00c90; review-fixy 93c22a7; playbook 4e4ff0a.
- Sesterské predošlé opravy: PR #536 riešil load-vs-load; toto rieši load-vs-optimistický-toggle.
- `pnpm gates:local` zelené (789 web / 1038 api unit), dev CI 33571433906 success.
- Verzia 0.3.0-dev.315. Issue 535 ostáva otvorené — zavriem ručne po naživo overení.
