### PR TITLE
docs: playbook uhrady.md + router + bump 0.3.0-dev.321 (po tickete 543)

### DIFF
--- a/.claude/rules/uhrady.md
+++ b/.claude/rules/uhrady.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "apps/api/src/modules/uhrady/**"
+  - "apps/api/src/http/uhrady-routes.ts"
+  - "apps/api/src/db/schema-uhrady.ts"
+  - "apps/web/src/components/UhradySection*"
+  - "apps/web/src/components/PaymentScanCard.tsx"
+  - "apps/web/src/uhradyApi.ts"
+  - "apps/web/tests/e2e/uhrady.spec.ts"
+---
+
+# SLAVOSPORT → Úhrady (#543 — skeny FA na úhradu + jednoriadkové poznámky)
+
+- **Účel:** miesto, kam Štěpán nahráva skeny papierových FA od dodávateľov, aby nezabudol uhradiť; po úhrade sken zmaže. Hore rýchle jednoriadkové poznámky (vzor daily-tasks, BEZ audia). Vidia to všetci prihlásení (zdieľané, nie per-user).
+- **Uloženie:** obrázky ako bytea v Postgres (`schema-uhrady.ts`, vzor daily-tasks audio; zdieľaný helper `apps/api/src/db/bytea.ts`). Servované cez `GET /api/uhrady/scans/<uuid>` — plná veľkosť, thumbnail je CSS (object-fit), žiadny server-side downscale.
+- **Popis skenu sa ukladá na BLUR** (nie Enter, nie tlačidlo). Playwright: `fill()` + klik mimo; syntetický `dispatchEvent(new Event('blur'))` React onBlur NEspustí — pri live-verify vždy reálna interakcia.
+- **Mazanie skenu má in-app potvrdenie** („Áno, zmazať"/„Zrušiť") — nie native confirm(). Mazanie poznámky je bez potvrdenia (zámer).
+- **Testids:** `uhrady-note-add`, `uhrady-file-input`, `uhrady-thumb-<id>`, `uhrady-desc-<id>`, `uhrady-delete-<id>`.
+- **URL:** `/?tab=uhrady` (nav registry `apps/web/src/nav.ts`, sekcia SLAVOSPORT).
+- **Mobil:** 390 px bez pretečenia — `min()`-strop vzor z issues 538/540/541; e2e to asserttuje.
+- **Live-verify gotcha (Playwright MCP):** `browser_file_upload` berie len súbory v allowed roots (repo alebo `.playwright-mcp/`) — testovacie jpg nakopíruj tam, po overení zmaž.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,4 +113,5 @@ Per-area rules live in `.claude/rules/<area>.md` with `paths:` frontmatter.
 - Profesionálne párovanie produktov (#387 E1+ — port starej appky @60b6164, rapidfuzz case-sensitive token_set_ratio, viac-kódová adaptácia, nahradilo `restock-links.md` v E8) → `.claude/rules/pairing-search.md`
 - Adresy z sitemapy + HTTP sonda (#402 — doplnok k shop-feed.md, byte-for-byte port url_resolver.py/resolve_urls.py, source stĺpec feed|sitemap|probe, karta vizuálne odlíši vyhľadávací fallback) → `.claude/rules/shop-sitemap.md`
 - Eshop → Objednávky predajňa (#410 — nahradilo Shoptet-viazané #345 vlastnými zápismi z predajne, `floor_note`/`floor_note_product` kľúčované variant.code, zdieľaná Vyhľadať/shop_product_url cesta, vizuálne odlíšený náhradný odkaz ako #402) → `.claude/rules/floor-notes.md`
+- SLAVOSPORT → Úhrady (#543 — skeny FA bytea, popis on-blur, in-app confirm mazania) → `.claude/rules/uhrady.md`
 - Úlohy na dnes + hlasová poznámka (#342/#487/#519 — zdieľaný zoznam, bytea audio na riadku, Whisper prepis + audio-only fallback, MediaRecorder hook, mobil-vs-desktop čisto CSS) → `.claude/rules/daily-tasks.md`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forestshop",
-  "version": "0.3.0-dev.320",
+  "version": "0.3.0-dev.321",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
Playbook zápis po tickete 543 (SLAVOSPORT → Úhrady):

- nové `.claude/rules/uhrady.md` (bytea uloženie skenov, popis on-blur — syntetický blur React nespustí, in-app confirm mazania, testids, Playwright allowed-roots gotcha pri uploade)
- riadok v `## Playbook router` v CLAUDE.md
- bump verzie 0.3.0-dev.320 → 0.3.0-dev.321

Len dokumentácia + bump; issue 543 už je zavreté po živom overení, tento PR žiadny ticket nezatvára.
