### PR TITLE
Mobil: riadky Úloh na dnes sa pri rozbalenom sidebari zmrštia namiesto pretečenia (follow-up issue 538)

### DIFF
--- a/.claude/rules/daily-tasks.md
+++ b/.claude/rules/daily-tasks.md
@@ -90,6 +90,30 @@ paths:
   `flex-basis`/`min-width` pasce sa opakujú naprieč appkou, aj v RÁMCI
   jednej obrazovky.
 
+- **TRETÍ tvar tej istej triedy (do-now follow-up k issue 538, žiadny nový
+  issue, naživo nájdené na PROD 0.3.0-dev.318): `.uloha-text`ov VLASTNÝ fix
+  z issue 538 (`min-width: 10rem`, garantujúci mu vlastný riadok po
+  `.uloha-row { flex-wrap: wrap }`) je SÁM pevný `min-width` bez `min()`-
+  wrapperu — presne ten istý pattern, čo `.ulohy-add-row input` musel
+  dostať o riadok vyššie v druhom follow-upe.** V RAIL-móde (dostupná šírka
+  `.ulohy-panel`u > 160px) sa nič nemení. Až keď používateľ sidebar RUČNE
+  ROZBALÍ na 390px viewporte (`--fs-sidebar-width: 250px`), dostupná šírka
+  `<main>` klesne POD 160px a pevný `min-width` pretlačí RIADOK (nie len
+  pridávací riadok) mimo viewport (naživo namerané: `scrollWidth` 440px pri
+  390px okne). Fix: `.uloha-text { min-width: min(10rem, 100%); }` — nad
+  160px kontajnerovej šírky (rail-mód) sa správa identicky ako predtým, pod
+  ňou sa zmrští namiesto pretečenia; pôvodný issue 538 rail-mode test
+  (`textWidth > 100px`) ostáva zelený bez zmeny (floor v rail móde je
+  stále plných 160px). **Testovacia diera, prečo to CI/lokálny beh
+  nezachytili:** predošlý follow-up e2e test (druhý tvar vyššie) overoval
+  LEN `.ulohy-add-row` s PRÁZDNYM zoznamom úloh — nikdy nevytvoril žiadny
+  `.uloha-row`, takže nikdy nezacielil TENTO floor. **Pravidlo pre KAŽDÝ
+  ĎALŠÍ `min-width`/pevný floor pridaný v `@media (max-width: 36rem)`
+  bloku tejto obrazovky (`app.css`): VŽDY `min(<floor>, 100%)`, nikdy holý
+  `<floor>`** — a jeho e2e regresný test musí vytvoriť SKUTOČNÝ prvok
+  (riadok/vstup), na ktorý floor pôsobí, PRED rozbalením sidebaru, nielen
+  overiť prázdny/liveness stav obrazovky.
+
 - **Testy:**
   - Web komponentové testy NEMAJÚ auto-cleanup (žiadne `globals: true`) — každý
     nový `*.test.tsx` MUSÍ `import { cleanup }` a volať ho v `afterEach`, inak sa

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -2910,8 +2910,18 @@ a.upozornenie-title:hover {
   .uloha-row {
     flex-wrap: wrap;
   }
+  /* Do-now follow-up k issue 538 (žiadny nový issue): pevný `min-width:
+     10rem` (160px) garantuje `.uloha-text`u vlastný riadok v RAIL-móde
+     (dostupná šírka `.ulohy-panel`u >160px), ale pri RUČNE ROZBALENOM
+     sidebari (`--fs-sidebar-width: 250px`) klesne dostupná šírka pod
+     160px a pevný floor riadok pretlačí mimo viewport (naživo namerané:
+     scrollWidth 440px pri 390px okne). `min(10rem, 100%)`-wrapper
+     (rovnaký vzor ako `.ulohy-add-row input`, issue 538's druhý follow-up,
+     aj issue 382's grid `minmax(min(500px,100%),1fr)`): nad 160px
+     kontajnerovej šírky (rail-mód) sa správa identicky ako predtým, pod
+     ňou sa zmrští namiesto pretečenia. */
   .uloha-text {
-    min-width: 10rem;
+    min-width: min(10rem, 100%);
   }
   /* Follow-up k issue 538 (do-now cleanup, zlyhal bundling gate, žiadny
      nový issue): rovnaký princíp, ale na PRIDÁVACOM riadku, nie riadkoch

--- a/apps/web/tests/e2e/daily-tasks.spec.ts
+++ b/apps/web/tests/e2e/daily-tasks.spec.ts
@@ -263,3 +263,62 @@ test("mobil (390px) s rozbaleným sidebarom: pridávací riadok Úloh na dnes ne
 
   expect(chyby).toEqual([]);
 });
+
+// Do-now follow-up k issue 538 (ticket je UŽ ZAVRETÝ, žiadny nový issue —
+// nájdené naživo na PROD 0.3.0-dev.318, 390×844, ROZBALENÝ sidebar):
+// predošlý follow-up test vyššie overil len PRIDÁVACÍ riadok (`.ulohy-add-
+// row`) s PRÁZDNYM zoznamom — nikdy nevytvoril žiadny `.uloha-row`, takže
+// nikdy nezacielil `.uloha-text`ov pevný `min-width: 10rem` (160px) z
+// media query `@media (max-width: 36rem)` (`app.css`). Pri rozbalenom
+// sidebari (`--fs-sidebar-width: 250px`) je dostupná šírka `<main>` menšia
+// než 160px, takže floor pretlačí riadok mimo viewport (naživo namerané:
+// `scrollWidth` 440px pri 390px okne). Tento test PRIDÁ úlohu s dosť
+// dlhým textom PRED rozbalením sidebaru (v predvolenom rail-móde sa
+// zmestí bez problémov), potom rozbalí sidebar a overí, že žiadny riadok
+// zoznamu (nielen pridávací riadok) nepretečie vodorovne — presne scenár
+// z majiteľovho naživo nálezu.
+test("mobil (390px) s rozbaleným sidebarom: riadok zoznamu Úloh na dnes nepreteká vodorovne", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const chyby: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error" || m.type() === "warning") chyby.push(m.text());
+  });
+  page.on("pageerror", (e) => {
+    chyby.push(e.message);
+  });
+
+  await page.goto("/?tab=ulohy");
+  await page.getByLabel("E-mail").fill(E2E_ULOHY_EMAIL);
+  await page.getByLabel("Heslo").fill(E2E_HESLO);
+  await page.getByRole("button", { name: "Prihlásiť sa" }).click();
+  await expect(page.getByRole("heading", { name: "Úlohy na dnes" })).toBeVisible();
+
+  // Pridať úlohu s dosť dlhým textom — v predvolenom rail-móde (72px
+  // sidebar) sa pridávací riadok zmestí bez problémov (existujúci fix,
+  // predošlý test vyššie).
+  const dlhyText = "Skontrolovať sklad a objednať chýbajúci tovar od dodávateľa do konca týždňa";
+  const novyVstup = page.getByTestId("uloha-new-input");
+  await novyVstup.fill(dlhyText);
+  await novyVstup.press("Enter");
+
+  const riadok = page.locator(".uloha-row").filter({ hasText: "Skontrolovať sklad" });
+  await expect(riadok).toBeVisible();
+
+  // Sidebar štartuje na 390px v rail-móde (predvolené pod ~640px) — ručne
+  // ho rozbaliť, presne majiteľov naživo scenár.
+  const railToggle = page.getByTestId("sidebar-rail-toggle");
+  await railToggle.click();
+  await expect(page.locator(".sidebar.sidebar-rail")).toHaveCount(0);
+
+  await expect(riadok).toBeVisible();
+
+  const [scrollWidth, innerWidth] = await page.evaluate(() => [document.documentElement.scrollWidth, window.innerWidth]);
+  expect(scrollWidth).toBeLessThanOrEqual(innerWidth);
+
+  // Upratanie po teste.
+  await riadok.getByRole("button", { name: /^Odstrániť úlohu/ }).click();
+  await expect(page.locator(".uloha-row").filter({ hasText: "Skontrolovať sklad" })).toHaveCount(0);
+
+  expect(chyby).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.318",
+  "version": "0.3.0-dev.319",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## Mobil: riadky „Úlohy na dnes" pretekali pri rozbalenom sidebari cez min-width floor (follow-up k issue 538)

**Príčina:** oprava issue 538 dala `.uloha-text`u v `@media (max-width: 36rem)` pevný `min-width: 10rem` (160 px), aby text v rail-móde dostal vlastný riadok. Pri ručne ROZBALENOM sidebari (`--fs-sidebar-width: 250px`) na 390 px viewporte však klesne dostupná šírka pod 160 px a pevný floor pretlačí každý riadok úlohy mimo viewport — naživo na PROD v0.3.0-dev.318 namerané `scrollWidth` 440 px (viewport 390). Add-riadok bol opravený už v PR #540; toto je tretí (posledný nameraný) tvar tej istej triedy.

**Prečo to e2e nezachytilo:** add-row test z PR #540 bežal s PRÁZDNYM zoznamom úloh — žiadny `.uloha-row` neexistoval, takže `.uloha-text` floor sa nikdy nemeral.

**Oprava:** `min-width: min(10rem, 100%)` — rovnaký `min()`-strop vzor ako `.ulohy-add-row input` a issue 382. Nad 160 px kontajnera (rail-mód) správanie identické ako predtým; pod ňou sa text zmrští namiesto pretečenia.

**Testy:** RED 4a4da11 (nový e2e: 390 px + rozbalený sidebar + reálny riadok úlohy s dlhým textom, assert `scrollWidth <= 390` — bez opravy 440) → GREEN d9229fe. Pôvodný issue-538 rail-mód test bez regresie (floor v rail-móde ostáva 160 px). `pnpm gates:local` zelené (789 web testov), daily-tasks e2e 5/5, plný e2e 74/74. Nezávislé review 0 🔴 0 🟡 0 🔵.

Verzia: 0.3.0-dev.319. Ticket issue 538 je už zavretý a týmto PR sa NEOTVÁRA ani nezatvára — do-now follow-up podľa follow-up gate, bez samostatného ticketu; dôkazy sú komentármi na issue 538.
