### PR TITLE
Mobil: prepis hlasovej poznámky v Úlohách na dnes tečie vodorovne (issue 538)

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -1576,3 +1576,36 @@ paths:
   .scrollIntoView === "function"`) je ZLÁ cesta — `no-unnecessary-condition`
   ho zhodí (DOM lib typuje metódu ako vždy-prítomnú); radšej čistý
   `el?.scrollIntoView(...)` v kóde + polyfill v teste.
+- **`flex-wrap` predvolene `nowrap` + JEDEN flexibilný prvok (`flex:1 1
+  auto; min-width:0`) medzi VIACERÝMI pevnými (`flex:0 0 auto`) súrodencami
+  na ÚZKOM riadku kolabuje na 0px šírku, nie len na "menšiu" šírku — a s
+  `overflow-wrap: break-word` sa text potom láme PO JEDNOM ZNAKU.** Issue
+  538 (`.uloha-row` v "Úlohy na dnes"): checkbox + autor + audio ovládanie
+  (▶+dĺžka+🗑) + akcie (✏️😊🗑) sú všetky `flex:0 0 auto`, `.uloha-text` je
+  jediný `flex:1 1 auto`. Na mobile (rail-mód sidebaru pod ~640px,
+  `.ulohy-panel` len ~270px) súčet pevných súrodencov PRIBLÍŽI/PREKROČÍ
+  dostupnú šírku, takže `.uloha-text` (s explicitným `min-width:0`, ktorý
+  DOVOĽUJE zmrštenie až na 0) dostane CELÝ deficit — nameraná šírka 0px
+  (nie napr. 40px), a keďže žiadne slovo sa do 0px stĺpca nezmestí,
+  `overflow-wrap: break-word` zalomí KAŽDÝ ZNAK zvlášť (naživo overené
+  throwaway Playwright: text-height 291px pre 20-znakový zástupný text
+  "🎤 Hlasová poznámka"). Toto je INÝ tvar issue 105's "flex-basis
+  rozhoduje o zalomení" pasce — tam šlo o RIADOK zalomenia jednej bunky
+  vnútri tabuľky s `flex-wrap:wrap` na rodičovi; tu rodič `flex-wrap` VÔBEC
+  NEMÁ (predvolené `nowrap`), takže sa nezalomí NIČ — celý deficit prevezme
+  jediný `min-width:0` prvok. Fix (mobilný `@media (max-width: 36rem)`
+  blok, `app.css`): `.uloha-row { flex-wrap: wrap; }` necháva pevné
+  súrodence, čo sa nezmestia, prirodzene skočiť na ĎALŠÍ riadok (rovnaký
+  princíp ako `.ord-supplier-assign`, issue 63), + `.uloha-text { min-width:
+  10rem; }` mu garantuje CELÝ vlastný riadok namiesto súperenia o
+  zvyškovú (0px) šírku. Overovacia technika (rovnaká ako issue 105/291):
+  throwaway Playwright proti lokálnemu dev serveru, reálny fake-mikrofón
+  cyklus (`--use-fake-device-for-media-stream`) presne ako
+  `daily-tasks.spec.ts`, `getBoundingClientRect()` na `.uloha-text` PRED aj
+  PO kandidátnej CSS zmene (`page.addStyleTag`). **Test na KAŽDÝ ĎALŠÍ
+  `display:flex` riadok v tejto appke s VIACERÝMI `flex:0 0 auto`
+  súrodencami a JEDNÝM `min-width:0` flexibilným prvkom, VYKRESLENÝ na
+  úzkom (mobilnom alebo zbalenom-sidebar rail) kontexte:** má rodič
+  `flex-wrap`? Ak nie, over reálne nameranú šírku toho flexibilného prvku
+  na najužšej cieľovej šírke — 0px (nie len "menej") je ľahko prehliadnuteľné
+  v CSS-only review, viditeľné len v reálnom render.

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2889,6 +2889,30 @@ a.upozornenie-title:hover {
   .ulohy-add-row .emoji-picker {
     display: none;
   }
+  /* issue 538: `.uloha-row` je `display:flex` bez `flex-wrap` (nowrap), takže
+     VŠETCI súrodenci (checkbox + autor + audio ovládanie + akcie, všetky
+     `flex:0 0 auto`) musia sedieť na JEDNOM riadku. Na mobile (rail-mód
+     sidebaru, `Sidebar.tsx`, sa zapína automaticky pod ~640px) je
+     `.ulohy-panel` len ~270px široký — súčet týchto pevných súrodencov sa
+     priblíži/prekročí túto šírku. Keďže `.uloha-text` je JEDINÝ flexibilný
+     prvok (flex:1 1 auto; min-width:0), celý deficit ide naň — nameraná
+     šírka 0px, a s `overflow-wrap: break-word` sa text zalomí PO JEDNOM
+     ZNAKU (žiadne slovo sa už do 0px stĺpca nezmestí). Fix: `flex-wrap:
+     wrap` necháva pevných súrodencov, čo sa na prvý riadok nezmestia,
+     prirodzene zalomiť na ĎALŠÍ riadok (rovnaký princíp ako `.ord-supplier-
+     assign`, issue 63), a `.uloha-text`ov `min-width: 10rem` mu garantuje
+     CELÝ vlastný riadok namiesto súperenia o zvyškovú (0px) šírku so
+     susedmi. Naživo overené (throwaway Playwright proti lokálnemu dev
+     serveru, 360px aj 390px, s audio riadkom aj bez neho, krátkym aj
+     180-znakovým textom): text sa zalamuje normálne po slovách, žiadne
+     vodorovné pretečenie (`scrollWidth === innerWidth`), edit-režim sa
+     zmestí bez kolízie. Desktop (mimo tejto media query) nezmenený. */
+  .uloha-row {
+    flex-wrap: wrap;
+  }
+  .uloha-text {
+    min-width: 10rem;
+  }
 }
 
 /* ---------------- POZNÁMKY (issue 437) ----------------

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -170,3 +170,53 @@ test("nahranie hlasovej poznámky (audio-only fallback): nahrať → uložiť �
 
   expect(chyby).toEqual([]);
 });
+
+// issue 538: na mobilnom viewporte (~360-430px) sa text prepisu hlasovej
+// poznámky (aj bežný dlhší text) vykresľoval PO JEDNOM ZNAKU pod seba —
+// `.uloha-row`ov jediný flexibilný prvok `.uloha-text` (flex:1 1 auto;
+// min-width:0) dostal celý deficit, keď pevní súrodenci (autor + audio
+// ovládanie + akcie) na úzkom `.ulohy-panel`i (rail-mód sidebaru pod
+// ~640px) takmer/úplne zaplnili šírku riadku — nameraná šírka 0px
+// (`.claude/rules/daily-tasks.md`). Test meria SKUTOČNE vykreslenú šírku
+// textového elementu v reálnom 390px viewporte — musí prejsť len keď je
+// text zalomený NORMÁLNE (po slovách), nie keď skolaboval na ~1 znak.
+test("mobil (390px): prepis dlhšieho textu úlohy sa zalamuje po slovách, nie po znakoch", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=ulohy");
+  await page.getByLabel("E-mail").fill(E2E_ULOHY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Úlohy na dnes" })).toBeVisible();
+
+  const dlhyText = "Skúška mikrofónu, skúšame či to funguje a či sa text pekne zalomí na viac riadkov.";
+  const novyVstup = page.getByTestId("uloha-new-input");
+  await novyVstup.fill(dlhyText);
+  await novyVstup.press("Enter");
+
+  const riadok = page.locator(".uloha-row").filter({ hasText: "Skúška mikrofónu" });
+  await expect(riadok).toBeVisible();
+
+  const textWidth = await riadok.locator(".uloha-text").evaluate((el) => el.getBoundingClientRect().width);
+  // Jeden vykreslený znak pri tomto písme je cca 6-10px širokom (kolabovaný
+  // stĺpec); normálne zalomená šírka na 390px okne je ~200-260px. 100px je
+  // bezpečne nad kolapsom a bezpečne pod normálnou šírkou.
+  expect(textWidth).toBeGreaterThan(100);
+
+  // Riadok ostáva funkčný — ovládacie tlačidlo je stále viditeľné a klikateľné.
+  await expect(riadok.getByRole("button", { name: "Upraviť text" })).toBeVisible();
+
+  // Upratanie po teste.
+  await riadok.getByRole("button", { name: /^Odstrániť úlohu/ }).click();
+  await expect(page.locator(".uloha-row").filter({ hasText: "Skúška mikrofónu" })).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.316",
+  "version": "0.3.0-dev.317",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.315",
+  "version": "0.3.0-dev.316",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Mobil: prepis hlasovej poznámky v „Úlohy na dnes" sa lámal po jednom znaku (issue 538)

**Príčina:** `.uloha-row` je `display:flex` bez `flex-wrap`; na mobile (rail-mód, panel ~270px) pevní súrodenci (checkbox, autor, audio ovládanie, akcie) vyčerpajú šírku riadku a jediný flexibilný prvok `.uloha-text` (min-width:0) skolabuje na 0px — s `overflow-wrap: break-word` sa text zalomí po jednom znaku.

**Oprava (len v existujúcej `@media (max-width: 36rem)`):** `.uloha-row { flex-wrap: wrap; }` + `.uloha-text { min-width: 10rem; }` — text dostane vlastný riadok a tečie normálne po slovách. Desktop nezmenený.

**Testy:** RED c2e3a33 (nový Playwright e2e meria reálnu šírku `.uloha-text` na 390px viewporte — pred opravou 84px) → GREEN 42c0b9c. `pnpm gates:local` zelené (1038 api + 789 web), plný e2e beh 72/72.

Verzia: 0.3.0-dev.317. Ticket 538 sa zavrie ručne po nasadení a naživo overení — issue 538 ostáva otvorené do overenia.
