### PR TITLE
Mobil: add-riadok Úloh na dnes pri rozbalenom sidebari sa zalomí namiesto pretečenia (follow-up issue 538)

### DIFF
--- a/.claude/rules/daily-tasks.md
+++ b/.claude/rules/daily-tasks.md
@@ -66,6 +66,30 @@ paths:
   skryje emoji na mobile (mikrofón ho nahrádza), na desktope sú oba. Žiadna JS
   detekcia šírky.
 
+- **Issue 538's fix opravil len RIADKY zoznamu (`.uloha-row`) — PRIDÁVACÍ
+  riadok (`.ulohy-add-row`) mal presne tú istú triedu chyby, len s iným
+  spúšťačom (follow-up k issue 538, žiadny nový issue — do-now cleanup).**
+  `.ulohy-add-row` je tiež `display:flex` bez `flex-wrap`, a vstup
+  (`min-width:8rem`=128px) je PEVNÝ, nie odvodený od `flex-basis:0%` ako
+  `.uloha-row`ov flexibilný text. Rail-mód (predvolený stav appky pod
+  ~640px, `Sidebar.tsx`) sa nepretečie — dostupná šírka `<main>` je tam
+  dosť veľká. Až keď používateľ sidebar RUČNE ROZBALÍ na úzkom (390px)
+  viewporte (`--fs-sidebar-width:250px` namiesto `--fs-sidebar-rail-
+  width:72px`), dostupná šírka `<main>` klesne pod vstupov pevný
+  min-width a riadok preteká — `flex-wrap:wrap` SAMO OSEBE nestačí, lebo
+  vstup PRETEČIE aj SÁM na vlastnom riadku. Fix (rovnaký `@media
+  (max-width: 36rem)` blok): `.ulohy-add-row { flex-wrap: wrap }` +
+  `.ulohy-add-row input { min-width: min(8rem, 100%) }` (`min()`-wrapper
+  vzor ako `.claude/rules/frontend-design.md`'s issue 382 grid entry —
+  nad 8rem kontajnerovej šírky sa správa identicky, pod ňou sa zmrští
+  namiesto pretečenia). **Test na KAŽDÝ ĎALŠÍ nález v TEJTO obrazovke:**
+  keď sa opravuje pretečenie JEDNÉHO flex riadku (`.uloha-row`/`.ulohy-
+  add-row`/budúci ďalší), skontroluj, či SUSEDNÝ riadok v tej istej
+  sekcii nemá TÚ ISTÚ triedu chyby s iným trigger-scenárom (rail vs.
+  rozbalený sidebar) — `.claude/rules/frontend-design.md`'s
+  `flex-basis`/`min-width` pasce sa opakujú naprieč appkou, aj v RÁMCI
+  jednej obrazovky.
+
 - **Testy:**
   - Web komponentové testy NEMAJÚ auto-cleanup (žiadne `globals: true`) — každý
     nový `*.test.tsx` MUSÍ `import { cleanup }` a volať ho v `afterEach`, inak sa

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2913,6 +2913,40 @@ a.upozornenie-title:hover {
   .uloha-text {
     min-width: 10rem;
   }
+  /* Follow-up k issue 538 (do-now cleanup, zlyhal bundling gate, žiadny
+     nový issue): rovnaký princíp, ale na PRIDÁVACOM riadku, nie riadkoch
+     zoznamu. `.ulohy-add-row` je tiež `display:flex` bez `flex-wrap`
+     (nowrap) — vstup (`flex:1 1 0%; min-width:8rem`=128px), `.uloha-mic-
+     btn` a "+ Pridať" (`.btn.good.sm`) musia sedieť na JEDNOM riadku.
+     `.ulohy-panel`ov `max-width:40rem` len obmedzuje HORNÚ hranicu — jeho
+     SKUTOČNÁ šírka je odvodená od `<main>`, ktorá závisí od sidebaru
+     (`--fs-sidebar-width:250px` rozbalený vs. `--fs-sidebar-rail-
+     width:72px` v rail-móde). V rail-móde (predvolený stav appky pod
+     ~640px) sa vstup+mikrofón+tlačidlo zmestia (390-72=318px), no keď
+     používateľ sidebar RUČNE ROZBALÍ na 390px viewporte, dostupná šírka
+     `<main>` klesne na ~140px (390-250, mínus `<main>`'s vlastný 2×24px
+     padding = 92px obsahovej šírky) a pridávací riadok preteká vodorovne
+     (naživo overené: `document.documentElement.scrollWidth` 502px pri
+     390px viewporte, oproti 390px v rail-móde — `.claude/rules/
+     daily-tasks.md`). `flex-wrap: wrap` samo osebe NESTAČÍ (na rozdiel od
+     `.uloha-row` vyššie) — vstupov PEVNÝ `min-width:8rem`=128px je väčší
+     než 92px dostupnej šírky, takže aj SAMOTNÝ na vlastnom riadku
+     pretečie (zmerané: `scrollWidth` klesol na 402px, presne
+     274px+128px). Fix: `flex-wrap: wrap` (mikrofón/tlačidlo skočia na
+     ďalší riadok, keď sa nezmestia) + vstupov `min-width: min(8rem,
+     100%)` (nikdy nevynúti vstup ŠIRŠÍ než 100% dostupnej šírky
+     kontajnera — nad 8rem kontajnerovej šírky sa správa identicky ako
+     predtým, pod ňou sa zmrští namiesto pretečenia; rovnaký `min()`-
+     wrapper vzor ako issue 382's `minmax(min(500px,100%),1fr)`). V rail-
+     móde/desktope, kde sa dnes všetko zmestí na jeden riadok bez zmeny
+     šírky, obe pravidlá nemenia nič (wrap/zmrštenie sa aktivujú len keď
+     je to skutočne potrebné). */
+  .ulohy-add-row {
+    flex-wrap: wrap;
+  }
+  .ulohy-add-row input {
+    min-width: min(8rem, 100%);
+  }
 }
 
 /* ---------------- POZNÁMKY (issue 437) ----------------

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -220,3 +220,46 @@ test("mobil (390px): prepis dlhšieho textu úlohy sa zalamuje po slovách, nie 
 
   expect(chyby).toEqual([]);
 });
+
+// Follow-up k issue 538: issue 538's fix (`.uloha-row { flex-wrap: wrap }`)
+// rieši pretečenie RIADKOV zoznamu, ale NIE pridávacieho riadku
+// (`.ulohy-add-row` — vstup + mikrofón + "+ Pridať"), ktorý zostáva
+// `display:flex` bez `flex-wrap`. Na 390px viewporte s MANUÁLNE
+// ROZBALENÝM sidebarom (250px, na rozdiel od predvoleného rail-módu
+// 72px pod ~640px) je dostupná šírka `<main>` príliš úzka, aby sa vstup +
+// mikrofón + tlačidlo zmestili na jeden riadok bez zalomenia — appka
+// pretečie vodorovne (`.claude/rules/daily-tasks.md`). Test meria
+// `document.documentElement.scrollWidth` proti `window.innerWidth` presne
+// v tomto scenári (rozbalený sidebar), rail-mód aj desktop ostávajú
+// nedotknuté (mimo tejto media query).
+test("mobil (390px) s rozbaleným sidebarom: pridávací riadok Úloh na dnes nepreteká vodorovne", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=ulohy");
+  await page.getByLabel("E-mail").fill(E2E_ULOHY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Úlohy na dnes" })).toBeVisible();
+
+  // Sidebar štartuje na 390px v rail-móde (predvolené pod ~640px) — ručne
+  // ho rozbaliť, presne scenár z issue 538's živého overenia.
+  const railToggle = page.getByTestId("sidebar-rail-toggle");
+  await railToggle.click();
+  await expect(page.locator(".sidebar.sidebar-rail")).toHaveCount(0);
+
+  const addRow = page.getByTestId("uloha-add-row");
+  await expect(addRow).toBeVisible();
+
+  const [scrollWidth, innerWidth] = await page.evaluate(() => [document.documentElement.scrollWidth, window.innerWidth]);
+  expect(scrollWidth).toBeLessThanOrEqual(innerWidth);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.317",
+  "version": "0.3.0-dev.318",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Mobil: add-riadok v „Úlohy na dnes" pretekal pri rozbalenom sidebari (follow-up k issue 538)

**Príčina:** `.ulohy-add-row` je `display:flex` bez `flex-wrap` a input má pevné `min-width: 8rem` (128 px). Pri ručne ROZBALENOM sidebari na 390 px viewporte (`--fs-sidebar-width: 250px`) ostáva na obsah ~92 px — input sa nezmestí a celý riadok (input + mikrofón + tlačidlo) pretečie do 502 px (`document.documentElement.scrollWidth`). V rail móde pretečenie nie je.

**Oprava (len v existujúcej `@media (max-width: 36rem)`):** `.ulohy-add-row { flex-wrap: wrap; }` + `.ulohy-add-row input { min-width: min(8rem, 100%); }` — rovnaký `min()`-strop vzor ako pri issue 382. Desktop aj rail mód nezmenené.

**Testy:** RED 675d515 (nový Playwright e2e: 390 px viewport + rozbalený sidebar, meria vodorovné pretečenie dokumentu — pred opravou scrollWidth 502) → GREEN a8635a7 (390 = 390). `pnpm gates:local` zelené, cielený e2e 4/4, plný beh 73/73. Nezávislé review 0 🔴 0 🟡 0 🔵.

Verzia: 0.3.0-dev.318. Pozorovanie aj dizajn sú zdokumentované komentármi na issue 538 (ticket je už zavretý a týmto PR sa NEOTVÁRA ani nezatvára — ide o do-now follow-up podľa follow-up gate, bez samostatného ticketu).
